### PR TITLE
VSCODE-NLP-046 Fixed lexer to allow for node attributes

### DIFF
--- a/syntaxes/nlp.tmLanguage.json
+++ b/syntaxes/nlp.tmLanguage.json
@@ -71,12 +71,15 @@
             ]
         },
         "rules-region": {
-            "begin": "([_a-zA-Z]+)\\s*(<-)",
+            "begin": "([_a-zA-Z]+)\\s*([a-zA-Z\\[\\]]+)\\s*(<-)",
             "beginCaptures": {
                 "1": {
                     "name": "variable.parameter.nlp"
                 },
                 "2": {
+                    "include": "#attributes"
+                },
+                "3": {
                     "name": "keyword.operator.nlp"
                 }
             },


### PR DESCRIPTION
Signed-off-by: David de Hilster <david.dehilster@lexisnexisrisk.com>