### PR TITLE
VSCODE-NLP-106 Typo fix in .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,7 +11,7 @@
 
 !.vscodeignore
 !CHANGELOG.md
-!/node_modules/tslib/**/*
+!node_modules/tslib/**/*
 !nlp-configuration.json
 !tree-configuration.json
 !txxt-configuration.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,5 @@ All notable changes to the "nlp" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## v0.9.14
+## v0.9.15
 - Initial preview release

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ There are many details in the windows version of VisualText that are yet to be i
 
 This language extension is dependent on the [NLP-ENGINE](https://github.com/VisualText/nlp-engine). Currently, the NLP-ENGINE only runs on Linux but can be used on windows uing the Windows Linux Subsystem.
 
-### v0.9.14
+### v0.9.15
 
 We are currently trying to fix the problem of this extension not working when published.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++ support for Visual Studio Code",
     "icon": "resources/NLPppLogo.png",
-    "version": "0.9.14",
+    "version": "0.9.15",
     "publisher": "dehilster",
     "enableProposedApi": false,
     "preview": true,


### PR DESCRIPTION
Signed-off-by: David de Hilster <david.dehilster@lexisnexisrisk.com>