### PR TITLE
VSCODE-NLP-563 cloud-compile UX: status-bar progress, elapsed-time, sticky completion

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -177,6 +177,11 @@ export class NLPCompile {
                     'Open Output'
                 ).then(choice => {
                     if (choice === 'Open Output') {
+                        // logView lives inside the `vtOutput` panel container
+                        // (see package.json viewsContainers). Just calling
+                        // `logView.focus` on a hidden container is a no-op,
+                        // so reveal the container first.
+                        vscode.commands.executeCommand('workbench.view.extension.vtOutput');
                         vscode.commands.executeCommand('logView.focus');
                     }
                 });

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1101,12 +1101,27 @@ endif()
             // 4. Cache hit short-circuits the poll.
             let artifactUrl = submitted.artifactUrl;
             if (!submitted.cached) {
-                progress.report({ message: `Building on ${platformKey}...` });
-                const polled = await this.pollCloudJob(dispatcherUrl, submitted.jobId, anapath);
-                if (polled.status !== 'done' || !polled.artifactUrl) {
-                    return false;
+                // Live elapsed-time tick on the status-bar progress message so
+                // the user can see the wait progressing rather than guessing
+                // whether the extension is hung. Refreshed every second.
+                const baseMsg = `Building on ${platformKey}...`;
+                const tickStart = Date.now();
+                progress.report({ message: baseMsg });
+                const tick = setInterval(() => {
+                    const sec = Math.floor((Date.now() - tickStart) / 1000);
+                    const m = Math.floor(sec / 60);
+                    const s = sec % 60;
+                    progress.report({ message: `${baseMsg} ${m}:${s.toString().padStart(2, '0')}` });
+                }, 1000);
+                try {
+                    const polled = await this.pollCloudJob(dispatcherUrl, submitted.jobId, anapath);
+                    if (polled.status !== 'done' || !polled.artifactUrl) {
+                        return false;
+                    }
+                    artifactUrl = polled.artifactUrl;
+                } finally {
+                    clearInterval(tick);
                 }
-                artifactUrl = polled.artifactUrl;
             }
 
             // 5. Download artifact next to the analyzer.

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -84,7 +84,11 @@ export class NLPCompile {
         }
 
         vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
+            // Status-bar progress instead of a sticky bottom-right popup —
+            // the cloud-compile path can wait several minutes for a GHA
+            // runner to dequeue, and a long-lived popup is intrusive.
+            // The completion notification below still appears as a popup.
+            location: vscode.ProgressLocation.Window,
             title: `Compile ${targetLabel}`,
             cancellable: false
         }, async (progress) => {
@@ -152,10 +156,30 @@ export class NLPCompile {
 
             if (success) {
                 const libName = this.sharedLibraryName(libBaseName);
+                const libPath = path.join(analyzerDir.fsPath, libName);
                 logView.addMessage(`Compile ${targetLabel} succeeded: ${libName}`, logLineType.ANALYER_OUTPUT, analyzerDir);
-                vscode.window.showInformationMessage(`Compile ${targetLabel} succeeded: ${libName}`);
+                // Action-button notification stays visible until dismissed (a
+                // plain showInformationMessage auto-fades after a few seconds,
+                // easy to miss after a long cloud-compile wait).
+                vscode.window.showInformationMessage(
+                    `Compile ${targetLabel} succeeded: ${libName}`,
+                    'Reveal in Explorer'
+                ).then(choice => {
+                    if (choice === 'Reveal in Explorer') {
+                        vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(libPath));
+                    }
+                });
             } else {
                 logView.addMessage(`Compile ${targetLabel} failed. Check the output for details.`, logLineType.ANALYER_OUTPUT, analyzerDir);
+                // Same persistence rationale as the success notification.
+                vscode.window.showErrorMessage(
+                    `Compile ${targetLabel} failed. See the NLP output panel for details.`,
+                    'Open Output'
+                ).then(choice => {
+                    if (choice === 'Open Output') {
+                        vscode.commands.executeCommand('logView.focus');
+                    }
+                });
             }
 
             vscode.commands.executeCommand('logView.refreshAll');
@@ -1179,7 +1203,11 @@ endif()
         anapath: string
     ): Promise<{ status: string; artifactUrl?: string }> {
         const logUri = vscode.Uri.file(anapath);
-        const deadline = Date.now() + 10 * 60 * 1000;   // 10 min ceiling
+        // 30 min ceiling. GHA's free-tier Windows runner pool can spend
+        // 5-10+ min in the queue before a runner picks up, plus actual build
+        // time. 10 min was too tight; 30 min covers worst observed cases
+        // while still bounding the wait to something the user would notice.
+        const deadline = Date.now() + 30 * 60 * 1000;
         let delay = 2000;
         while (Date.now() < deadline) {
             await new Promise(r => setTimeout(r, delay));


### PR DESCRIPTION
## Summary

UX polish for the cloud-compile path. Three independent improvements,
each as its own commit:

1. **Status-bar progress instead of sticky popup** — `ProgressLocation.Notification`
   parked a popup in the bottom-right for 5–15 minutes while waiting for
   the GHA runner. Switched to `ProgressLocation.Window` so the wait
   shows in the status bar and doesn't intrude.
2. **Live elapsed-time counter** — refreshes every second
   (`Building on windows... 4:23`) so users can see the wait progressing
   rather than guessing whether the extension is hung.
3. **30-min poll timeout** — bumped from 10 min. GHA free-tier Windows
   runner pool can spend 5–10+ min queued before a runner picks up,
   plus build time. 10 min was too tight; 30 min covers worst observed
   cases.
4. **Sticky completion notifications with action buttons** — converts
   the plain "Compile succeeded" message to a persistent notification
   with `Reveal in Explorer` (success) or `Open Output` (failure) action
   buttons. Plain `showInformationMessage` auto-fades and was easy to
   miss after a long wait.
5. **`Open Output` action reveals the output container first** — `logView`
   lives inside the `vtOutput` panel container; just calling
   `logView.focus` on a hidden container is a no-op, so reveal the
   container first.

## Changes

- `src/compile.ts` only

## Test plan

- [x] Cloud compile shows status-bar progress with live MM:SS counter
- [x] Success notification persists with "Reveal in Explorer" action
- [x] Failure notification persists with "Open Output" action
- [x] "Open Output" reveals the output panel (no longer a no-op when
      panel container is collapsed)
- [x] Slow cloud build (>10 min) no longer times out at 10 min
