### PR TITLE
VSCODE-NLP-564 bump version to 3.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.13",
+    "version": "3.1.14",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
## Summary

Bumps the extension version to 3.1.14 in preparation for a Marketplace
release. Picks up:

- **VSCODE-NLP-562** — engine-release precheck before cloud submit (so
  users with an unpublished `nlp.exe` version get a clear local error
  instead of "release not found" from the runner)
- **VSCODE-NLP-563** — cloud-compile UX polish: status-bar progress,
  live elapsed-time counter, 30-min poll timeout, sticky completion
  notifications with `Reveal in Explorer` / `Open Output` action buttons

## Note on cloud-compile maturity

Cloud compile in this release is **experimental**. The end-to-end
pipeline now functions through 15 of 17 passes for the date-time test
analyzer. Analyzers with a KB pass currently fail at pass 16 — the
compiled `run.dll` lacks an exported `kb_setup` entry point and the
engine's compiled-KB fallback path crashes when interpreted KB data is
used by compiled pass code. This is an open engine-side issue that will
be addressed in a future nlp-engine release.

## Test plan

- [ ] Marketplace package builds clean (`npm run package`)
- [ ] Installed extension reports version 3.1.14
- [ ] Cloud-compile precheck (562) fires when nlp.exe version isn't
      published
- [ ] Cloud-compile status-bar progress + elapsed-time counter (563)
      shows during job
