### PR TITLE
3.1.15 release: toggle fix + .vscodeignore cleanup

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,10 +3,10 @@ src/**
 tsconfig.json
 webpack.config.js
 
-# Build artifacts we don't need  
+# Build artifacts we don't need
 *.vsix
-.vscode/launch.json
-.vscode/tasks.json
+.vscode/**
+.claude/**
 
 # Node modules - bundled by webpack
 node_modules/**
@@ -15,6 +15,7 @@ node_modules/**
 .git*
 .eslintrc.json
 npm-debug.log*
+*.log
 .nyc_output
 coverage
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.14",
+    "version": "3.1.15",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/status.ts
+++ b/src/status.ts
@@ -244,27 +244,42 @@ export class NLPStatusBar {
     }
 
     toggleRunMode() {
+        // Cycle to the next mode, skipping any compiled mode whose lib
+        // doesn't exist. INTERPRETED is always available so the loop always
+        // lands somewhere within 3 attempts.
+        // Previously, hitting an unavailable compiled mode showed a warning
+        // and returned without advancing — leaving the toggle stuck (e.g.
+        // on COMPILED with no kb.dll, advancing to COMPILED_KB was blocked
+        // and the toggle wouldn't cycle back to INTERPRETED).
         let next = this.nextRunMode(this.runMode);
-        if (next === RunMode.COMPILED && !this.hasCompiledLib(RunMode.COMPILED) && this.hasCompiledLib(RunMode.COMPILED_KB)) {
-            next = RunMode.COMPILED_KB;
+        for (let attempts = 0; attempts < 3; attempts++) {
+            if (next === RunMode.INTERPRETED) break;
+            if (this.hasCompiledLib(next)) break;
+            next = this.nextRunMode(next);
         }
-        if ((next === RunMode.COMPILED || next === RunMode.COMPILED_KB) && !this.hasCompiledLib(next)) {
+
+        // If we cycled all the way back to INTERPRETED while already on
+        // INTERPRETED, no compiled mode is available — the user clicked
+        // toggle expecting a compiled mode but nothing's built. Pop a
+        // one-shot prompt offering to compile.
+        if (next === RunMode.INTERPRETED && this.runMode === RunMode.INTERPRETED) {
             const name = this.currentAnalyzerName() || 'this analyzer';
-            const compileCmd = next === RunMode.COMPILED_KB ? 'kbView.compileKB' : 'analyzerView.compileAnalyzer';
-            const compileLabel = next === RunMode.COMPILED_KB ? 'Compile KB' : 'Compile Analyzer and KB';
-            const modeLabel = next === RunMode.COMPILED_KB ? 'Compiled KB' : 'Compiled';
             vscode.window
                 .showWarningMessage(
-                    `${name} hasn't been compiled yet. Compile it before switching to ${modeLabel} run mode.`,
-                    compileLabel
+                    `${name} has nothing compiled yet. Compile it to switch to a compiled run mode.`,
+                    'Compile Analyzer and KB',
+                    'Compile KB'
                 )
                 .then(choice => {
-                    if (choice === compileLabel) {
-                        vscode.commands.executeCommand(compileCmd);
+                    if (choice === 'Compile Analyzer and KB') {
+                        vscode.commands.executeCommand('analyzerView.compileAnalyzer');
+                    } else if (choice === 'Compile KB') {
+                        vscode.commands.executeCommand('kbView.compileKB');
                     }
                 });
             return;
         }
+
         this.setRunMode(next);
     }
 


### PR DESCRIPTION
## Summary

Bundles three small commits into a 3.1.15 Marketplace release:

- **VSCODE-NLP-565** — fix run-mode toggle getting stuck on unavailable
  compiled modes. Repro: be on Run: Compiled with run.dll but no kb.dll;
  clicking the toggle showed "hasn't been compiled yet" warning and
  returned without advancing. Subsequent clicks repeated the warning —
  toggle wouldn't even cycle back to Interpreted. Fix: silently skip
  unavailable compiled modes (status-bar text changes so the new mode
  is visible), and only show the warning when nothing's compiled at all
  *and* the user clicked from INTERPRETED.

- **VSCODE-NLP-566** — `.vscodeignore` was missing `.vscode/settings*.json`,
  `.claude/`, and `*.log`, so the packaged .vsix was shipping local IDE
  state and Claude Code permission files to every user (~10KB of harmless
  but irrelevant bloat). Switched to excluding the entire `.vscode/`
  directory, added `.claude/**`, and added `*.log`.

- **VSCODE-NLP-567** — bump `package.json` version to 3.1.15.

## Test plan

- [ ] Toggle works through all three modes when nothing's compiled
      (silent skip; no stuck state)
- [ ] Toggle still shows "compile?" prompt when on INTERPRETED with
      nothing built
- [ ] Built .vsix no longer contains `.vscode/`, `.claude/`, or `eclcc.log`
- [ ] Marketplace install of 3.1.15 reports the correct version
