### PR TITLE
VSCODE-NLP-568 toggle run mode cycles freely; drop fragile compiled-l…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.15",
+    "version": "3.1.16",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/status.ts
+++ b/src/status.ts
@@ -244,43 +244,26 @@ export class NLPStatusBar {
     }
 
     toggleRunMode() {
-        // Cycle to the next mode, skipping any compiled mode whose lib
-        // doesn't exist. INTERPRETED is always available so the loop always
-        // lands somewhere within 3 attempts.
-        // Previously, hitting an unavailable compiled mode showed a warning
-        // and returned without advancing — leaving the toggle stuck (e.g.
-        // on COMPILED with no kb.dll, advancing to COMPILED_KB was blocked
-        // and the toggle wouldn't cycle back to INTERPRETED).
-        let next = this.nextRunMode(this.runMode);
-        for (let attempts = 0; attempts < 3; attempts++) {
-            if (next === RunMode.INTERPRETED) break;
-            if (this.hasCompiledLib(next)) break;
-            next = this.nextRunMode(next);
-        }
-
-        // If we cycled all the way back to INTERPRETED while already on
-        // INTERPRETED, no compiled mode is available — the user clicked
-        // toggle expecting a compiled mode but nothing's built. Pop a
-        // one-shot prompt offering to compile.
-        if (next === RunMode.INTERPRETED && this.runMode === RunMode.INTERPRETED) {
-            const name = this.currentAnalyzerName() || 'this analyzer';
-            vscode.window
-                .showWarningMessage(
-                    `${name} has nothing compiled yet. Compile it to switch to a compiled run mode.`,
-                    'Compile Analyzer and KB',
-                    'Compile KB'
-                )
-                .then(choice => {
-                    if (choice === 'Compile Analyzer and KB') {
-                        vscode.commands.executeCommand('analyzerView.compileAnalyzer');
-                    } else if (choice === 'Compile KB') {
-                        vscode.commands.executeCommand('kbView.compileKB');
-                    }
-                });
-            return;
-        }
-
-        this.setRunMode(next);
+        // Cycle freely through all three modes: INTERPRETED -> COMPILED ->
+        // COMPILED_KB -> INTERPRETED. The toggle deliberately does NOT gate
+        // on whether a compiled lib exists.
+        //
+        // It used to skip compiled modes whose lib it couldn't find via
+        // getCurrentAnalyzer()/<name>.dll. But "the current analyzer" is
+        // resolved three different ways across the codebase
+        // (visualText.currentAnalyzer here, analyzer.getAnalyzerDirectory()
+        // in the compile path, and the input-file-derived path in the run
+        // path). When those drift — e.g. multiple installed copies of the
+        // same analyzer — the toggle would report "nothing compiled yet"
+        // even though the .dll was sitting right where compile/run expect
+        // it, making Run: Compiled KB unreachable.
+        //
+        // The authoritative guard is stageCompiledAnalyzer() in nlp.ts,
+        // which checks for the lib at RUN time using the reliable
+        // input-file-derived analyzer path and prompts to compile if it's
+        // missing. So the toggle just advances; running in a mode with no
+        // lib yet surfaces an actionable message at the right moment.
+        this.setRunMode(this.nextRunMode(this.runMode));
     }
 
     private nextRunMode(mode: RunMode): RunMode {


### PR DESCRIPTION
…ib gating

The status-bar run-mode toggle (Interpreted / Compiled / Compiled KB) gated each compiled mode on whether it could find the corresponding .dll at getCurrentAnalyzer()/<name>.dll. But "the current analyzer" is resolved three different ways across the codebase:

- status.ts toggle:   visualText.currentAnalyzer
- compile (kbView):   analyzer.getAnalyzerDirectory()
- run (nlp.ts):       derived from the input file path (before /input/)

When those drift apart — e.g. when there are multiple installed copies of the same analyzer, as happens across extension-version upgrades — the toggle reports "nothing compiled yet" and refuses to switch to Run: Compiled KB even though kb.dll is sitting exactly where the compile dropped it and where the run path looks for it. Repro: cloud- compile the KB for date-time (produces <analyzer>/kb.dll), then try to toggle to Compiled KB → "KB not compiled", unreachable.

Fix: the toggle now cycles freely through all three modes and does not gate on lib detection at all. The authoritative guard already lives at RUN time in stageCompiledAnalyzer() (nlp.ts), which resolves the analyzer dir from the input file path (the reliable source) and prompts to compile if the lib is missing. So a missing lib surfaces an actionable message at the right moment instead of silently blocking the toggle.

This also preserves the fix from VSCODE-NLP-565 (toggle could get stuck showing a warning without advancing) — free cycling can never get stuck. The fragile getCurrentAnalyzer-based detection that 565 layered on is what caused the new bug, so it's removed.

Bumps version to 3.1.16.