### PR TITLE
@

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,6 +6,8 @@ webpack.config.js
 # Build artifacts we don't need
 *.vsix
 .vscode/**
+# ...but ship the colorization template: colorizeAnalyzer() copies it into each workspace's .vscode/settings.json
+!.vscode/settings.json
 .claude/**
 
 # Node modules - bundled by webpack

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.16",
+    "version": "3.1.17",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
VSCODE-NLP-569 ship .vscode/settings.json so Update Colorizer works

VSCODE-NLP-566 added `.vscode/**` to .vscodeignore, which excluded the colorization template that colorizeAnalyzer() copies into each workspaces