### PR TITLE
@ VSCODE-NLP-570 read Update Colorizer template from running extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.17",
+    "version": "3.1.18",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1372,7 +1372,10 @@ export class VisualText {
             let add = false;
             const toDir = vscode.workspace.workspaceFolders[0].uri;
             const toFile = path.join(toDir.fsPath, '.vscode', 'settings.json');
-            const fromDir = visualText.extensionDirectory();
+            // Read the colorization template from the running extension (source tree in
+            // debug, installed .vsix dir in production) rather than the manually-built
+            // installed path, which only holds the downloaded nlp-engine assets.
+            const fromDir = this._ctx.extensionUri;
             const fromFile = path.join(fromDir.fsPath, '.vscode', 'settings.json');
             if (fs.existsSync(toFile)) {
                 if (this.jsonState.jsonParse(toDir, 'settings')) {


### PR DESCRIPTION
colorizeAnalyzer() resolved the colorization template via extensionDirectory(), which manually builds <extensions>/dehilster.nlp-<version>. In the Extension Development Host that points at the installed package, which only holds the downloaded nlp-engine assets and not the shipped .vscode/settings.json, so copyFile failed:

  copyFile from does not exist: ...dehilster.nlp-3.1.17\.vscode\settings.json

Read the template from this._ctx.extensionUri (the running extension: source tree in debug, installed .vsix dir in production) instead. Bump to 3.1.18.