### PR TITLE
VSCODE-NLP-573 Bump version to 3.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.20",
+    "version": "3.1.21",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
Bumps the extension to 3.1.21, repackaged with engine 3.1.44 bundled.

Engine 3.1.44 (nlp-engine NLP-ENGINE-516) enables compiled-RUN dispatch on Linux/macOS:
- `NLP::load_compiled` stores the `dlopen` handle in `hrundll_` instead of unloading-and-returning
- `runAnalyzer` dispatch now calls `call_runAnalyzer` (`dlsym` `run_analyzer`) on Linux too

Without this republish the Marketplace still serves the 3.1.20 .vsix bundling the older engine, where `-COMPILED` silently fell back to interpreted on Linux.