### PR TITLE
VSCODE-NLP-574 Bump version to 3.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.21",
+    "version": "3.1.22",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
Docs-only republish to surface the README refresh from PR #1027 on the Marketplace listing.`n`nNo code changes between 3.1.21 and 3.1.22. Bundled engine binaries remain at v3.1.50.`n`nMerge after #1027.