### PR TITLE
VSCODE-NLP-575 Prefer markdown help files over HTML

### DIFF
--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1434,9 +1434,10 @@ export class VisualText {
     }
 
     displayHelpFile(title: string, filename: string) {
-        const pathFile = path.join(visualText.getVisualTextDirectory("Help"), "helps", filename);
-        const mdFile = pathFile + ".md";
-        const htmlFile = pathFile + ".htm";
+        const helpDir = visualText.getVisualTextDirectory("Help");
+        const baseName = path.parse(filename).name;
+        const mdFile = path.join(helpDir, "markdown", baseName + ".md");
+        const htmlFile = path.join(helpDir, "helps", baseName + ".html");
         if (fs.existsSync(mdFile)) {
             vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(mdFile));
         }


### PR DESCRIPTION
## Summary

`displayHelpFile` now prefers markdown help files over HTML:

1. Looks for `<Help>/markdown/<name>.md` first and, if found, opens it as a markdown preview.
2. Falls back to `<Help>/helps/<name>.html` rendered as HTML when no markdown file exists.

Any extension on the incoming `filename` is stripped (via `path.parse().name`) so both callers that pass a bare word (e.g. `helpView`) and those that pass a filename with an extension (e.g. `logView` passing `DOWNLOADHELP.html`) resolve correctly.

### Behavior changes
- Markdown now resolves from the new `markdown/` subdirectory (previously `helps/`).
- HTML fallback uses `.html` instead of the old `.htm` extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
