### PR TITLE
VSCODE-NLP-576 Bump version to 3.1.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.1.16",
+    "version": "3.1.23",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.1.16",
+            "version": "3.1.23",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.22",
+    "version": "3.1.23",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
## Summary

Bumps the extension version from `3.1.22` to `3.1.23` following the merge of the markdown-help-file change (VSCODE-NLP-575, #1029).

- `package.json`: `3.1.22` → `3.1.23`
- `package-lock.json`: project version fields synced to `3.1.23`

Minimal version-only change — no dependency or lockfile-format churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
