### PR TITLE
VSCODE-NLP-577 Use markdown help menus, drop browser help items

### DIFF
--- a/package.json
+++ b/package.json
@@ -534,20 +534,26 @@
             {
                 "command": "helpView.windowCHMHelp",
                 "category": "NLP",
-                "title": "Open Full Windows Help",
-                "description": "Open Browser function help"
+                "title": "Open Legacy Windows Help",
+                "description": "Open the legacy Windows CHM help file"
             },
             {
-                "command": "helpView.openBrowserFunctionHelp",
+                "command": "helpView.openHelpIndex",
                 "category": "NLP",
-                "title": "Open Browser Function Help",
-                "description": "Open browser function help"
+                "title": "Open Help Index",
+                "description": "Open the markdown help index"
             },
             {
-                "command": "helpView.openBrowserVariableHelp",
+                "command": "helpView.openFunctionHelp",
                 "category": "NLP",
-                "title": "Open Browser Variable Help",
-                "description": "Open browser variable help"
+                "title": "Open Functions Help",
+                "description": "Open the markdown functions help"
+            },
+            {
+                "command": "helpView.openVariableHelp",
+                "category": "NLP",
+                "title": "Open Variables Help",
+                "description": "Open the markdown variables help"
             },
             {
                 "command": "nlp.selectSequence",
@@ -560,12 +566,6 @@
                 "category": "NLP",
                 "title": "Lookup Word",
                 "description": "Lookup a term in the help"
-            },
-            {
-                "command": "helpView.lookupBrowser",
-                "category": "NLP",
-                "title": "Lookup Word in Browser",
-                "description": "Lookup a term in the help in Browser"
             },
             {
                 "command": "textView.copyToAnalyzer",
@@ -1880,11 +1880,6 @@
                     "group": "anlp"
                 },
                 {
-                    "when": "isWindows && resourceExtname == .nlp",
-                    "command": "helpView.windowCHMHelp",
-                    "group": "help"
-                },
-                {
                     "when": "resourceExtname == .pat || resourceExtname == .nlp",
                     "command": "sequenceView.finalTree",
                     "group": "bnlp"
@@ -1901,23 +1896,28 @@
                 },
                 {
                     "when": "resourceExtname == .pat || resourceExtname == .nlp",
-                    "command": "helpView.openBrowserFunctionHelp",
-                    "group": "help"
-                },
-                {
-                    "when": "resourceExtname == .pat || resourceExtname == .nlp",
-                    "command": "helpView.openBrowserVariableHelp",
-                    "group": "help"
-                },
-                {
-                    "when": "resourceExtname == .pat || resourceExtname == .nlp",
                     "command": "helpView.lookup",
-                    "group": "help"
+                    "group": "help@1"
                 },
                 {
                     "when": "resourceExtname == .pat || resourceExtname == .nlp",
-                    "command": "helpView.lookupBrowser",
-                    "group": "help"
+                    "command": "helpView.openHelpIndex",
+                    "group": "help@2"
+                },
+                {
+                    "when": "resourceExtname == .pat || resourceExtname == .nlp",
+                    "command": "helpView.openFunctionHelp",
+                    "group": "help@3"
+                },
+                {
+                    "when": "resourceExtname == .pat || resourceExtname == .nlp",
+                    "command": "helpView.openVariableHelp",
+                    "group": "help@4"
+                },
+                {
+                    "when": "isWindows && resourceExtname == .nlp",
+                    "command": "helpView.windowCHMHelp",
+                    "group": "help@5"
                 },
                 {
                     "when": "resourceExtname == .pat || resourceExtname == .nlp",

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -14,10 +14,10 @@ export class HelpView {
 
     constructor(private context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('helpView.lookup', (resource) => this.lookup(resource));
-        vscode.commands.registerCommand('helpView.lookupBrowser', (resource) => this.lookupBrowser(resource));
         vscode.commands.registerCommand('helpView.windowCHMHelp', (resource) => this.windowCHMHelp(resource));
-        vscode.commands.registerCommand('helpView.openBrowserFunctionHelp', this.openBrowserFunctionHelp);
-        vscode.commands.registerCommand('helpView.openBrowserVariableHelp', this.openBrowserVariableHelp);
+        vscode.commands.registerCommand('helpView.openHelpIndex', () => this.openHelpIndex());
+        vscode.commands.registerCommand('helpView.openFunctionHelp', () => this.openFunctionHelp());
+        vscode.commands.registerCommand('helpView.openVariableHelp', () => this.openVariableHelp());
         this.exists = false;
         this.ctx = context;
         this.panel = undefined;
@@ -28,24 +28,6 @@ export class HelpView {
             helpView = new HelpView(ctx);
         }
         return helpView;
-    }
-
-    lookupBrowser(resource: vscode.Uri) {
-        let editor = vscode.window.activeTextEditor;
-        if (editor) {
-            let cursorPosition = editor.selection.start;
-            let wordRange = editor.document.getWordRangeAtPosition(cursorPosition);
-            if (wordRange) {
-                const text = this.getTerm(editor, wordRange);
-                var helpPath = visualText.getVisualTextDirectory('Help');
-                helpPath = path.join(helpPath, 'helps', text + '.htm');
-                if (!fs.existsSync(helpPath)) {
-                    vscode.window.showErrorMessage(`File does not exist: ${helpPath}`);
-                    return;
-                }
-                vscode.env.openExternal(vscode.Uri.file(helpPath));
-            }
-        }
     }
 
     lookup(resource: vscode.Uri) {
@@ -107,16 +89,24 @@ export class HelpView {
         }
     }
 
-    openBrowserFunctionHelp() {
-        var helpPath = visualText.getVisualTextDirectory('Help');
-        helpPath = path.join(helpPath, 'helps', 'NLP_PP_Stuff', 'Functions' + '.htm');
-        vscode.env.openExternal(vscode.Uri.file(helpPath));
-
+    openHelpIndex() {
+        this.displayMarkdownHelp('index');
     }
 
-    openBrowserVariableHelp() {
-        var helpPath = visualText.getVisualTextDirectory('Help');
-        helpPath = path.join(helpPath, 'helps', 'NLP_PP_Stuff', 'Variable_types' + '.htm');
-        vscode.env.openExternal(vscode.Uri.file(helpPath));
+    openFunctionHelp() {
+        this.displayMarkdownHelp(path.join('NLP_PP_Stuff', 'Functions'));
+    }
+
+    openVariableHelp() {
+        this.displayMarkdownHelp(path.join('NLP_PP_Stuff', 'About_NLP++_Variables'));
+    }
+
+    displayMarkdownHelp(relativeName: string) {
+        const mdFile = path.join(visualText.getVisualTextDirectory('Help'), 'markdown', relativeName + '.md');
+        if (fs.existsSync(mdFile)) {
+            vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(mdFile));
+        } else {
+            vscode.window.showErrorMessage(`Help file does not exist: ${mdFile}`);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Reworks the NLP editor context-menu help items to use the markdown help tree and drops the browser-based (online) help items.

### Removed (opened local `.htm` files in an external browser)
- **Open Browser Function Help** (`helpView.openBrowserFunctionHelp`)
- **Open Browser Variable Help** (`helpView.openBrowserVariableHelp`)
- **Lookup Word in Browser** (`helpView.lookupBrowser`)

Their command contributions and methods are removed as well.

### Added (open `Help/markdown/*.md` as a VS Code markdown preview)
- **Open Help Index** → `markdown/index.md`
- **Open Functions Help** → `markdown/NLP_PP_Stuff/Functions.md`
- **Open Variables Help** → `markdown/NLP_PP_Stuff/About_NLP++_Variables.md`

A shared `displayMarkdownHelp(relativeName)` helper resolves the file under the installed extension's `Help/markdown/` directory and shows an error if it is missing.

### Renamed
- **Open Full Windows Help** → **Open Legacy Windows Help** (unchanged behavior; still shown only on Windows for `.nlp` files).

### Menu ordering
The `help` group is now explicitly ordered (`help@1..5`): Lookup Word, Open Help Index, Open Functions Help, Open Variables Help, then Open Legacy Windows Help — so Functions and Variables sit above the legacy Windows help item.

## Notes
- Only `src/helpView.ts` and `package.json` are changed; `dist/` is not committed (built at publish time via `webpack-prod && vsce package`, consistent with prior feature PRs).
- Version bump is intentionally not included here — it is handled separately in #1030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
