### PR TITLE
VSCODE-NLP-578 Bump version to 3.1.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.1.23",
+    "version": "3.1.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.1.23",
+            "version": "3.1.24",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.23",
+    "version": "3.1.24",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
## Summary

Bumps the extension version `3.1.23` → `3.1.24`.

The markdown help menu changes (VSCODE-NLP-577, #1031) were merged without their own version bump, so they shipped under the same `3.1.23` the prior bump PR created. This bumps the version so that work has its own release number.

- `package.json`: `3.1.23` → `3.1.24`
- `package-lock.json`: project version fields synced to `3.1.24`

Minimal version-only change — no dependency or lockfile-format churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
