### PR TITLE
feat: add "Compile Analyzer Only" command (-COMPILEANA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.1.25
+Added **"Compile Analyzer Only to C++ Library"**, which invokes `nlp.exe -COMPILEANA` (requires NLP-engine 3.6.0+).
+
+- Regenerates only the analyzer C++ (`run/`) and rebuilds the analyzer library, reusing the already-generated KB C++ (`kb/`) — a fast recompile when only NLP++ rules changed, skipping KB regeneration.
+- Available from the Analyzers view title menu and an analyzer's context menu, alongside "Compile Analyzer and KB" and "Compile KB".
+- Warns if no KB C++ exists yet (run "Compile Analyzer and KB" or "Compile KB" once first).
+
 ### 3.1.10
 Added the ability to compile only the knowledge base (KB) and to run an interpreted analyzer against the compiled KB.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.24",
+    "version": "3.1.25",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -1696,6 +1696,14 @@
                 }
             },
             {
+                "command": "analyzerView.compileAnalyzerOnly",
+                "title": "Compile Analyzer Only to C++ Library",
+                "icon": {
+                    "light": "resources/light/run.svg",
+                    "dark": "resources/dark/run.svg"
+                }
+            },
+            {
                 "command": "kbView.compileKB",
                 "title": "Compile KB to C++ Library",
                 "icon": {
@@ -2263,6 +2271,11 @@
                 },
                 {
                     "command": "analyzerView.compileAnalyzer",
+                    "when": "view == analyzerView",
+                    "group": "secondary"
+                },
+                {
+                    "command": "analyzerView.compileAnalyzerOnly",
                     "when": "view == analyzerView",
                     "group": "secondary"
                 },
@@ -3034,6 +3047,11 @@
                 },
                 {
                     "command": "analyzerView.compileAnalyzer",
+                    "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
+                    "group": "compile"
+                },
+                {
+                    "command": "analyzerView.compileAnalyzerOnly",
                     "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
                     "group": "compile"
                 },

--- a/src/analyzerView.ts
+++ b/src/analyzerView.ts
@@ -216,6 +216,7 @@ export class AnalyzerView {
 		vscode.commands.registerCommand('analyzerView.video', () => this.video());
 		vscode.commands.registerCommand('analyzerView.copyPath', () => this.copyPath());
 		vscode.commands.registerCommand('analyzerView.compileAnalyzer', resource => this.compileAnalyzer(resource));
+		vscode.commands.registerCommand('analyzerView.compileAnalyzerOnly', resource => this.compileAnalyzerOnly(resource));
 
 		visualText.colorizeAnalyzer();
 		this.folderUri = undefined;
@@ -769,6 +770,20 @@ export class AnalyzerView {
 		}
 		const compile = NLPCompile.attach();
 		await compile.compileAnalyzer(analyzerDir);
+	}
+
+	async compileAnalyzerOnly(analyzerItem: AnalyzerItem) {
+		let analyzerDir: vscode.Uri;
+		if (analyzerItem && analyzerItem.uri) {
+			analyzerDir = dirfuncs.isDir(analyzerItem.uri.fsPath) ? analyzerItem.uri : vscode.Uri.file(path.dirname(analyzerItem.uri.fsPath));
+		} else if (visualText.analyzer.isLoaded()) {
+			analyzerDir = visualText.analyzer.getAnalyzerDirectory();
+		} else {
+			vscode.window.showWarningMessage('No analyzer loaded. Open an analyzer first.');
+			return;
+		}
+		const compile = NLPCompile.attach();
+		await compile.compileAnalyzerOnly(analyzerDir);
 	}
 
 	public deleteAllAnalyzerLogs() {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { visualText } from './visualText';
 import { logView, logLineType } from './logView';
 
-export enum compileTarget { ANALYZER, KB_ONLY }
+export enum compileTarget { ANALYZER, KB_ONLY, ANALYZER_ONLY }
 
 interface NlpCompileResult {
     ok: boolean;
@@ -53,13 +53,26 @@ export class NLPCompile {
         await this.runCompile(analyzerDir, compileTarget.KB_ONLY);
     }
 
+    // Analyzer-only: regenerate the analyzer C++ (run/) via -COMPILEANA without
+    // regenerating the KB, then rebuild the analyzer library reusing the
+    // already-generated kb/*.cpp. Fast recompile when only NLP++ rules changed.
+    async compileAnalyzerOnly(analyzerDir: vscode.Uri): Promise<void> {
+        await this.runCompile(analyzerDir, compileTarget.ANALYZER_ONLY);
+    }
+
     // ---------------------------------------------------------------------------
     // Core compile flow
     // ---------------------------------------------------------------------------
 
     private async runCompile(analyzerDir: vscode.Uri, target: compileTarget): Promise<void> {
-        const targetLabel = target === compileTarget.KB_ONLY ? 'KB' : 'Analyzer and KB';
-        const compileFlag = target === compileTarget.KB_ONLY ? '-COMPILEKB' : '-COMPILE';
+        const targetLabel =
+            target === compileTarget.KB_ONLY ? 'KB' :
+            target === compileTarget.ANALYZER_ONLY ? 'Analyzer' :
+            'Analyzer and KB';
+        const compileFlag =
+            target === compileTarget.KB_ONLY ? '-COMPILEKB' :
+            target === compileTarget.ANALYZER_ONLY ? '-COMPILEANA' :
+            '-COMPILE';
 
         // 1. Check NLP engine executable
         const exe = visualText.exePath().fsPath;
@@ -77,6 +90,20 @@ export class NLPCompile {
             if (kbSources.length === 0) {
                 const analyzerName = path.basename(analyzerDir.fsPath.replace(/[\\/]+$/, ''));
                 const message = `No .kbb or .dict files found under ${analyzerName}/kb/user. Add KB sources before compiling the KB.`;
+                logView.addMessage(message, logLineType.ANALYER_OUTPUT, analyzerDir);
+                vscode.window.showWarningMessage(message);
+                return;
+            }
+        }
+
+        // Analyzer-only compile regenerates run/ C++ but NOT the KB. The analyzer
+        // library still links kb/*.cpp, so those must already exist from a prior
+        // "Compile Analyzer and KB" / "Compile KB".
+        if (target === compileTarget.ANALYZER_ONLY) {
+            const kbCpp = this.findGeneratedCppFiles(analyzerDir.fsPath, true); // kb only
+            if (kbCpp.length === 0) {
+                const analyzerName = path.basename(analyzerDir.fsPath.replace(/[\\/]+$/, ''));
+                const message = `No generated KB C++ found under ${analyzerName}/kb/. Run "Compile Analyzer and KB" (or "Compile KB") once before "Compile Analyzer Only".`;
                 logView.addMessage(message, logLineType.ANALYER_OUTPUT, analyzerDir);
                 vscode.window.showWarningMessage(message);
                 return;


### PR DESCRIPTION
## Why
NLP-engine 3.6.0 added `-COMPILEANA` (analyzer-only compile: regenerate the analyzer C++ without regenerating the KB). This surfaces it in the extension as a third compile command.

## Change
- **compile.ts**: `compileTarget.ANALYZER_ONLY`, `compileAnalyzerOnly()` entry point, `-COMPILEANA` flag + "Analyzer" label, and a guard requiring existing KB C++ (the analyzer library still links `kb/*.cpp`).
- **analyzerView.ts**: register `analyzerView.compileAnalyzerOnly` + method (mirrors `compileAnalyzer`).
- **package.json**: command declaration + view-title (`secondary`) and analyzer-context (`compile`) menu entries; version `3.1.24 → 3.1.25`.
- **CHANGELOG.md**: 3.1.25 entry.

The native lib build is unchanged (globs `run/` + existing `kb/`); only the engine codegen step skips KB regeneration → fast rule-only recompile.

## Behavior assumption (flag if wrong)
"Analyzer only" rebuilds the **full analyzer library** reusing the already-generated KB C++ — i.e. a faster "Compile Analyzer and KB" that skips KB regen. It warns if the KB C++ isn't present yet. If you intended codegen-only (no native lib build), that's a small follow-up.

## Requires
NLP-engine **3.6.0+** (the `-COMPILEANA` flag). Local and cloud compile paths both work since neither changes for this target.

## Testing
- [ ] `npm run compile` / package builds clean
- [ ] Command appears in both menus; runs `-COMPILEANA` and rebuilds the lib
- [ ] Warns cleanly when KB C++ is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)