### PR TITLE
feat: Compiled Analyzer run mode with analyzer.dll naming (3.1.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,19 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.1.26
+Gave the analyzer-only compile its own library name and a matching run mode.
+
+- "Compile Analyzer Only" now produces `analyzer.dll` (`analyzer.so` / `analyzer.dylib`) instead of `<analyzerName>.dll`; the analyzer-named library is reserved for "Compile Analyzer and KB", which compiles both together.
+- The run-mode status bar now cycles through four modes: Interpreted -> Compiled KB -> Compiled Analyzer -> Compiled. In Compiled Analyzer mode the analyzer is run from `analyzer.dll` while the KB stays interpreted.
+- The KB view now also surfaces `analyzer.dll` alongside `kb.dll` and the analyzer-named library.
+
 ### 3.1.25
 Added **"Compile Analyzer Only to C++ Library"**, which invokes `nlp.exe -COMPILEANA` (requires NLP-engine 3.6.0+).
 
 - Regenerates only the analyzer C++ (`run/`) and rebuilds the analyzer library, reusing the already-generated KB C++ (`kb/`) — a fast recompile when only NLP++ rules changed, skipping KB regeneration.
 - Available from the Analyzers view title menu and an analyzer's context menu, alongside "Compile Analyzer and KB" and "Compile KB".
 - Warns if no KB C++ exists yet (run "Compile Analyzer and KB" or "Compile KB" once first).
-- "Compile Analyzer Only" now produces `analyzer.dll` (`analyzer.so` / `analyzer.dylib`) instead of `<analyzerName>.dll`; the analyzer-named library is reserved for "Compile Analyzer and KB", which compiles both together.
-- The run-mode status bar now cycles through four modes: Interpreted -> Compiled KB -> Compiled Analyzer -> Compiled. In Compiled Analyzer mode the analyzer is run from `analyzer.dll` while the KB stays interpreted.
-- The KB view now also surfaces `analyzer.dll` alongside `kb.dll` and the analyzer-named library.
 
 ### 3.1.10
 Added the ability to compile only the knowledge base (KB) and to run an interpreted analyzer against the compiled KB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Added **"Compile Analyzer Only to C++ Library"**, which invokes `nlp.exe -COMPIL
 - Regenerates only the analyzer C++ (`run/`) and rebuilds the analyzer library, reusing the already-generated KB C++ (`kb/`) — a fast recompile when only NLP++ rules changed, skipping KB regeneration.
 - Available from the Analyzers view title menu and an analyzer's context menu, alongside "Compile Analyzer and KB" and "Compile KB".
 - Warns if no KB C++ exists yet (run "Compile Analyzer and KB" or "Compile KB" once first).
+- "Compile Analyzer Only" now produces `analyzer.dll` (`analyzer.so` / `analyzer.dylib`) instead of `<analyzerName>.dll`; the analyzer-named library is reserved for "Compile Analyzer and KB", which compiles both together.
+- The run-mode status bar now cycles through four modes: Interpreted -> Compiled KB -> Compiled Analyzer -> Compiled. In Compiled Analyzer mode the analyzer is run from `analyzer.dll` while the KB stays interpreted.
+- The KB view now also surfaces `analyzer.dll` alongside `kb.dll` and the analyzer-named library.
 
 ### 3.1.10
 Added the ability to compile only the knowledge base (KB) and to run an interpreted analyzer against the compiled KB.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.1.25",
+    "version": "3.1.26",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.1.25",
+            "version": "3.1.26",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.25",
+    "version": "3.1.26",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -153,7 +153,14 @@ export class NLPCompile {
             }
 
             const kbOnly = target === compileTarget.KB_ONLY;
-            const libBaseName = kbOnly ? 'kb' : path.basename(anapath);
+            // Library naming mirrors the run modes in status.ts:
+            //   KB_ONLY       -> kb.<ext>              (KB compiled, analyzer interpreted)
+            //   ANALYZER_ONLY -> analyzer.<ext>        (analyzer compiled, KB interpreted)
+            //   ANALYZER      -> <analyzerName>.<ext>  (analyzer + KB compiled together)
+            const libBaseName =
+                target === compileTarget.KB_ONLY ? 'kb' :
+                target === compileTarget.ANALYZER_ONLY ? 'analyzer' :
+                path.basename(anapath);
 
             const compileMode = (vscode.workspace.getConfiguration('compile').get<string>('mode') || 'local').toLowerCase();
             let success = false;

--- a/src/kbView.ts
+++ b/src/kbView.ts
@@ -106,16 +106,20 @@ export class FileSystemProvider implements vscode.TreeDataProvider<KBItem> {
 
 		// At the KB root, surface compiled artifacts from the analyzer root so they show up
 		// alongside the KB sources for visual reference. The DLL lives outside kb/user/ and
-		// is produced by Compile KB / Compile Analyzer and KB.
+		// is produced by Compile KB (kb), Compile Analyzer Only (analyzer), or
+		// Compile Analyzer and KB (<analyzerName>).
 		if (visualText.analyzer.isLoaded() && dir.fsPath === visualText.analyzer.getKBDirectory().fsPath) {
 			const anaRoot = visualText.analyzer.getAnalyzerDirectory().fsPath;
 			const libExt = os.platform() === 'win32' ? '.dll' : os.platform() === 'darwin' ? '.dylib' : '.so';
 			const analyzerName = path.basename(anaRoot.replace(/[\\/]+$/, ''));
 			const compiledLibs = [
 				path.join(anaRoot, 'kb' + libExt),
+				path.join(anaRoot, 'analyzer' + libExt),
 				path.join(anaRoot, analyzerName + libExt)
 			];
-			for (const libPath of compiledLibs) {
+			// Dedupe in case the analyzer is itself named "analyzer", which would
+			// make the analyzer-only and full-compile paths identical.
+			for (const libPath of [...new Set(compiledLibs)]) {
 				if (fs.existsSync(libPath)) {
 					files.push({ uri: vscode.Uri.file(libPath), type: vscode.FileType.File });
 				}

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -101,7 +101,7 @@ export class NLPFile extends TextFile {
 			const devFlagStr = mode == DevMode.DEV ? '-DEV' : mode == DevMode.SILENT ? '-SILENT' : '';
 
 			const runMode = nlpStatusBar.getRunMode();
-			const usingCompiled = runMode === RunMode.COMPILED || runMode === RunMode.COMPILED_KB;
+			const usingCompiled = runMode === RunMode.COMPILED || runMode === RunMode.COMPILED_KB || runMode === RunMode.COMPILED_ANALYZER;
 			if (usingCompiled) {
 				const staged = visualText.nlp.stageCompiledAnalyzer(anapath, engineDir, filepath, runMode);
 				if (!staged) {
@@ -112,10 +112,11 @@ export class NLPFile extends TextFile {
 			}
 
 			const args: string[] = ['-ANA', '"' + anapath + '"', '-WORK', '"' + engineDir + '"'];
-			// -COMPILED loads bin/run.dll as the analyzer body. COMPILED_KB keeps the analyzer
-			// interpreted; consh independently auto-loads bin/kb.dll when present (nlp_engine.cpp
-			// line 248 hardcodes the compiled-KB attempt with interpreted fallback).
-			if (runMode === RunMode.COMPILED) {
+			// -COMPILED loads bin/run.dll as the analyzer body, so it is passed for both
+			// COMPILED (analyzer + KB) and COMPILED_ANALYZER (analyzer only). COMPILED_KB keeps
+			// the analyzer interpreted; consh independently auto-loads bin/kb.dll when present
+			// (nlp_engine.cpp line 248 hardcodes the compiled-KB attempt with interpreted fallback).
+			if (runMode === RunMode.COMPILED || runMode === RunMode.COMPILED_ANALYZER) {
 				args.push('-COMPILED');
 			}
 			args.push('"' + filestr + '"', devFlagStr);
@@ -177,22 +178,31 @@ export class NLPFile extends TextFile {
 		const analyzerName = path.basename(anapath.replace(/[\\/]+$/, ''));
 		const platform = os.platform();
 		const ext = platform === 'win32' ? '.dll' : platform === 'darwin' ? '.dylib' : '.so';
-		const libBaseName = runMode === RunMode.COMPILED_KB ? 'kb' : analyzerName;
+		// Library naming mirrors the compile targets in compile.ts:
+		//   COMPILED_KB       -> kb.<ext>
+		//   COMPILED_ANALYZER -> analyzer.<ext>
+		//   COMPILED          -> <analyzerName>.<ext>
+		const libBaseName =
+			runMode === RunMode.COMPILED_KB ? 'kb' :
+			runMode === RunMode.COMPILED_ANALYZER ? 'analyzer' :
+			analyzerName;
 		const compiledLibName = `${libBaseName}${ext}`;
 		const compiledLib = path.join(anapath, compiledLibName);
 
 		if (!fs.existsSync(compiledLib)) {
 			logView.addMessage(`Compiled library not found: ${compiledLib}`, logLineType.ANALYER_OUTPUT, filepath);
-			const isKbOnly = runMode === RunMode.COMPILED_KB;
-			const primaryAction = isKbOnly ? 'Compile KB' : 'Compile Analyzer and KB';
-			const secondaryAction = isKbOnly ? 'Compile Analyzer and KB' : 'Compile KB';
+			const primaryAction =
+				runMode === RunMode.COMPILED_KB ? 'Compile KB' :
+				runMode === RunMode.COMPILED_ANALYZER ? 'Compile Analyzer Only' :
+				'Compile Analyzer and KB';
 			vscode.window.showErrorMessage(
-				`Compiled library not found: ${compiledLibName}. Compile the analyzer (or KB) first, or switch the run mode back to Interpreted.`,
-				primaryAction,
-				secondaryAction
+				`Compiled library not found: ${compiledLibName}. ${primaryAction} first, or switch the run mode back to Interpreted.`,
+				primaryAction
 			).then(choice => {
 				if (choice === 'Compile Analyzer and KB') {
 					vscode.commands.executeCommand('analyzerView.compileAnalyzer');
+				} else if (choice === 'Compile Analyzer Only') {
+					vscode.commands.executeCommand('analyzerView.compileAnalyzerOnly');
 				} else if (choice === 'Compile KB') {
 					vscode.commands.executeCommand('kbView.compileKB');
 				}
@@ -214,10 +224,23 @@ export class NLPFile extends TextFile {
 			// nlp.exe build flavor decides whether it loads the ANSI or unicode name;
 			// stage both so the engine finds whichever it expects.
 			if (runMode === RunMode.COMPILED_KB) {
+				// KB compiled, analyzer interpreted.
 				fs.copyFileSync(compiledLib, path.join(binDir, `kb${ext}`));
 				fs.copyFileSync(compiledLib, path.join(binDir, `kbu${ext}`));
 				logView.addMessage(`Staged ${compiledLibName} as ${path.join(binDir, `kb${ext}`)} (and kbu${ext})`, logLineType.ANALYER_OUTPUT, filepath);
+			} else if (runMode === RunMode.COMPILED_ANALYZER) {
+				// Analyzer compiled, KB interpreted. Stage only the analyzer body and remove
+				// any stale bin/kb<ext> left by a prior COMPILED run so consh auto-detection
+				// falls back to interpreting the KB instead of loading a stale compiled one.
+				fs.copyFileSync(compiledLib, path.join(binDir, `run${ext}`));
+				fs.copyFileSync(compiledLib, path.join(binDir, `runu${ext}`));
+				for (const stale of [`kb${ext}`, `kbu${ext}`]) {
+					const stalePath = path.join(binDir, stale);
+					if (fs.existsSync(stalePath)) fs.unlinkSync(stalePath);
+				}
+				logView.addMessage(`Staged ${compiledLibName} as ${path.join(binDir, `run${ext}`)} (and runu${ext}); KB interpreted`, logLineType.ANALYER_OUTPUT, filepath);
 			} else {
+				// Analyzer + KB compiled together.
 				fs.copyFileSync(compiledLib, path.join(binDir, `run${ext}`));
 				fs.copyFileSync(compiledLib, path.join(binDir, `runu${ext}`));
 				// The full-analyzer compile globs run/*.cpp AND kb/*.cpp into one library, so

--- a/src/status.ts
+++ b/src/status.ts
@@ -18,7 +18,7 @@ let nlpStatusBarAnalyzersVersion: vscode.StatusBarItem;
 
 export enum DevMode { NORMAL, DEV, SILENT }
 export enum FiredMode { BUILT, FIRED }
-export enum RunMode { INTERPRETED, COMPILED, COMPILED_KB }
+export enum RunMode { INTERPRETED, COMPILED, COMPILED_KB, COMPILED_ANALYZER }
 
 export let nlpStatusBar: NLPStatusBar;
 export class NLPStatusBar {
@@ -244,9 +244,9 @@ export class NLPStatusBar {
     }
 
     toggleRunMode() {
-        // Cycle freely through all three modes: INTERPRETED -> COMPILED ->
-        // COMPILED_KB -> INTERPRETED. The toggle deliberately does NOT gate
-        // on whether a compiled lib exists.
+        // Cycle freely through all four modes: INTERPRETED -> COMPILED_KB ->
+        // COMPILED_ANALYZER -> COMPILED -> INTERPRETED. The toggle deliberately
+        // does NOT gate on whether a compiled lib exists.
         //
         // It used to skip compiled modes whose lib it couldn't find via
         // getCurrentAnalyzer()/<name>.dll. But "the current analyzer" is
@@ -268,9 +268,10 @@ export class NLPStatusBar {
 
     private nextRunMode(mode: RunMode): RunMode {
         switch (mode) {
-            case RunMode.INTERPRETED: return RunMode.COMPILED;
-            case RunMode.COMPILED:    return RunMode.COMPILED_KB;
-            default:                  return RunMode.INTERPRETED;
+            case RunMode.INTERPRETED:       return RunMode.COMPILED_KB;
+            case RunMode.COMPILED_KB:       return RunMode.COMPILED_ANALYZER;
+            case RunMode.COMPILED_ANALYZER: return RunMode.COMPILED;
+            default:                        return RunMode.INTERPRETED;
         }
     }
 
@@ -287,6 +288,9 @@ export class NLPStatusBar {
         if (mode === RunMode.COMPILED_KB) {
             return path.join(ana.fsPath, 'kb' + ext);
         }
+        if (mode === RunMode.COMPILED_ANALYZER) {
+            return path.join(ana.fsPath, 'analyzer' + ext);
+        }
         const name = this.currentAnalyzerName();
         if (!name) return undefined;
         return path.join(ana.fsPath, name + ext);
@@ -300,6 +304,8 @@ export class NLPStatusBar {
     updateRunModeState() {
         if (this.runMode === RunMode.COMPILED) {
             nlpStatusBarRunMode.text = '$(symbol-method) Run: Compiled';
+        } else if (this.runMode === RunMode.COMPILED_ANALYZER) {
+            nlpStatusBarRunMode.text = '$(symbol-class) Run: Compiled Analyzer';
         } else if (this.runMode === RunMode.COMPILED_KB) {
             nlpStatusBarRunMode.text = '$(symbol-namespace) Run: Compiled KB';
         } else {
@@ -315,6 +321,7 @@ export class NLPStatusBar {
                 : vscode.workspace.getConfiguration('analyzer');
             const value = config.get<string>('runMode');
             if (value === 'compiled') return RunMode.COMPILED;
+            if (value === 'compiled-analyzer') return RunMode.COMPILED_ANALYZER;
             if (value === 'compiled-kb') return RunMode.COMPILED_KB;
             return RunMode.INTERPRETED;
         } catch {
@@ -326,6 +333,7 @@ export class NLPStatusBar {
         try {
             const folder = visualText.getWorkspaceFolder();
             const value = mode === RunMode.COMPILED ? 'compiled'
+                        : mode === RunMode.COMPILED_ANALYZER ? 'compiled-analyzer'
                         : mode === RunMode.COMPILED_KB ? 'compiled-kb'
                         : 'interpreted';
             if (folder.fsPath.length) {


### PR DESCRIPTION
## Summary

Completes the "Compile Analyzer Only" feature (3.1.25) by giving the analyzer-only build its own library name and a matching run mode, so the three compiled artifacts are distinct:

| Run mode | Library | What's compiled |
|---|---|---|
| Interpreted | — | nothing |
| Compiled KB | `kb.dll` | KB only, analyzer interpreted |
| **Compiled Analyzer** *(new)* | **`analyzer.dll`** | analyzer rules only, **KB interpreted** |
| Compiled | `<analyzerName>.dll` | analyzer + KB together |

Previously both "Compile Analyzer Only" and "Compile Analyzer and KB" emitted `<analyzerName>.dll`, so the analyzer-only output had no distinct identity and there was no run mode for it.

## Changes

- **status.ts** — add `RunMode.COMPILED_ANALYZER` (resolves to `analyzer.<ext>`), status-bar label `Run: Compiled Analyzer`, `compiled-analyzer` config persistence, and a 4-way toggle order: Interpreted → Compiled KB → Compiled Analyzer → Compiled.
- **compile.ts** — `-COMPILEANA` (Analyzer Only) names its library `analyzer` instead of `<analyzerName>`. `-COMPILE` keeps `<analyzerName>`, `-COMPILEKB` keeps `kb`.
- **nlp.ts** — for the new mode, stage `analyzer.dll` as `bin/run.<ext>` only and remove any stale `bin/kb.<ext>` so consh falls back to interpreting the KB; pass `-COMPILED`.
- **kbView.ts** — surface `analyzer.dll` in the KB view alongside `kb.dll` and the analyzer-named library (deduped for analyzers literally named `analyzer`).

## Notes

- The `-COMPILEANA` library still links `kb/*.cpp`, so `analyzer.dll` physically contains `kb_setup`; it is simply not staged as `bin/kb.<ext>`, which is what keeps the KB interpreted at runtime.
- `dist/` is intentionally not included (feature commits ship `src/` only, per repo convention).
- Version bumped to **3.1.26** (`package.json` + `package-lock.json`).

## Testing

Built with `npm run webpack` and verified in the Extension Dev Host: the toggle now exposes Compiled Analyzer, `analyzer.dll` is produced by Compile Analyzer Only, and it appears in the KB view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
