### PR TITLE
Add Python pass type support to the analyzer sequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.26",
+    "version": "3.1.27",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -1037,6 +1037,14 @@
                 "icon": {
                     "light": "resources/light/new-file.svg",
                     "dark": "resources/dark/new-file.svg"
+                }
+            },
+            {
+                "command": "sequenceView.insertPython",
+                "title": "Python",
+                "icon": {
+                    "light": "resources/light/python.svg",
+                    "dark": "resources/dark/python.svg"
                 }
             },
             {
@@ -2302,6 +2310,10 @@
                 {
                     "command": "sequenceView.insertDecl",
                     "group": "edit@3"
+                },
+                {
+                    "command": "sequenceView.insertPython",
+                    "group": "edit@4"
                 }
             ],
             "librarypass": [

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -44,6 +44,11 @@ export class PassItem {
 	public isRuleFile(): boolean {
 		return this.typeStr.localeCompare('nlp') == 0 || this.typeStr.localeCompare('rec') == 0;
 	}
+
+	public isPython(): boolean {
+		const t = this.typeStr.toLowerCase();
+		return t == 'python' || t == 'pythonpre' || t == 'pypre';
+	}
 	
 	public isFolder(): boolean {
 		return this.typeStr.localeCompare('folder') == 0;
@@ -214,7 +219,10 @@ export class SequenceFile extends TextFile {
 				if (passItem.typeStr.localeCompare('nlp') == 0 || passItem.typeStr.localeCompare('rec') == 0) {
 					passItem.uri = this.passItemUri(passItem);
 				}
-				passItem.comment = this.tokenStr(tokens,2);				
+				if (passItem.isPython()) {
+					passItem.uri = vscode.Uri.file(path.join(this.specDir.fsPath,passItem.name + '.py'));
+				}
+				passItem.comment = this.tokenStr(tokens,2);
 			}
 			passItem.empty = false;
 		}
@@ -397,6 +405,50 @@ export class SequenceFile extends TextFile {
 		}
 	}
 			
+	insertNewPythonPass(seqItem: SequenceItem, newPass: string, pre: boolean) {
+		if (this.passItems.length && newPass.length) {
+			const foundItem = this.findPass(seqItem.type,seqItem.name);
+			const passItem = this.createPythonPassItem(newPass,pre);
+			if (foundItem)
+				this.passItems.splice(foundItem.row+1,0,passItem);
+			else
+				this.passItems.push(passItem);
+			this.saveFile();
+		}
+	}
+
+	createPythonPassItem(newPass: string, pre: boolean): PassItem {
+		const newfile = this.createNewPythonFile(newPass);
+		const passItem = new PassItem();
+		passItem.uri = vscode.Uri.file(newfile);
+		passItem.name = newPass;
+		passItem.typeStr = pre ? 'pythonpre' : 'python';
+		passItem.comment = '# python pass';
+		passItem.text = this.passString(passItem);
+		passItem.empty = false;
+		return passItem;
+	}
+
+	createNewPythonFile(filename: string): string {
+		const newfilepath = path.join(visualText.analyzer.getSpecDirectory().fsPath,filename.concat('.py'));
+		if (!fs.existsSync(newfilepath))
+			fs.writeFileSync(newfilepath,this.newPythonContent(filename),{flag:'w+'});
+		return newfilepath;
+	}
+
+	newPythonContent(filename: string): string {
+		let py = '# NLP++ python pass: ' + filename + '\n';
+		py = py.concat('# Invoked as:  python "<appdir>/spec/',filename,'.py" "<appdir>" "<inputfile>" <pre|post>\n');
+		py = py.concat('#   pre  = pythonpre pass (runs before tokenization)\n');
+		py = py.concat('#   post = python pass (runs at its position, after tokenization)\n');
+		py = py.concat('import sys, io, os\n\n');
+		py = py.concat('appdir    = sys.argv[1] if len(sys.argv) > 1 else "."\n');
+		py = py.concat('inputfile = sys.argv[2] if len(sys.argv) > 2 else ""\n');
+		py = py.concat('phase     = sys.argv[3] if len(sys.argv) > 3 else "post"\n\n');
+		py = py.concat('# TODO: your pass logic here\n');
+		return py;
+	}
+
 	insertNewFolderPass(row: number, folderName: string, type: string): number {
 		const passItem = this.getPassByRow(row);
 		if (folderName.length) {

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -145,6 +145,24 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 						collapsibleState: collapse, active: passItem.active
 					});
 
+			} else if (passItem.isPython()) {
+				conVal = conVal + 'pythonfile';
+				label = passItem.name;
+				if (debugConVal) label = row.toString() + ' ' + conVal;
+				tooltip = passItem.uri.fsPath;
+				if (passItem.fileExists())
+					seqItems.push({
+						uri: passItem.uri, label: label, name: passItem.name, tooltip: tooltip, contextValue: conVal,
+						inFolder: passItem.inFolder, type: passItem.typeStr, passNum: passItem.passNum, library: passItem.library, row: row,
+						collapsibleState: collapse, active: passItem.active
+					});
+				else
+					seqItems.push({
+						uri: passItem.uri, label: label, name: passItem.name, tooltip: 'MISSING', contextValue: 'missing', inFolder: passItem.inFolder,
+						type: 'missing', passNum: passItem.passNum, library: passItem.library, row: row,
+						collapsibleState: collapse, active: passItem.active
+					});
+
 			} else {
 				tooltip = passItem.uri.fsPath;
 				if (passItem.tokenizer) {
@@ -194,6 +212,9 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 		} else if (seqItem.type.localeCompare('folder') == 0) {
 			icon = seqItem.active ? 'folder.svg' : 'folder-inactive.svg';
 			collapse = vscode.TreeItemCollapsibleState.Collapsed;
+
+		} else if (seqItem.type.localeCompare('python') == 0 || seqItem.type.localeCompare('pythonpre') == 0 || seqItem.type.localeCompare('pypre') == 0) {
+			icon = 'python.svg';
 
 		} else if (seqItem.type.localeCompare('nlp')) {
 			icon = 'seq-circle.svg';
@@ -420,6 +441,27 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 		}
 	}
 
+	insertPython(seqItem: SequenceItem): void {
+		if (visualText.hasWorkspaceFolder()) {
+			const seqFile = visualText.analyzer.seqFile;
+			const flavors = [
+				{ label: 'python', description: 'normal pass - runs at this position (after tokenization)' },
+				{ label: 'pythonpre', description: 'pre-tokenization - runs before the tokenizer (raw text)' }
+			];
+			vscode.window.showQuickPick(flavors, { title: 'Insert Python Pass', placeHolder: 'Choose python pass type' }).then(choice => {
+				if (choice) {
+					const pre = choice.label === 'pythonpre';
+					vscode.window.showInputBox({ title: 'Insert Python Pass', value: 'pyfiller', prompt: 'Enter python pass name' }).then(newname => {
+						if (newname) {
+							seqFile.insertNewPythonPass(seqItem, newname, pre);
+							vscode.commands.executeCommand('sequenceView.refreshAll');
+						}
+					});
+				}
+			});
+		}
+	}
+
 	renameTopComment(passFile: vscode.Uri) {
 		const textFile = new TextFile();
 		textFile.setFile(passFile);
@@ -599,6 +641,7 @@ export class SequenceView {
 		vscode.commands.registerCommand('sequenceView.insertNew', (seqItem) => treeDataProvider.insertRules(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertCode', (seqItem) => treeDataProvider.insertCode(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertDecl', (seqItem) => treeDataProvider.insertDecl(seqItem));
+		vscode.commands.registerCommand('sequenceView.insertPython', (seqItem) => treeDataProvider.insertPython(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertLibrary', (seqItem) => treeDataProvider.insertLibraryPass(seqItem));
 		vscode.commands.registerCommand('sequenceView.libraryKBFuncs', (seqItem) => treeDataProvider.libraryKBFuncs(seqItem));
 		vscode.commands.registerCommand('sequenceView.libraryTreeFuncs', (seqItem) => treeDataProvider.libraryTreeFuncs(seqItem));


### PR DESCRIPTION
## Summary

Adds VSCode-extension support for the native **python pass type** (and its pre-tokenization flavor) introduced in the nlp-engine (see nlp-engine PR #673). The analyzer sequence can now contain Python passes that the engine shells out to.

- **Python icon** in the sequence tree for `python` / `pythonpre` / `pypre` passes.
- **Right-click → New Pass → Python**: prompts for the flavor (post-tokenize vs. pre-tokenize) and a name, creates a `.py` stub in `spec/`, and inserts the pass after the selected item.

## Changes

**`src/sequence.ts`**
- `PassItem.isPython()` — matches `python` / `pythonpre` / `pypre`.
- `.py` uri resolution in `setPass`.
- `insertNewPythonPass` → `createPythonPassItem` (sets `typeStr` to `python`/`pythonpre`) → `createNewPythonFile` → `newPythonContent`. The stub documents the engine argv contract: `python "<appdir>/spec/<name>.py" "<appdir>" "<inputfile>" <pre|post>`.

**`src/sequenceView.ts`**
- `makeItem`: python branch sets contextValue `pythonfile` (with missing-file fallback).
- `getTreeItem`: renders `python.svg` for python pass types.
- `insertPython(seqItem)` + registered command `sequenceView.insertPython`.

**`package.json`**
- Command def `sequenceView.insertPython` and entry in the `sequencetype` ("New Pass") submenu.
- Version bump to 3.1.27.

## Notes

- `resources/{light,dark}/python.svg` were already present in the repo.
- Compiles clean (`tsc -p ./`). `dist/` is intentionally left out of this PR — the committed bundle is rebuilt at packaging time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)