### PR TITLE
feat: simplify Python pass to a single position-aware type (3.1.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Simplified the Python pass type into a single, position-aware pass.
 
 - Removed the separate `pythonpre` flavor. There is now one **Python** pass that runs wherever it sits in the sequence: place it before the tokenizer to run on raw text, or after the tokenizer to run post-tokenization. It is the only pass type allowed before tokenization.
 - "Insert > Python" now just prompts for a name (no pre/post choice). The generated `.py` stub documents the positional pre/post behavior the engine passes as its phase argument.
+- The tokenizer's right-click menu gains **"Insert Python Pass Before Tokenizer"**, so a python pass can be placed ahead of the tokenizer (previously the menu only inserted after the selected pass).
 - Existing `pythonpre` passes are still recognized when read, so older analyzers keep working.
 
 ### 3.1.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.1.28
+Simplified the Python pass type into a single, position-aware pass.
+
+- Removed the separate `pythonpre` flavor. There is now one **Python** pass that runs wherever it sits in the sequence: place it before the tokenizer to run on raw text, or after the tokenizer to run post-tokenization. It is the only pass type allowed before tokenization.
+- "Insert > Python" now just prompts for a name (no pre/post choice). The generated `.py` stub documents the positional pre/post behavior the engine passes as its phase argument.
+- Existing `pythonpre` passes are still recognized when read, so older analyzers keep working.
+
+### 3.1.27
+Added support for the native **Python pass** type in the analyzer sequence: a Python icon in the sequence tree, an "Insert > Python" command that creates a `.py` stub in `spec/`, and `.py` pass handling in the sequence model.
+
 ### 3.1.26
 Gave the analyzer-only compile its own library name and a matching run mode.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.1.26",
+    "version": "3.1.28",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.1.26",
+            "version": "3.1.28",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.27",
+    "version": "3.1.28",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1048,6 +1048,14 @@
                 }
             },
             {
+                "command": "sequenceView.insertPythonBeforeTokenize",
+                "title": "Insert Python Pass Before Tokenizer",
+                "icon": {
+                    "light": "resources/light/python.svg",
+                    "dark": "resources/dark/python.svg"
+                }
+            },
+            {
                 "command": "sequenceView.insert",
                 "title": "Insert Existing Pass(es)",
                 "icon": {
@@ -2561,6 +2569,11 @@
                     "command": "sequenceView.openKB",
                     "when": "view == sequenceView && viewItem =~ /.*hasLog.*/",
                     "group": "display"
+                },
+                {
+                    "command": "sequenceView.insertPythonBeforeTokenize",
+                    "when": "view == sequenceView && viewItem =~ /.*tokenize.*/",
+                    "group": "tokenize@0"
                 },
                 {
                     "command": "sequenceView.tokenize",

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -405,12 +405,14 @@ export class SequenceFile extends TextFile {
 		}
 	}
 			
-	insertNewPythonPass(seqItem: SequenceItem, newPass: string) {
+	insertNewPythonPass(seqItem: SequenceItem, newPass: string, before: boolean = false) {
 		if (this.passItems.length && newPass.length) {
 			const foundItem = this.findPass(seqItem.type,seqItem.name);
 			const passItem = this.createPythonPassItem(newPass);
 			if (foundItem)
-				this.passItems.splice(foundItem.row+1,0,passItem);
+				// before: splice at the target's row (above it) so a python pass can
+				// be placed before the tokenizer; otherwise insert after it.
+				this.passItems.splice(before ? foundItem.row : foundItem.row+1,0,passItem);
 			else
 				this.passItems.push(passItem);
 			this.saveFile();

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -405,10 +405,10 @@ export class SequenceFile extends TextFile {
 		}
 	}
 			
-	insertNewPythonPass(seqItem: SequenceItem, newPass: string, pre: boolean) {
+	insertNewPythonPass(seqItem: SequenceItem, newPass: string) {
 		if (this.passItems.length && newPass.length) {
 			const foundItem = this.findPass(seqItem.type,seqItem.name);
-			const passItem = this.createPythonPassItem(newPass,pre);
+			const passItem = this.createPythonPassItem(newPass);
 			if (foundItem)
 				this.passItems.splice(foundItem.row+1,0,passItem);
 			else
@@ -417,12 +417,14 @@ export class SequenceFile extends TextFile {
 		}
 	}
 
-	createPythonPassItem(newPass: string, pre: boolean): PassItem {
+	createPythonPassItem(newPass: string): PassItem {
 		const newfile = this.createNewPythonFile(newPass);
 		const passItem = new PassItem();
 		passItem.uri = vscode.Uri.file(newfile);
 		passItem.name = newPass;
-		passItem.typeStr = pre ? 'pythonpre' : 'python';
+		// A single python pass type that runs wherever it sits in the sequence.
+		// Placed before the tokenizer it runs on raw text; after it, post-tokenization.
+		passItem.typeStr = 'python';
 		passItem.comment = '# python pass';
 		passItem.text = this.passString(passItem);
 		passItem.empty = false;
@@ -439,8 +441,9 @@ export class SequenceFile extends TextFile {
 	newPythonContent(filename: string): string {
 		let py = '# NLP++ python pass: ' + filename + '\n';
 		py = py.concat('# Invoked as:  python "<appdir>/spec/',filename,'.py" "<appdir>" "<inputfile>" <pre|post>\n');
-		py = py.concat('#   pre  = pythonpre pass (runs before tokenization)\n');
-		py = py.concat('#   post = python pass (runs at its position, after tokenization)\n');
+		py = py.concat('#   The pass runs wherever it sits in the sequence. The engine passes\n');
+		py = py.concat('#   "pre" when it is placed before the tokenizer (raw text), or\n');
+		py = py.concat('#   "post" when it is placed after the tokenizer.\n');
 		py = py.concat('import sys, io, os\n\n');
 		py = py.concat('appdir    = sys.argv[1] if len(sys.argv) > 1 else "."\n');
 		py = py.concat('inputfile = sys.argv[2] if len(sys.argv) > 2 else ""\n');

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -444,19 +444,13 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 	insertPython(seqItem: SequenceItem): void {
 		if (visualText.hasWorkspaceFolder()) {
 			const seqFile = visualText.analyzer.seqFile;
-			const flavors = [
-				{ label: 'python', description: 'normal pass - runs at this position (after tokenization)' },
-				{ label: 'pythonpre', description: 'pre-tokenization - runs before the tokenizer (raw text)' }
-			];
-			vscode.window.showQuickPick(flavors, { title: 'Insert Python Pass', placeHolder: 'Choose python pass type' }).then(choice => {
-				if (choice) {
-					const pre = choice.label === 'pythonpre';
-					vscode.window.showInputBox({ title: 'Insert Python Pass', value: 'pyfiller', prompt: 'Enter python pass name' }).then(newname => {
-						if (newname) {
-							seqFile.insertNewPythonPass(seqItem, newname, pre);
-							vscode.commands.executeCommand('sequenceView.refreshAll');
-						}
-					});
+			// A single python pass type. It runs wherever it is placed in the
+			// sequence — move it above the tokenizer to run on raw text, or leave
+			// it below to run post-tokenization. (The old "pythonpre" flavor is gone.)
+			vscode.window.showInputBox({ title: 'Insert Python Pass', value: 'pyfiller', prompt: 'Enter python pass name' }).then(newname => {
+				if (newname) {
+					seqFile.insertNewPythonPass(seqItem, newname);
+					vscode.commands.executeCommand('sequenceView.refreshAll');
 				}
 			});
 		}

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -441,15 +441,18 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 		}
 	}
 
-	insertPython(seqItem: SequenceItem): void {
+	insertPython(seqItem: SequenceItem, before: boolean = false): void {
 		if (visualText.hasWorkspaceFolder()) {
 			const seqFile = visualText.analyzer.seqFile;
 			// A single python pass type. It runs wherever it is placed in the
-			// sequence — move it above the tokenizer to run on raw text, or leave
-			// it below to run post-tokenization. (The old "pythonpre" flavor is gone.)
-			vscode.window.showInputBox({ title: 'Insert Python Pass', value: 'pyfiller', prompt: 'Enter python pass name' }).then(newname => {
+			// sequence — before the tokenizer to run on raw text, or after it to
+			// run post-tokenization. (The old "pythonpre" flavor is gone.) The
+			// tokenizer context menu uses before=true so a python pass can be
+			// inserted ahead of the tokenizer (the only pass allowed there).
+			const title = before ? 'Insert Python Pass Before Tokenizer' : 'Insert Python Pass';
+			vscode.window.showInputBox({ title: title, value: 'pyfiller', prompt: 'Enter python pass name' }).then(newname => {
 				if (newname) {
-					seqFile.insertNewPythonPass(seqItem, newname);
+					seqFile.insertNewPythonPass(seqItem, newname, before);
 					vscode.commands.executeCommand('sequenceView.refreshAll');
 				}
 			});
@@ -636,6 +639,7 @@ export class SequenceView {
 		vscode.commands.registerCommand('sequenceView.insertCode', (seqItem) => treeDataProvider.insertCode(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertDecl', (seqItem) => treeDataProvider.insertDecl(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertPython', (seqItem) => treeDataProvider.insertPython(seqItem));
+		vscode.commands.registerCommand('sequenceView.insertPythonBeforeTokenize', (seqItem) => treeDataProvider.insertPython(seqItem, true));
 		vscode.commands.registerCommand('sequenceView.insertLibrary', (seqItem) => treeDataProvider.insertLibraryPass(seqItem));
 		vscode.commands.registerCommand('sequenceView.libraryKBFuncs', (seqItem) => treeDataProvider.libraryKBFuncs(seqItem));
 		vscode.commands.registerCommand('sequenceView.libraryTreeFuncs', (seqItem) => treeDataProvider.libraryTreeFuncs(seqItem));


### PR DESCRIPTION
## Summary

Simplifies the Python pass type (added in 3.1.27) into a **single, position-aware** pass, removing the separate `pythonpre` flavor.

A Python pass now runs wherever it sits in the sequence:
- placed **before** the tokenizer → runs on raw text (what `pythonpre` used to mean)
- placed **after** the tokenizer → runs post-tokenization

Position replaces the old pre/post pass type, so there's only one thing to insert and reason about. It remains the only pass type allowed before tokenization.

## Changes

- **sequence.ts** — `createPythonPassItem` / `insertNewPythonPass` drop the `pre` parameter and always create `typeStr = 'python'`. The generated `.py` stub now documents that the engine's phase argument (`pre`/`post`) follows the pass's position. `isPython()` still recognizes legacy `pythonpre`/`pypre` on read, so existing analyzers keep working.
- **sequenceView.ts** — "Insert > Python" no longer shows a flavor quick-pick; it just prompts for a name.
- Version bumped to **3.1.28**; CHANGELOG entries added for 3.1.27 (the original Python pass feature, which shipped without one) and 3.1.28.

## Notes

- **Placing before the tokenizer already works** with no further changes: a Python pass receives `mvup`/`mvdown` in its context value, and `movePass` has no guard against swapping above the tokenizer — so you insert it and move it up.
- `package-lock.json` change is the version bump only (it was lagging at 3.1.26 on master); the Dependabot dependency versions on main are untouched.
- `dist/` is intentionally excluded (feature commits ship `src/` only, per repo convention).

## Testing

`tsc --noEmit` clean and `npm run webpack` builds successfully. Inserting a Python pass creates a single `python` pass with the Python icon; it can be moved above the tokenizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
