### PR TITLE
fix: python passes before the tokenizer — icon + open (3.1.29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.1.29
+Fixed two issues with python passes placed before the tokenizer.
+
+- A python pass now always shows the Python icon. `getPassFiles` was overwriting every pass's uri with `<name>.nlp`, so a python pass pointed at a non-existent `.nlp`, read as "missing", and fell back to the default dot icon. Python passes now keep their `.py` uri.
+- Clicking a python pass inserted before the tokenizer now opens its `.py` file. The sequence view treated "pass 1" as the tokenizer (opening the sequence file / tree / rule matches); a python pass at pass 1 is now excluded from that special-casing.
+
 ### 3.1.28
 Simplified the Python pass type into a single, position-aware pass.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.1.28",
+    "version": "3.1.29",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.1.28",
+            "version": "3.1.29",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.28",
+    "version": "3.1.29",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -146,7 +146,10 @@ export class SequenceFile extends TextFile {
 
 			if (passItem.text.length) {
 				passItem.row = row++;
-				passItem.uri = vscode.Uri.file(path.join(specDir,passItem.name + '.nlp'));
+				// Keep the .py uri that setPass() assigned to python passes;
+				// only rule passes resolve to a .nlp file here.
+				if (!passItem.isPython())
+					passItem.uri = vscode.Uri.file(path.join(specDir,passItem.name + '.nlp'));
 				passItem.library = vscode.Uri.file(this.getLibraryFile(passItem.uri.fsPath));
 				this.passItems.push(passItem);
 			}

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -1116,10 +1116,18 @@ export class SequenceView {
 		return true;
 	}
 
+	// A python pass can now sit at pass 1 (before the tokenizer), so "pass 1"
+	// no longer implies "the tokenizer". The passNum == 1 shortcuts below
+	// (open the sequence file / tree / rule matches) are tokenizer behaviour and
+	// must skip python passes, which open their own .py file like any other pass.
+	private isPythonItem(seqItem: SequenceItem): boolean {
+		return seqItem.type == 'python' || seqItem.type == 'pythonpre' || seqItem.type == 'pypre';
+	}
+
 	private openPass(seqItem: SequenceItem): void {
 		if (this.notMissing(seqItem) && seqItem.type.localeCompare('folder') && seqItem.type.localeCompare('stub')) {
 			// Mostly for debugging purposes
-			if (seqItem.passNum == 1)
+			if (seqItem.passNum == 1 && !this.isPythonItem(seqItem))
 				seqItem.uri = visualText.analyzer.seqFile.getSequenceFile();
 			this.textFile.setFile(seqItem.uri);
 			if (seqItem.passNum != 1 && !this.textFile.isFileType(nlpFileType.NLP)) {
@@ -1134,7 +1142,7 @@ export class SequenceView {
 
 	private openTree(seqItem: SequenceItem): void {
 		if (this.notMissing(seqItem)) {
-			if (seqItem.passNum == 1) {
+			if (seqItem.passNum == 1 && !this.isPythonItem(seqItem)) {
 				this.openTreeFile(seqItem.passNum);
 			} else {
 				this.textFile.setFileType(seqItem.uri.fsPath);
@@ -1178,7 +1186,7 @@ export class SequenceView {
 
 	private displayMatchedRules(seqItem: SequenceItem): void {
 		if (this.notMissing(seqItem)) {
-			if (seqItem.passNum == 1) {
+			if (seqItem.passNum == 1 && !this.isPythonItem(seqItem)) {
 				this.openRuleMatchFile(seqItem.passNum);
 			} else {
 				this.textFile.setFile(seqItem.uri);


### PR DESCRIPTION
## Summary

Fixes two issues with python passes placed **before the tokenizer** (i.e. at pass 1), both rooted in the old assumption that pass 1 is always the tokenizer.

## Fixes

1. **Python icon was a dot.** `getPassFiles()` overwrote *every* pass's uri with `<name>.nlp` right after `setPass()` assigned the correct path. A python pass then pointed at a non-existent `.nlp` file, so `fileExists()` was false, the tree pushed `type: 'missing'`, and the icon fell back to `seq-circle.svg`. Fix: keep the `.py` uri that `setPass()` assigns to python passes.

2. **Clicking a before-tokenizer python pass opened the sequence file.** `openPass` (and `openTree` / `displayMatchedRules`) treated `passNum == 1` as the tokenizer and redirected the click to `analyzer.seq` / tree / rule-match files. A python pass placed before the tokenizer *is* pass 1, so it never opened its `.py`. Fix: add `isPythonItem()` and exclude python passes from the `passNum == 1` special-casing.

## Changes

- **sequence.ts** — `getPassFiles` guards the `.nlp` uri overwrite with `if (!passItem.isPython())`.
- **sequenceView.ts** — new `isPythonItem(seqItem)`; `openPass`, `openTree`, and `displayMatchedRules` use `passNum == 1 && !isPythonItem(...)`.
- Version bumped to **3.1.29**; CHANGELOG entry added.

## Notes

- `package-lock.json` change is the version bump only.
- `dist/` excluded per repo convention.

## Testing

`tsc --noEmit` clean, `npm run webpack` builds. Verified in the dev host: a python pass inserted before the tokenizer shows the Python icon and opens its `.py` template; inserting elsewhere is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
