### PR TITLE
Add "Run Regression Test (All Files)" button to the Analyzers panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1720,6 +1720,16 @@
                 }
             },
             {
+                "command": "analyzerView.runRegressionTest",
+                "title": "Run Regression Test (All Files)",
+                "icon": "$(beaker)"
+            },
+            {
+                "command": "analyzerView.blessRegression",
+                "title": "Bless Regression Goldens (All Files)",
+                "icon": "$(save-all)"
+            },
+            {
                 "command": "kbView.compileKB",
                 "title": "Compile KB to C++ Library",
                 "icon": {
@@ -2249,6 +2259,11 @@
                     "command": "analyzerView.video",
                     "when": "view == analyzerView",
                     "group": "navigation@5"
+                },
+                {
+                    "command": "analyzerView.runRegressionTest",
+                    "when": "view == analyzerView",
+                    "group": "navigation@6"
                 },
                 {
                     "command": "analyzerView.copyPath",
@@ -3079,6 +3094,16 @@
                     "command": "analyzerView.compileAnalyzerOnly",
                     "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
                     "group": "compile"
+                },
+                {
+                    "command": "analyzerView.runRegressionTest",
+                    "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
+                    "group": "regress"
+                },
+                {
+                    "command": "analyzerView.blessRegression",
+                    "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
+                    "group": "regress"
                 },
                 {
                     "command": "kbView.compileKB",

--- a/src/analyzerView.ts
+++ b/src/analyzerView.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { visualText } from './visualText';
 import { dirfuncs } from './dirfuncs';
 import { textView, TextItem } from './textView';
@@ -217,6 +218,8 @@ export class AnalyzerView {
 		vscode.commands.registerCommand('analyzerView.copyPath', () => this.copyPath());
 		vscode.commands.registerCommand('analyzerView.compileAnalyzer', resource => this.compileAnalyzer(resource));
 		vscode.commands.registerCommand('analyzerView.compileAnalyzerOnly', resource => this.compileAnalyzerOnly(resource));
+		vscode.commands.registerCommand('analyzerView.runRegressionTest', resource => this.runRegressionTest(resource));
+		vscode.commands.registerCommand('analyzerView.blessRegression', resource => this.blessRegression(resource));
 
 		visualText.colorizeAnalyzer();
 		this.folderUri = undefined;
@@ -784,6 +787,53 @@ export class AnalyzerView {
 		}
 		const compile = NLPCompile.attach();
 		await compile.compileAnalyzerOnly(analyzerDir);
+	}
+
+	// Run the cross-platform golden-file regression tester (nlp_regress.py, shipped
+	// in visualText/python) over every file in the analyzer's input/ directory.
+	// The semantic JSON compare is stable across cosmetic engine drift, unlike the
+	// per-file line-by-line "Run Regression Test" on text/output files.
+	private runRegress(analyzerItem: AnalyzerItem, command: 'test' | 'bless') {
+		let analyzerDir: vscode.Uri;
+		if (analyzerItem && analyzerItem.uri) {
+			analyzerDir = dirfuncs.isDir(analyzerItem.uri.fsPath) ? analyzerItem.uri : vscode.Uri.file(path.dirname(analyzerItem.uri.fsPath));
+		} else if (visualText.analyzer.isLoaded()) {
+			analyzerDir = visualText.analyzer.getAnalyzerDirectory();
+		} else {
+			vscode.window.showWarningMessage('No analyzer loaded. Open an analyzer first.');
+			return;
+		}
+		const script = path.join(visualText.getVisualTextDirectory('python'), 'nlp_regress.py');
+		if (!fs.existsSync(script)) {
+			vscode.window.showErrorMessage('Regression script not found: ' + script);
+			return;
+		}
+		const engineDir = visualText.engineDirectory().fsPath;
+		const py = os.platform() === 'win32' ? 'python' : 'python3';
+		const cmd = `${py} "${script}" ${command} "${analyzerDir.fsPath}" --cli --engine "${engineDir}"`;
+
+		const termName = 'NLP++ Regression';
+		let term = vscode.window.terminals.find(t => t.name === termName);
+		if (!term) {
+			term = vscode.window.createTerminal(termName);
+		}
+		term.show(true);
+		term.sendText(cmd);
+	}
+
+	runRegressionTest(analyzerItem: AnalyzerItem) {
+		this.runRegress(analyzerItem, 'test');
+	}
+
+	blessRegression(analyzerItem: AnalyzerItem) {
+		vscode.window.showWarningMessage(
+			'Bless will OVERWRITE the regression goldens (test/expected/) with the analyzer\'s CURRENT output. Only do this after confirming the current output is correct. Continue?',
+			{ modal: true }, 'Bless'
+		).then(choice => {
+			if (choice === 'Bless') {
+				this.runRegress(analyzerItem, 'bless');
+			}
+		});
 	}
 
 	public deleteAllAnalyzerLogs() {


### PR DESCRIPTION
## Summary
Adds a **beaker button** in the Analyzers panel toolbar (and a right-click menu item on an analyzer) that runs the cross-platform golden-file regression tester over **every file** in the analyzer's `input/` directory, plus a **Bless Regression Goldens (All Files)** command to (re)capture the goldens.

The handler shells out to `nlp_regress.py` — shipped in the engine's `visualText/python` folder (found via `getVisualTextDirectory('python')`, companion PR: visualtext/visualtext-files) — in an "NLP++ Regression" integrated terminal, passing the loaded/selected analyzer and the bundled engine (`--cli --engine`). A terminal keeps it cross-platform (Windows/macOS/Linux) and shows live PASS/FAIL output.

### Why a second regression command
Complements the existing per-file, line-by-line **Run Regression Test**: `nlp_regress` compares the structured extraction **semantically** (records `id`-stripped and order-insensitive), so it's stable across cosmetic engine drift while still catching a real added/removed/changed extraction. **Bless** prompts for modal confirmation before overwriting goldens.

### Scope / notes
- Source-only change: `package.json` + `src/analyzerView.ts`. `tsc -p ./` passes.
- Rebuild `dist/` via `npm run compile` when packaging the .vsix.
- Requires `python` on PATH (already assumed by the extension's Python Scripts feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)