### PR TITLE
feat: in-extension Help system + built-in regression runner (3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.0
+Added an in-extension Help system and a built-in regression-test runner.
+
+- **Help view** in the NLP++ sidebar plus a 📖 book button on the view toolbars, opening markdown help pages (Quick Start, Compiling, Regression Testing, Lazy Loading) and an **NLP++** reference node (functions, variables, etc.). Help content lives in the VisualText files under `Help/markdown/vscode/`.
+- **Version notes**: on first install the Help home opens; on upgrade the newest unseen `versions/<ver>.md` opens automatically (tracked in globalState).
+- **Create Claude Prompt to Build an Analyzer** (Help view + Analyzers toolbar): opens a new editor with a generated prompt containing this machine's engine, example/template analyzer, and library paths.
+- **Built-in regression runner**: "Run Regression Test" / "Bless Regression Goldens" now run natively and stream `PASS`/`FAIL`/`MISSING` into the **Logging** view (no terminal, no Python dependency). Set `analyzer.regressionTerminal` to use the old `nlp_regress.py` terminal path. A 🧪 test icon and right-click items on each Text-view file/folder scope a run to that item.
+- The Logging view now **auto-scrolls** to the newest line, and a regression run **clears the log** before starting.
+
 ### 3.1.30
 Added a whole-analyzer regression tester to the Analyzers panel.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.1.30",
+    "version": "3.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.1.30",
+            "version": "3.2.0",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.1.30",
+    "version": "3.2.0",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -51,6 +51,11 @@
                     "id": "kbView",
                     "name": "KB",
                     "icon": "resources/dark/kb.svg"
+                },
+                {
+                    "id": "helpView",
+                    "name": "Help",
+                    "icon": "resources/dark/document.svg"
                 }
             ],
             "vtOutput": [
@@ -554,6 +559,25 @@
                 "category": "NLP",
                 "title": "Open Variables Help",
                 "description": "Open the markdown variables help"
+            },
+            {
+                "command": "helpView.openHome",
+                "category": "NLP",
+                "title": "NLP++ Help",
+                "description": "Open the NLP++ help home page",
+                "icon": "$(book)"
+            },
+            {
+                "command": "helpView.refreshHelp",
+                "category": "NLP",
+                "title": "Refresh Help",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "helpView.createClaudePrompt",
+                "category": "NLP",
+                "title": "Create Claude Prompt to Build an Analyzer",
+                "icon": "$(comment-discussion)"
             },
             {
                 "command": "nlp.selectSequence",
@@ -1730,6 +1754,16 @@
                 "icon": "$(save-all)"
             },
             {
+                "command": "textView.runRegressionItem",
+                "title": "Run Regression Test",
+                "icon": "$(beaker)"
+            },
+            {
+                "command": "textView.blessRegressionItem",
+                "title": "Bless Regression Goldens",
+                "icon": "$(save-all)"
+            },
+            {
                 "command": "kbView.compileKB",
                 "title": "Compile KB to C++ Library",
                 "icon": {
@@ -2071,6 +2105,26 @@
                     "group": "navigation@4"
                 },
                 {
+                    "command": "helpView.openHome",
+                    "when": "view == textView",
+                    "group": "navigation@9"
+                },
+                {
+                    "command": "helpView.openHome",
+                    "when": "view == sequenceView",
+                    "group": "navigation@9"
+                },
+                {
+                    "command": "helpView.openHome",
+                    "when": "view == kbView",
+                    "group": "navigation@9"
+                },
+                {
+                    "command": "helpView.refreshHelp",
+                    "when": "view == helpView",
+                    "group": "navigation@1"
+                },
+                {
                     "command": "textView.fastLoad",
                     "when": "view == textView && !textView.fastload",
                     "group": "secondary@0"
@@ -2264,6 +2318,11 @@
                     "command": "analyzerView.runRegressionTest",
                     "when": "view == analyzerView",
                     "group": "navigation@6"
+                },
+                {
+                    "command": "helpView.createClaudePrompt",
+                    "when": "view == analyzerView",
+                    "group": "navigation@7"
                 },
                 {
                     "command": "analyzerView.copyPath",
@@ -3016,6 +3075,21 @@
                     "group": "inline@01"
                 },
                 {
+                    "command": "textView.runRegressionItem",
+                    "when": "view == textView && viewItem =~ /file|dir/",
+                    "group": "inline@05"
+                },
+                {
+                    "command": "textView.runRegressionItem",
+                    "when": "view == textView && viewItem =~ /file|dir/",
+                    "group": "regress@00"
+                },
+                {
+                    "command": "textView.blessRegressionItem",
+                    "when": "view == textView && viewItem =~ /file|dir/",
+                    "group": "regress@01"
+                },
+                {
                     "command": "textView.analyze",
                     "when": "view == textView && viewItem =~ /.*file.*/",
                     "group": "inline@02"
@@ -3029,16 +3103,6 @@
                     "command": "textView.copyToAnalyzer",
                     "when": "view == textView",
                     "group": "inline@04"
-                },
-                {
-                    "command": "textView.newDir",
-                    "when": "view == textView && viewItem =~ /.*dir.*/",
-                    "group": "inline@05"
-                },
-                {
-                    "command": "textView.newText",
-                    "when": "view == textView && viewItem =~ /.*dir.*/",
-                    "group": "inline@06"
                 },
                 {
                     "command": "textView.deleteDir",
@@ -3132,6 +3196,12 @@
                     "scope": "application",
                     "default": false,
                     "description": "Load textview fast. Attributes for text files are lost such as has logs, etc."
+                },
+                "analyzer.regressionTerminal": {
+                    "type": "boolean",
+                    "scope": "resource",
+                    "default": false,
+                    "description": "Run regression tests by shelling out to nlp_regress.py in a terminal instead of the built-in runner (which streams results into the NLP++ log view)."
                 },
                 "user.name": {
                     "type": "string",

--- a/src/analyzerView.ts
+++ b/src/analyzerView.ts
@@ -10,6 +10,7 @@ import { SequenceFile } from './sequence';
 import { TextFile } from './textFile';
 import { anaSubDir } from './analyzer';
 import { NLPCompile } from './compile';
+import { regressionRunner } from './regression';
 
 export enum analyzerItemType { ANALYZER, FOLDER, NLP, SEQUENCE, ECL, MANIFEST, FILE, README }
 
@@ -799,6 +800,22 @@ export class AnalyzerView {
 			vscode.window.showWarningMessage('No analyzer loaded. Open an analyzer first.');
 			return;
 		}
+		// Default to the native (TypeScript) runner: results stream into the NLP++
+		// log view and there is no python dependency. Set
+		// "analyzer.regressionTerminal": true to fall back to shelling out to
+		// nlp_regress.py in a terminal (useful for A/B-ing the two).
+		const useTerminal = vscode.workspace.getConfiguration('analyzer').get<boolean>('regressionTerminal', false);
+		if (useTerminal) {
+			this.runRegressTerminal(analyzerDir, command);
+			return;
+		}
+		if (command === 'bless')
+			regressionRunner.bless(analyzerDir);
+		else
+			regressionRunner.test(analyzerDir);
+	}
+
+	private runRegressTerminal(analyzerDir: vscode.Uri, command: 'test' | 'bless') {
 		const script = path.join(visualText.getVisualTextDirectory('python'), 'nlp_regress.py');
 		if (!fs.existsSync(script)) {
 			vscode.window.showErrorMessage('Regression script not found: ' + script);
@@ -829,7 +846,7 @@ export class AnalyzerView {
 		}
 		// Only warn about overwriting when goldens already exist. On the first
 		// bless there is nothing to overwrite, so just create them.
-		if (!this.hasBlessedGoldens(analyzerDir)) {
+		if (!regressionRunner.goldensExist(analyzerDir)) {
 			this.runRegress(analyzerItem, 'bless');
 			return;
 		}
@@ -853,24 +870,6 @@ export class AnalyzerView {
 			return visualText.analyzer.getAnalyzerDirectory();
 		}
 		return undefined;
-	}
-
-	// True if any golden (.json under test/expected/) has been blessed already.
-	private hasBlessedGoldens(analyzerDir: vscode.Uri): boolean {
-		const expectedDir = path.join(analyzerDir.fsPath, 'test', 'expected');
-		if (!fs.existsSync(expectedDir)) return false;
-		const hasJson = (dir: string): boolean => {
-			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-				const full = path.join(dir, entry.name);
-				if (entry.isDirectory()) {
-					if (hasJson(full)) return true;
-				} else if (entry.name.endsWith('.json')) {
-					return true;
-				}
-			}
-			return false;
-		};
-		return hasJson(expectedDir);
 	}
 
 	public deleteAllAnalyzerLogs() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,9 +21,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
     SequenceView.attach(ctx);
     KBView.attach(ctx);
     FindView.attach(ctx);
-    HelpView.attach(ctx);
+    const help = HelpView.attach(ctx);
     NLPCommands.attach(ctx);
     NLPStatusBar.attach(ctx);
+
+    // First-run welcome / new-version notes (guarded; never blocks activation).
+    help.checkVersionNotes();
 
     vscode.commands.executeCommand('setContext', 'textView.fastload', visualText.getTextFastLoad());
       

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -5,12 +5,85 @@ import * as os from 'os';
 import { visualText } from './visualText';
 import { ETIME } from 'constants';
 
+// One entry in the Help tree view. `page` is a path under Help/markdown/ (no .md).
+export interface HelpItem {
+    label: string;
+    page: string;
+    icon: string;
+    isVersionRoot?: boolean;
+    collapsible?: boolean;
+    expanded?: boolean;
+    children?: HelpItem[];
+    cmd?: string;   // run this command instead of opening a markdown page
+}
+
+export class HelpTreeDataProvider implements vscode.TreeDataProvider<HelpItem> {
+    private _onDidChangeTreeData = new vscode.EventEmitter<HelpItem | undefined | null | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+    refresh(): void { this._onDidChangeTreeData.fire(); }
+
+    getTreeItem(item: HelpItem): vscode.TreeItem {
+        const collapse = item.collapsible
+            ? (item.expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed)
+            : vscode.TreeItemCollapsibleState.None;
+        const ti = new vscode.TreeItem(item.label, collapse);
+        ti.iconPath = new vscode.ThemeIcon(item.icon);
+        // Items can run a command (e.g. Create Claude Prompt); leaf pages open
+        // their markdown; parent nodes just expand.
+        if (item.cmd) {
+            ti.command = { command: item.cmd, title: item.label };
+        } else if (!item.collapsible && !item.isVersionRoot && item.page) {
+            ti.command = { command: 'helpView.openVscodeHelp', title: 'Open Help', arguments: [item] };
+        }
+        return ti;
+    }
+
+    getChildren(item?: HelpItem): HelpItem[] {
+        if (!item) {
+            return [
+                { label: 'Create Claude Prompt to Build an Analyzer', page: '', icon: 'comment-discussion', cmd: 'helpView.createClaudePrompt' },
+                { label: 'Home', page: 'vscode/home', icon: 'home' },
+                { label: 'Quick Start', page: 'vscode/quickstart', icon: 'rocket' },
+                { label: 'Regression Testing', page: 'vscode/testing', icon: 'beaker' },
+                { label: 'Compiling Analyzers', page: 'vscode/compiling', icon: 'gear' },
+                { label: 'Lazy Loading', page: 'vscode/lazyload', icon: 'symbol-array' },
+                {
+                    label: 'NLP++', page: '', icon: 'symbol-namespace', collapsible: true,
+                    children: [
+                        { label: 'About NLP++', page: 'NLP_PP_Stuff/About_NLP++', icon: 'book' },
+                        { label: 'Variables', page: 'NLP_PP_Stuff/About_NLP++_Variables', icon: 'symbol-variable' },
+                        { label: 'Tokens', page: 'NLP_PP_Stuff/Tokens', icon: 'symbol-key' },
+                        { label: 'String Functions', page: 'Table_of_String_Functions', icon: 'symbol-string' },
+                        { label: 'Node / Parse Tree Functions', page: 'Table_of_Parse_Tree_Functions', icon: 'list-tree' },
+                        { label: 'Knowledge Base Functions', page: 'Table_of_Knowledge_Base_Functions', icon: 'database' },
+                        { label: 'Math Functions', page: 'Table_of_Math_Functions', icon: 'symbol-operator' },
+                        { label: 'Array Functions', page: 'Table_of_Array_Functions', icon: 'symbol-array' },
+                        { label: 'Formatting & I/O Functions', page: 'Table_of_Formatting_and_I_O_Functions', icon: 'output' },
+                        { label: 'Special Functions', page: 'Table_of_Special_Functions', icon: 'symbol-misc' },
+                    ],
+                },
+                { label: 'Version Notes', page: '', icon: 'history', isVersionRoot: true, collapsible: true, expanded: true },
+            ];
+        }
+        if (item.isVersionRoot) {
+            return helpView.listVersionNotes().map(v => (
+                { label: v, page: 'vscode/versions/' + v, icon: 'tag' } as HelpItem));
+        }
+        if (item.children) {
+            return item.children;
+        }
+        return [];
+    }
+}
+
 export let helpView: HelpView;
 export class HelpView {
 
     panel: vscode.WebviewPanel | undefined;
     exists: boolean;
     ctx: vscode.ExtensionContext;
+    helpTreeProvider: HelpTreeDataProvider;
+    helpTree: vscode.TreeView<HelpItem>;
 
     constructor(private context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('helpView.lookup', (resource) => this.lookup(resource));
@@ -18,9 +91,15 @@ export class HelpView {
         vscode.commands.registerCommand('helpView.openHelpIndex', () => this.openHelpIndex());
         vscode.commands.registerCommand('helpView.openFunctionHelp', () => this.openFunctionHelp());
         vscode.commands.registerCommand('helpView.openVariableHelp', () => this.openVariableHelp());
+        vscode.commands.registerCommand('helpView.openHome', () => this.openHome());
+        vscode.commands.registerCommand('helpView.openVscodeHelp', (item) => this.openVscodeHelp(item));
+        vscode.commands.registerCommand('helpView.refreshHelp', () => this.helpTreeProvider.refresh());
+        vscode.commands.registerCommand('helpView.createClaudePrompt', () => this.createClaudePrompt());
         this.exists = false;
         this.ctx = context;
         this.panel = undefined;
+        this.helpTreeProvider = new HelpTreeDataProvider();
+        this.helpTree = vscode.window.createTreeView('helpView', { treeDataProvider: this.helpTreeProvider });
     }
 
     static attach(ctx: vscode.ExtensionContext) {
@@ -107,6 +186,110 @@ export class HelpView {
             vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(mdFile));
         } else {
             vscode.window.showErrorMessage(`Help file does not exist: ${mdFile}`);
+        }
+    }
+
+    openHome() {
+        this.displayMarkdownHelp('vscode/home');
+    }
+
+    openVscodeHelp(item: HelpItem) {
+        if (item && item.page)
+            this.displayMarkdownHelp(item.page);
+    }
+
+    // Build a ready-to-paste prompt for Claude that points it at this machine's
+    // engine, example/template analyzers, and library files, then open it in a
+    // new editor. Paths are machine-specific, which is why this is generated.
+    async createClaudePrompt() {
+        const engineDir = visualText.engineDirectory().fsPath;
+        const exeName = os.platform() === 'win32' ? 'nlp.exe' : 'nlp';
+        const exe = path.join(engineDir, exeName);
+        const analyzersDir = visualText.getVisualTextDirectory('analyzers');
+        const templatesDir = visualText.getVisualTextDirectory('analyzer-templates');
+        const vtDir = visualText.getVisualTextDirectory();
+        const languagesDir = visualText.getVisualTextDirectory('languages');
+        const miscDir = visualText.getVisualTextDirectory('misc');
+
+        const prompt =
+`I want you to help me write a prototype NLP++ analyzer. NLP++ is a rule-based programming language for natural language processing, run by the NLP engine. Everything you need is already installed on this machine at the paths below:
+
+- NLP engine executable (run analyzers with this): ${exe}
+- Example analyzers (study these for patterns, the pass sequence, and how rules and the knowledge base work together): ${analyzersDir}
+- Analyzer templates (good starting points for a new analyzer): ${templatesDir}
+- VisualText support files: ${vtDir}
+    - Library functions and language dictionaries / knowledge bases: ${languagesDir}
+    - Misc library functions: ${miscDir}
+
+An NLP++ analyzer is a folder containing: spec/ (the .nlp passes plus analyzer.seq, the ordered pass sequence), input/ (text files to analyze), and kb/ (the knowledge base). Before writing anything, read several of the example and template analyzers above to learn the analyzer.seq format, the pass structure, and the library functions and KB conventions available in the languages and misc directories. Run an analyzer by invoking the engine executable above on an input file.
+
+Create a folder of text files from the internet that (FILL IN YOUR DESCRIPTION) and create an analyzer that does (FILL IN YOUR DESCRIPTION OF THE ANALYZER).`;
+
+        const doc = await vscode.workspace.openTextDocument({ content: prompt, language: 'markdown' });
+        await vscode.window.showTextDocument(doc);
+    }
+
+    helpExists(relativeName: string): boolean {
+        return fs.existsSync(path.join(visualText.getVisualTextDirectory('Help'), 'markdown', relativeName + '.md'));
+    }
+
+    // Version-note files live at Help/markdown/vscode/versions/<version>.md. Only
+    // significant releases get one. Returns the versions present, newest first.
+    listVersionNotes(): string[] {
+        const dir = path.join(visualText.getVisualTextDirectory('Help'), 'markdown', 'vscode', 'versions');
+        if (!fs.existsSync(dir)) return [];
+        return fs.readdirSync(dir)
+            .filter(f => f.toLowerCase().endsWith('.md'))
+            .map(f => f.replace(/\.md$/i, ''))
+            .sort((a, b) => this.compareVersions(b, a));
+    }
+
+    // Numeric dotted-version compare: returns >0 if a>b, <0 if a<b, 0 if equal.
+    compareVersions(a: string, b: string): number {
+        const pa = a.split('.').map(n => parseInt(n, 10) || 0);
+        const pb = b.split('.').map(n => parseInt(n, 10) || 0);
+        const len = Math.max(pa.length, pb.length);
+        for (let i = 0; i < len; i++) {
+            const d = (pa[i] || 0) - (pb[i] || 0);
+            if (d !== 0) return d;
+        }
+        return 0;
+    }
+
+    private extensionVersion(): string {
+        const v = this.ctx.extension?.packageJSON?.version;
+        return (typeof v === 'string' && v.length) ? v : (visualText.version || '');
+    }
+
+    // Called once on activation. On a first install, opens the help home. On an
+    // upgrade, opens the newest version note the user hasn't seen yet (a note
+    // exists only for releases the developers marked significant). Never blocks
+    // activation and never nags about a version already seen.
+    checkVersionNotes() {
+        try {
+            const key = 'nlp.helpLastSeenVersion';
+            const current = this.extensionVersion();
+            const lastSeen = this.ctx.globalState.get<string>(key);
+
+            if (!lastSeen) {
+                // First install — show the hub once the help content is present.
+                if (this.helpExists('vscode/home')) {
+                    this.openHome();
+                    this.ctx.globalState.update(key, current);
+                }
+                return;
+            }
+
+            if (current && this.compareVersions(current, lastSeen) > 0) {
+                const next = this.listVersionNotes().find(v =>
+                    this.compareVersions(v, lastSeen) > 0 &&
+                    this.compareVersions(v, current) <= 0);
+                if (next)
+                    this.displayMarkdownHelp('vscode/versions/' + next);
+                this.ctx.globalState.update(key, current);
+            }
+        } catch {
+            // Help should never break activation.
         }
     }
 }

--- a/src/logView.ts
+++ b/src/logView.ts
@@ -50,6 +50,12 @@ export class OutputTreeDataProvider implements vscode.TreeDataProvider<LogItem> 
 		}
 		return [];
 	}
+
+	// Required for TreeView.reveal() (used to auto-scroll to the newest line).
+	// The log is a flat list, so every item is a root node with no parent.
+	public getParent(element: LogItem): LogItem | undefined {
+		return undefined;
+	}
 }
 
 export let logView: LogView;
@@ -65,7 +71,7 @@ export class LogView {
 	constructor(context: vscode.ExtensionContext) {
 		const logViewProvider = new OutputTreeDataProvider();
 		this.logView = vscode.window.createTreeView('logView', { treeDataProvider: logViewProvider });
-		vscode.commands.registerCommand('logView.refreshAll', () => logViewProvider.refresh());
+		vscode.commands.registerCommand('logView.refreshAll', () => { logViewProvider.refresh(); this.revealLast(); });
 		vscode.commands.registerCommand('logView.openFile', (resource) => this.openFile(resource));
 		vscode.commands.registerCommand('logView.addMessage', (message, type, uri) => this.addMessage(message, type, uri));
 		vscode.commands.registerCommand('logView.conceptualGrammar', () => this.loadCGLog());
@@ -92,6 +98,19 @@ export class LogView {
 			logView = new LogView(ctx);
 		}
 		return logView;
+	}
+
+	// Auto-scroll the log view to the most recent line. reveal() relies on the
+	// provider's getParent(); the log is flat so this just scrolls to the tail.
+	// select/focus false = scroll only, don't steal selection or keyboard focus.
+	private revealLast() {
+		if (!this.logView || this.logs.length === 0) return;
+		const last = this.logs[this.logs.length - 1];
+		try {
+			this.logView.reveal(last, { select: false, focus: false });
+		} catch {
+			// view not visible / not ready yet — nothing to scroll
+		}
 	}
 
 	enginePath() {

--- a/src/regression.ts
+++ b/src/regression.ts
@@ -1,0 +1,380 @@
+// Native (TypeScript) golden-file regression runner for NLP++ analyzers.
+//
+// This is the in-extension equivalent of visualText/python/nlp_regress.py run
+// in its --cli mode: for every input file it runs nlp.exe, reads the analyzer's
+// <input>_log/output.json, normalizes it semantically (drop volatile `id`
+// fields, sort extraction-record lists), and compares against a golden under
+// <analyzer>/test/expected/. Output goes to the NLP++ log view instead of a
+// terminal, and it needs no python on PATH.
+//
+// The normalization MUST stay byte-compatible with nlp_regress.py so goldens
+// blessed by either path interchange. See canon()/diffRecords() below.
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as cp from 'child_process';
+import { visualText } from './visualText';
+import { logView, logLineType } from './logView';
+
+const LOG_DIR_SUFFIX = '_log';
+const DEFAULT_EXCLUDE_NAMES = new Set(['sources.md', 'readme.md']);
+const DEFAULT_EXCLUDE_SUFFIXES = new Set(['.json']);
+const DEFAULT_IGNORE_FIELDS = ['id'];
+
+interface RegressConfig {
+    include: string[];
+    exclude: string[];
+    ignoreFields: string[];
+}
+
+export class RegressionRunner {
+
+    // ----- public entry points -------------------------------------------------
+
+    // scope (optional) limits the run to a folder under <analyzer>/input/; when
+    // omitted the whole input/ tree is used.
+    public async test(analyzerDir: vscode.Uri, scope?: vscode.Uri): Promise<void> {
+        await this.run(analyzerDir, 'test', scope);
+    }
+
+    public async bless(analyzerDir: vscode.Uri, scope?: vscode.Uri): Promise<void> {
+        await this.run(analyzerDir, 'bless', scope);
+    }
+
+    // True if any golden (.json under test/expected/) exists for the analyzer, or
+    // for the given scope folder (mirrored under test/expected/).
+    public goldensExist(analyzerDir: vscode.Uri, scope?: vscode.Uri): boolean {
+        const expectedRoot = path.join(analyzerDir.fsPath, 'test', 'expected');
+        const inputRoot = path.join(analyzerDir.fsPath, 'input');
+        if (scope && this.isFile(scope.fsPath)) {
+            const rel = path.relative(inputRoot, scope.fsPath);
+            return fs.existsSync(path.join(expectedRoot, rel + '.json'));
+        }
+        const dir = scope ? path.join(expectedRoot, path.relative(inputRoot, scope.fsPath)) : expectedRoot;
+        return this.dirHasJson(dir);
+    }
+
+    // ----- core loop -----------------------------------------------------------
+
+    private async run(analyzerDir: vscode.Uri, command: 'test' | 'bless', scope?: vscode.Uri): Promise<void> {
+        const anaPath = analyzerDir.fsPath;
+        const name = path.basename(anaPath.replace(/[\\/]+$/, ''));
+
+        const exe = this.enginePath();
+        if (!exe || !fs.existsSync(exe)) {
+            this.log(`Regression: NLP engine not found (${exe || 'nlp.exe'})`, analyzerDir);
+            vscode.window.showErrorMessage('NLP engine not found. Download it first.');
+            return;
+        }
+        const engineDir = visualText.engineDirectory().fsPath;
+
+        const cfg = this.loadConfig(anaPath);
+        const inputRoot = path.join(anaPath, 'input');
+        // scope can be a single input file, a folder under input/, or nothing.
+        let inputs: string[];
+        let scopeLabel = '';
+        if (scope && this.isFile(scope.fsPath)) {
+            inputs = [scope.fsPath];
+            scopeLabel = ` (file: ${path.relative(inputRoot, scope.fsPath)})`;
+        } else {
+            inputs = this.findInputs(anaPath, cfg, scope?.fsPath);
+            scopeLabel = scope ? ` (folder: ${path.relative(inputRoot, scope.fsPath) || 'input'})` : '';
+        }
+        if (inputs.length === 0) {
+            this.log(`${name}: no input files found under input/${scopeLabel}`, analyzerDir);
+            vscode.window.showWarningMessage(`${name}: no input files found under input/${scopeLabel}`);
+            return;
+        }
+
+        const ignore = new Set(cfg.ignoreFields);
+
+        // Surface everything in the NLP++ log view (not the status bar): reveal
+        // the panel, clear prior output, then refresh after each file so results
+        // stream in live.
+        vscode.commands.executeCommand('workbench.view.extension.vtOutput');
+        vscode.commands.executeCommand('logView.focus');
+        logView.clearLogs();
+
+        this.log(`engine: ${exe}`, analyzerDir);
+        this.log(`${name}: ${command === 'bless' ? 'blessing' : 'testing'} ${inputs.length} input file(s)${scopeLabel}`, analyzerDir);
+        this.refresh();
+
+        let passed = 0, failed = 0, missing = 0, blessed = 0;
+
+        for (const inp of inputs) {
+            const rel = path.relative(path.join(anaPath, 'input'), inp);
+            const inputUri = vscode.Uri.file(inp);
+
+            const out = await this.analyze(exe, engineDir, anaPath, inp);
+            const actual = this.canon(out, ignore);
+            const gp = this.goldenPath(anaPath, inp);
+
+            if (command === 'bless') {
+                fs.mkdirSync(path.dirname(gp), { recursive: true });
+                fs.writeFileSync(gp, this.serialize(actual) + '\n', 'utf8');
+                blessed++;
+                this.log(`  blessed  ${rel}`, inputUri);
+                this.refresh();
+                continue;
+            }
+
+            if (!fs.existsSync(gp)) {
+                missing++;
+                this.log(`  MISSING  ${rel}  (no golden - run 'bless')`, inputUri);
+                this.refresh();
+                continue;
+            }
+            const expected = JSON.parse(fs.readFileSync(gp, 'utf8'));
+            if (this.deepEqual(expected, actual)) {
+                passed++;
+                this.log(`  PASS     ${rel}`, inputUri);
+                this.refresh();
+                continue;
+            }
+            failed++;
+            this.log(`  FAIL     ${rel}`, inputUri);
+            const { removed, added } = this.diffRecords(expected, actual, ignore);
+            for (const r of removed) this.log(`      - ${r}`, inputUri);
+            for (const a of added) this.log(`      + ${a}`, inputUri);
+            if (removed.length === 0 && added.length === 0)
+                this.log('      (output structure changed; see test/expected/ vs run)', inputUri);
+            this.refresh();
+        }
+
+        if (command === 'bless') {
+            const msg = `${name}: blessed ${blessed} golden(s) under test/expected/`;
+            this.log(msg, analyzerDir);
+            vscode.window.showInformationMessage(msg);
+        } else {
+            const total = passed + failed + missing;
+            const status = (failed === 0 && missing === 0) ? 'OK' : 'REGRESSION';
+            const summary = `${name}: ${passed}/${total} passed`
+                + (failed ? `, ${failed} failed` : '')
+                + (missing ? `, ${missing} missing` : '')
+                + `   [${status}]`;
+            this.log(`  ${summary}`, analyzerDir);
+            if (status === 'OK')
+                vscode.window.showInformationMessage(summary);
+            else
+                vscode.window.showWarningMessage(summary);
+        }
+        vscode.commands.executeCommand('logView.refreshAll');
+    }
+
+    // ----- engine invocation (CLI backend) -------------------------------------
+
+    private enginePath(): string {
+        const engineDir = visualText.engineDirectory().fsPath;
+        if (!engineDir) return '';
+        const exeName = os.platform() === 'win32' ? 'nlp.exe' : 'nlp';
+        return path.join(engineDir, exeName);
+    }
+
+    // Run nlp.exe over one input and return the parsed <input>_log/output.json.
+    // Mirrors CliBackend.analyze in nlp_regress.py: clear the log dir, run the
+    // engine, read output.json, then remove the log dir.
+    private analyze(exe: string, engineDir: string, anaPath: string, inputPath: string): Promise<any> {
+        const logDir = inputPath + LOG_DIR_SUFFIX;
+        this.rmrf(logDir);
+        const args = ['-ANA', anaPath, '-WORK', engineDir, inputPath];
+        return new Promise(resolve => {
+            cp.execFile(exe, args, { maxBuffer: 1024 * 1024 * 64 }, () => {
+                let data: any = {};
+                try {
+                    const outJson = path.join(logDir, 'output.json');
+                    if (fs.existsSync(outJson))
+                        data = JSON.parse(fs.readFileSync(outJson, 'utf8'));
+                } catch {
+                    data = {};
+                }
+                this.rmrf(logDir);
+                resolve(data || {});
+            });
+        });
+    }
+
+    // ----- input discovery (find_inputs) ---------------------------------------
+
+    private findInputs(anaPath: string, cfg: RegressConfig, walkDir?: string): string[] {
+        const root = path.join(anaPath, 'input');
+        // Discover from walkDir (a folder under input/) when scoped; rel paths,
+        // golden paths and include/exclude globs stay anchored at input/.
+        const start = walkDir ?? root;
+        if (!this.isDir(start)) return [];
+        const inputs: string[] = [];
+        const walk = (dir: string) => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) { walk(full); continue; }
+                if (!entry.isFile()) continue;
+                const rel = path.relative(root, full);
+                // skip anything inside an engine "<file>_log" output directory
+                if (rel.split(/[\\/]/).some(p => p.endsWith(LOG_DIR_SUFFIX))) continue;
+                if (DEFAULT_EXCLUDE_NAMES.has(entry.name.toLowerCase())) continue;
+                if (DEFAULT_EXCLUDE_SUFFIXES.has(path.extname(entry.name).toLowerCase())) continue;
+                const relPosix = rel.split(path.sep).join('/');
+                if (cfg.include.length && !cfg.include.some(g => this.globMatch(relPosix, g))) continue;
+                if (cfg.exclude.some(g => this.globMatch(relPosix, g))) continue;
+                inputs.push(full);
+            }
+        };
+        walk(start);
+        inputs.sort();
+        return inputs;
+    }
+
+    private dirHasJson(dir: string): boolean {
+        if (!this.isDir(dir)) return false;
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                if (this.dirHasJson(full)) return true;
+            } else if (entry.name.endsWith('.json')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private loadConfig(anaPath: string): RegressConfig {
+        const cfg: RegressConfig = { include: [], exclude: [], ignoreFields: [...DEFAULT_IGNORE_FIELDS] };
+        const cfgPath = path.join(anaPath, 'test', 'regress.json');
+        if (fs.existsSync(cfgPath)) {
+            try {
+                const raw = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+                if (Array.isArray(raw.include)) cfg.include = raw.include;
+                if (Array.isArray(raw.exclude)) cfg.exclude = raw.exclude;
+                if (Array.isArray(raw.ignore_fields)) cfg.ignoreFields = raw.ignore_fields;
+            } catch (e: any) {
+                this.log(`Regression: could not read ${cfgPath}: ${e?.message ?? e}`, vscode.Uri.file(cfgPath));
+            }
+        }
+        return cfg;
+    }
+
+    private goldenPath(anaPath: string, inputPath: string): string {
+        const rel = path.relative(path.join(anaPath, 'input'), inputPath);
+        return path.join(anaPath, 'test', 'expected', rel + '.json');
+    }
+
+    // ----- normalization & diff (must match nlp_regress.py) --------------------
+
+    // Drop ignore fields recursively; sort lists whose items are all objects/arrays
+    // so a renumber/reorder is not flagged as a regression.
+    private canon(obj: any, ignore: Set<string>): any {
+        if (Array.isArray(obj)) {
+            const items = obj.map(v => this.canon(v, ignore));
+            if (items.length && items.every(v => v !== null && typeof v === 'object')) {
+                items.sort((a, b) => {
+                    const ka = this.stable(a), kb = this.stable(b);
+                    return ka < kb ? -1 : ka > kb ? 1 : 0;
+                });
+            }
+            return items;
+        }
+        if (obj !== null && typeof obj === 'object') {
+            const out: any = {};
+            for (const k of Object.keys(obj))
+                if (!ignore.has(k)) out[k] = this.canon(obj[k], ignore);
+            return out;
+        }
+        return obj;
+    }
+
+    // Flatten the extraction records (leaf list-of-dicts) for a readable diff.
+    private records(obj: any): any[] {
+        const out: any[] = [];
+        if (Array.isArray(obj)) {
+            if (obj.length && obj.every(v => v !== null && typeof v === 'object' && !Array.isArray(v)))
+                out.push(...obj);
+            else
+                for (const v of obj) out.push(...this.records(v));
+        } else if (obj !== null && typeof obj === 'object') {
+            for (const v of Object.values(obj)) out.push(...this.records(v));
+        }
+        return out;
+    }
+
+    private diffRecords(expected: any, actual: any, ignore: Set<string>): { removed: string[]; added: string[] } {
+        const bag = (o: any): Map<string, number> => {
+            const b = new Map<string, number>();
+            for (const r of this.records(o)) {
+                const stripped: any = {};
+                for (const k of Object.keys(r)) if (!ignore.has(k)) stripped[k] = r[k];
+                const key = this.stable(stripped);
+                b.set(key, (b.get(key) ?? 0) + 1);
+            }
+            return b;
+        };
+        const eb = bag(expected), ab = bag(actual);
+        const removed: string[] = [], added: string[] = [];
+        for (const [k, n] of eb) for (let i = 0; i < Math.max(0, n - (ab.get(k) ?? 0)); i++) removed.push(k);
+        for (const [k, n] of ab) for (let i = 0; i < Math.max(0, n - (eb.get(k) ?? 0)); i++) added.push(k);
+        return { removed, added };
+    }
+
+    // ----- json helpers --------------------------------------------------------
+
+    // Stable stringify with recursively sorted object keys (matches python
+    // json.dumps(..., sort_keys=True)). Arrays keep their order.
+    private stable(obj: any): string {
+        return JSON.stringify(this.sortKeys(obj));
+    }
+
+    // Pretty (indent=2) sorted-key serialization for golden files, matching
+    // json.dumps(canon, indent=2, ensure_ascii=False, sort_keys=True).
+    private serialize(obj: any): string {
+        return JSON.stringify(this.sortKeys(obj), null, 2);
+    }
+
+    private sortKeys(obj: any): any {
+        if (Array.isArray(obj)) return obj.map(v => this.sortKeys(v));
+        if (obj !== null && typeof obj === 'object') {
+            const out: any = {};
+            for (const k of Object.keys(obj).sort()) out[k] = this.sortKeys(obj[k]);
+            return out;
+        }
+        return obj;
+    }
+
+    private deepEqual(a: any, b: any): boolean {
+        return this.stable(a) === this.stable(b);
+    }
+
+    // ----- misc ----------------------------------------------------------------
+
+    // Minimal glob matcher for test/regress.json include/exclude (supports ** / * / ?).
+    private globMatch(relPosix: string, glob: string): boolean {
+        const re = '^' + glob
+            .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+            .replace(/\*\*/g, ' ')
+            .replace(/\*/g, '[^/]*')
+            .replace(/ /g, '.*')
+            .replace(/\?/g, '.') + '$';
+        return new RegExp(re).test(relPosix);
+    }
+
+    private isDir(p: string): boolean {
+        try { return fs.statSync(p).isDirectory(); } catch { return false; }
+    }
+
+    private isFile(p: string): boolean {
+        try { return fs.statSync(p).isFile(); } catch { return false; }
+    }
+
+    private rmrf(p: string): void {
+        try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+
+    private log(message: string, uri: vscode.Uri): void {
+        logView.addMessage(message, logLineType.ANALYER_OUTPUT, uri);
+    }
+
+    private refresh(): void {
+        vscode.commands.executeCommand('logView.refreshAll');
+    }
+}
+
+export const regressionRunner = new RegressionRunner();

--- a/src/textView.ts
+++ b/src/textView.ts
@@ -8,6 +8,7 @@ import { dirfuncs } from './dirfuncs';
 import { nlpStatusBar, DevMode, FiredMode } from './status';
 import { fileOperation, fileOpRefresh } from './fileOps';
 import { anaSubDir } from './analyzer';
+import { regressionRunner } from './regression';
 import * as fs from 'fs';
 import moment from 'moment';
 import 'moment-duration-format'
@@ -301,6 +302,8 @@ export class TextView {
 		vscode.commands.registerCommand('textView.analyzerCurrent', () => this.analyzerCurrent());
 		vscode.commands.registerCommand('textView.analyze', (textItem) => this.analyze(textItem));
 		vscode.commands.registerCommand('textView.analyzeDir', (textItem) => this.analyzeDir(textItem));
+		vscode.commands.registerCommand('textView.runRegressionItem', (textItem) => this.runRegressionItem(textItem));
+		vscode.commands.registerCommand('textView.blessRegressionItem', (textItem) => this.blessRegressionItem(textItem));
 		vscode.commands.registerCommand('textView.openText', () => this.openText());
 		vscode.commands.registerCommand('textView.search', () => this.search());
 		vscode.commands.registerCommand('textView.fastLoad', () => this.fastLoad(true));
@@ -665,6 +668,44 @@ export class TextView {
 				this.deleteFileLogDir(textItem.uri.fsPath);
 			}
 		}
+	}
+
+	// Run the golden-file regression tester scoped to the clicked line — a single
+	// input file, or every file under a folder in the analyzer's input/ tree.
+	public runRegressionItem(textItem: TextItem): void {
+		const analyzerDir = this.regressionAnalyzerDir(textItem);
+		if (analyzerDir)
+			regressionRunner.test(analyzerDir, textItem.uri);
+	}
+
+	public blessRegressionItem(textItem: TextItem): void {
+		const analyzerDir = this.regressionAnalyzerDir(textItem);
+		if (!analyzerDir) return;
+		// Warn only when goldens already exist for this file/folder.
+		if (!regressionRunner.goldensExist(analyzerDir, textItem.uri)) {
+			regressionRunner.bless(analyzerDir, textItem.uri);
+			return;
+		}
+		const itemName = path.basename(textItem.uri.fsPath);
+		vscode.window.showWarningMessage(
+			`Bless will OVERWRITE the existing regression goldens for '${itemName}' with the analyzer's CURRENT output. Continue?`,
+			{ modal: true }, 'Bless'
+		).then(choice => {
+			if (choice === 'Bless')
+				regressionRunner.bless(analyzerDir, textItem.uri);
+		});
+	}
+
+	private regressionAnalyzerDir(textItem: TextItem): vscode.Uri | undefined {
+		if (!textItem || !textItem.uri || !fs.existsSync(textItem.uri.fsPath)) {
+			vscode.window.showWarningMessage('Select an input file or folder to run a regression test.');
+			return undefined;
+		}
+		if (!visualText.analyzer.isLoaded()) {
+			vscode.window.showWarningMessage('No analyzer loaded. Open an analyzer first.');
+			return undefined;
+		}
+		return visualText.analyzer.getAnalyzerDirectory();
 	}
 
 	public deleteFileLogs(textItem: TextItem): void {


### PR DESCRIPTION
## Summary

Two features for **3.2.0**: an in-extension **Help system** and a **built-in regression-test runner**, plus log-view quality-of-life.

Pairs with **VisualText/visualtext-files#175**, which adds the help markdown content (`Help/markdown/vscode/`). The extension reads help from the installed engine dir, so that content needs to ship in a `visualtext.zip` release for the help pages / version notes to appear for end users.

## Help system

- **Help view** in the NLP++ sidebar + a 📖 **book button** on the Text/Analyzer/KB toolbars → opens `home.md`.
- Tree lists Quick Start, Compiling, Regression Testing, Lazy Loading, an **NLP++** reference node (String/Node/KB/Math/Array functions, Variables, …), and a dynamic **Version Notes** node.
- **First-run / new-version auto-show** (`checkVersionNotes`, `globalState`): first install opens the hub; an upgrade opens the newest unseen `versions/<ver>.md`.
- **Create Claude Prompt to Build an Analyzer** (Help view + Analyzers toolbar): opens a new editor with a generated prompt embedding this machine's engine, example/template-analyzer, and library (`languages`/`misc`) paths.

## Built-in regression runner

- **regression.ts** — native TS port of `nlp_regress.py --cli`: runs `nlp.exe` per input, semantically compares `output.json` to `test/expected/` goldens (ignores `id`, order-insensitive), streams **PASS/FAIL/MISSING** into the **Logging** view. No terminal, no Python dependency.
- Scopes to a single **file** or **folder**: a 🧪 test icon + Run/Bless context items on each Text-view line.
- `analyzer.regressionTerminal` (default `false`) falls back to the old `nlp_regress.py` terminal path.
- Bless warns about overwriting only when goldens already exist.

## Logging

- The Logging view **auto-scrolls** to the newest line (added `getParent` + `reveal`), and a regression run **clears the log** first.

## Notes

- `dist/` excluded per repo convention; `package-lock.json` change is the version bump only.
- The native runner and the `nlp_regress.py` script share the same comparison semantics; if both are kept long-term, one should be canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)