### PR TITLE
chore: bump version to 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.3
+Toolbar cleanup: moved the **Video** and **Create Claude Prompt** actions (Analyzers view) and **Video** (Output view) from the title bar into the `...` overflow. The Run Regression Test button stays on the Analyzers toolbar.
+
 ### 3.2.2
 Help announcements, an LLM prompt library, and polish.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
## Summary

Version bump to **3.2.3**. This is the bump that should have ridden with #1046 (the toolbar-overflow change) but was added after that PR merged — so master is currently 3.2.2 with the menu change but no bump. This lands it.

- `package.json` + `package-lock.json` → **3.2.3** (version-only change).
- CHANGELOG 3.2.3 entry (the Video / Create Claude Prompt → `...` overflow cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)