### PR TITLE
feat: analyze timing + keep log on completion + run-mode order (3.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.4
+Analyze logging and run-mode improvements.
+
+- The Logging view now shows the **total analyze time** — "Done analyzing … (2.34 sec)".
+- The log **no longer clears when an analysis completes**, so the "Analyzing…" line, the engine output, and the timing all stay visible. A directory analyze now shows every file's result instead of only the last.
+- The status-bar run-mode toggle now cycles **Interpreted → Compiled → Compiled KB → Compiled Analyzer**.
+
 ### 3.2.3
 Toolbar cleanup: moved the **Video** and **Create Claude Prompt** actions (Analyzers view) and **Video** (Output view) from the title bar into the `...` overflow. The Run Regression Test button stays on the Analyzers toolbar.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.3",
+    "version": "3.2.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.3",
+            "version": "3.2.4",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.3",
+    "version": "3.2.4",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/logView.ts
+++ b/src/logView.ts
@@ -147,8 +147,9 @@ export class LogView {
 		visualText.displayHelpFile('Updater Help', 'UPDATERHELP.html');
 	}
 
-	public loadAnalyzerOuts() {
-		this.clearLogs();
+	public loadAnalyzerOuts(clear: boolean = true) {
+		if (clear)
+			this.clearLogs();
 		const outputDir = path.join(visualText.getCurrentAnalyzer().fsPath, "output");
 		const outFile = vscode.Uri.file(path.join(outputDir, 'stdout.log'));
 		const errFile = vscode.Uri.file(path.join(outputDir, 'stderr.log'));

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -90,6 +90,7 @@ export class NLPFile extends TextFile {
 
 			const filename = path.basename(filepath.fsPath);
 			const typeStr = dirfuncs.isDir(filepath.fsPath) ? 'directory' : 'file';
+			const analyzeStart = Date.now();
 			logView.addMessage('Analyzing ' + typeStr + ': ' + filename, logLineType.ANALYER_OUTPUT, filepath);
 			vscode.commands.executeCommand('logView.refreshAll');
 			outputView.setType(outputFileType.ALL);
@@ -146,15 +147,16 @@ export class NLPFile extends TextFile {
 						if (syntaxError)
 							logView.loadMakeAna();
 						else if (!logView.makeAna())
-							logView.loadAnalyzerOuts();
+							logView.loadAnalyzerOuts(false);
 
 						vscode.commands.executeCommand('outputView.refreshAll');
 						vscode.commands.executeCommand('logView.refreshAll');
 						resolve('Failed');
 					} else {
-						logView.loadAnalyzerOuts();
+						logView.loadAnalyzerOuts(false);
 						const typeStr = dirfuncs.isDir(filestr) ? 'directory' : 'file';
-						logView.addMessage('Done analyzing ' + typeStr + ': ' + filename, logLineType.ANALYER_OUTPUT, vscode.Uri.file(filestr));
+						const secs = ((Date.now() - analyzeStart) / 1000).toFixed(2);
+						logView.addMessage('Done analyzing ' + typeStr + ': ' + filename + '  (' + secs + ' sec)', logLineType.ANALYER_OUTPUT, vscode.Uri.file(filestr));
 						visualText.analyzer.saveCurrentFile(filepath);
 						vscode.commands.executeCommand('textView.refreshAll');
 						vscode.commands.executeCommand('outputView.refreshAll');

--- a/src/status.ts
+++ b/src/status.ts
@@ -244,8 +244,8 @@ export class NLPStatusBar {
     }
 
     toggleRunMode() {
-        // Cycle freely through all four modes: INTERPRETED -> COMPILED_KB ->
-        // COMPILED_ANALYZER -> COMPILED -> INTERPRETED. The toggle deliberately
+        // Cycle freely through all four modes: INTERPRETED -> COMPILED ->
+        // COMPILED_KB -> COMPILED_ANALYZER -> INTERPRETED. The toggle deliberately
         // does NOT gate on whether a compiled lib exists.
         //
         // It used to skip compiled modes whose lib it couldn't find via
@@ -268,9 +268,9 @@ export class NLPStatusBar {
 
     private nextRunMode(mode: RunMode): RunMode {
         switch (mode) {
-            case RunMode.INTERPRETED:       return RunMode.COMPILED_KB;
+            case RunMode.INTERPRETED:       return RunMode.COMPILED;
+            case RunMode.COMPILED:          return RunMode.COMPILED_KB;
             case RunMode.COMPILED_KB:       return RunMode.COMPILED_ANALYZER;
-            case RunMode.COMPILED_ANALYZER: return RunMode.COMPILED;
             default:                        return RunMode.INTERPRETED;
         }
     }


### PR DESCRIPTION
## Summary

Analyze-logging and run-mode improvements for **3.2.4**.

## Changes

- **Total analyze time** — the Logging view now ends a run with `Done analyzing … (2.34 sec)` (captured in the extension between the "Analyzing…" message and completion).
- **Log no longer clears on completion** — `loadAnalyzerOuts` gained a `clear` flag; the analyze flow calls it with `false`, so the "Analyzing…" line, the engine output, and the timing all stay visible. The log is still cleared at the *start* of a run, and a **directory** analyze now shows every file's result instead of only the last.
- **Run-mode toggle order** — the status-bar toggle now cycles **Interpreted → Compiled → Compiled KB → Compiled Analyzer** (was Interpreted → Compiled KB → Compiled Analyzer → Compiled).
- Bump to **3.2.4**.

## Not included (needs the engine)

A **KB read time** in the final output was requested too, but "Loaded knowledge base" is printed by `nlp.exe`, not the extension — the extension only displays engine output and can't time the KB-load slice of a single run. Adding it requires an nlp-engine change (e.g. `Loaded knowledge base (0.42 sec)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)