### PR TITLE
feat(help): hover descriptions for LLM Prompts tree (3.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.5
+LLM Prompts help tree: hover descriptions.
+
+- Prompt entries in the **LLM Prompts** help tree now show a longer **hover tooltip** describing what each prompt does, read from an optional `<!-- desc: ... -->` line in the prompt file.
+- The description marker is stripped when a prompt is opened, so it never appears in the text you paste into the LLM.
+
 ### 3.2.4
 Analyze logging and run-mode improvements.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.4",
+            "version": "3.2.5",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -219,7 +219,7 @@
             },
             {
                 "command": "textView.fastLoadOff",
-                "title": "\u2713 Fast Load (ON)",
+                "title": "✓ Fast Load (ON)",
                 "icon": {
                     "light": "resources/light/test.svg",
                     "dark": "resources/dark/test.svg"
@@ -3246,7 +3246,10 @@
                 },
                 "compile.mode": {
                     "type": "string",
-                    "enum": ["local", "cloud"],
+                    "enum": [
+                        "local",
+                        "cloud"
+                    ],
                     "scope": "application",
                     "default": "local",
                     "description": "Where to compile generated C++. 'local' uses CMake on this machine; 'cloud' uploads to compile.dispatcherUrl."

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -18,6 +18,7 @@ export interface HelpItem {
     children?: HelpItem[];
     cmd?: string;        // run this command instead of opening a markdown page
     promptFile?: string; // an LLM-prompt file under prompts/ to fill + open
+    tooltip?: string;    // hover text (markdown) — e.g. an LLM prompt's description
 }
 
 export class HelpTreeDataProvider implements vscode.TreeDataProvider<HelpItem> {
@@ -31,6 +32,7 @@ export class HelpTreeDataProvider implements vscode.TreeDataProvider<HelpItem> {
             : vscode.TreeItemCollapsibleState.None;
         const ti = new vscode.TreeItem(item.label, collapse);
         ti.iconPath = new vscode.ThemeIcon(item.icon);
+        if (item.tooltip) ti.tooltip = new vscode.MarkdownString(item.tooltip);
         // Items can run a command, open an LLM prompt, or open a markdown page;
         // parent nodes just expand.
         if (item.cmd) {
@@ -82,7 +84,7 @@ export class HelpTreeDataProvider implements vscode.TreeDataProvider<HelpItem> {
         }
         if (item.isPromptRoot) {
             return helpView.listPrompts().map(p => (
-                { label: p.title, page: '', icon: 'sparkle', promptFile: p.file } as HelpItem));
+                { label: p.title, page: '', icon: 'sparkle', promptFile: p.file, tooltip: p.description || p.title } as HelpItem));
         }
         if (item.children) {
             return item.children;
@@ -244,16 +246,19 @@ export class HelpView {
     }
 
     // Prompt files: prompts/<file>.md whose FIRST line is the title (shown in the
-    // Help tree) and the rest is the prompt body. Returns them sorted by file name.
-    listPrompts(): { file: string; title: string }[] {
+    // Help tree). An optional `<!-- desc: ... -->` marker gives the hover tooltip.
+    // The rest is the prompt body. Returns them sorted by file name.
+    listPrompts(): { file: string; title: string; description?: string }[] {
         const dir = this.promptsDir();
         if (!fs.existsSync(dir)) return [];
         return fs.readdirSync(dir)
             .filter(f => f.toLowerCase().endsWith('.md'))
             .sort()
             .map(f => {
-                const first = (fs.readFileSync(path.join(dir, f), 'utf8').split(/\r?\n/)[0] || '').replace(/^#+\s*/, '').trim();
-                return { file: f, title: first || f.replace(/\.md$/i, '') };
+                const raw = fs.readFileSync(path.join(dir, f), 'utf8');
+                const first = (raw.split(/\r?\n/)[0] || '').replace(/^#+\s*/, '').trim();
+                const m = raw.match(/<!--\s*desc:\s*([\s\S]*?)-->/i);
+                return { file: f, title: first || f.replace(/\.md$/i, ''), description: m ? m[1].trim() : undefined };
             });
     }
 
@@ -267,7 +272,8 @@ export class HelpView {
         }
         const raw = fs.readFileSync(full, 'utf8');
         const nl = raw.indexOf('\n');
-        const body = nl >= 0 ? raw.slice(nl + 1) : '';
+        let body = nl >= 0 ? raw.slice(nl + 1) : '';
+        body = body.replace(/<!--\s*desc:[\s\S]*?-->\s*/i, ''); // drop the tooltip marker
         const content = this.fillPromptVariables(body).replace(/^\s+/, '');
         const doc = await vscode.workspace.openTextDocument({ content, language: 'markdown' });
         await vscode.window.showTextDocument(doc);


### PR DESCRIPTION
## What

Adds longer **hover tooltips** to the entries under **LLM Prompts** in the Help tree.

- `listPrompts()` now reads an optional `<!-- desc: ... -->` marker from each prompt file and returns it as a `description`.
- `getTreeItem()` renders that description as the item's `tooltip` (a `MarkdownString`).
- `openPromptByFile()` strips the marker so it never appears in the prompt text opened for pasting into the LLM.

Previously hovering a prompt showed only its title.

## Version

Bumps the extension **3.2.4 → 3.2.5** (package.json, package-lock.json, CHANGELOG.md).

## Companion PR

The `desc:` lines that populate these tooltips live in the prompt content — **visualtext/visualtext-files#178**. This PR is code-only and degrades gracefully: with no `desc` marker the tooltip falls back to the title.

## Build note

Source-only change. `dist/` is regenerated by `npm run package` (`webpack-prod`) at publish time, so it is intentionally not rebuilt here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)