### PR TITLE
feat: analyze timing summary + engine-updater loop fix (3.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.6
+Analyze log: clean timing summary with its own log file.
+
+- The Logging view now shows a **concise, fully-additive timing breakdown** for each analyze — Setup, Engine startup + load, Loaded knowledge base, Exec analyzer time, Post-processing — and the segments **sum exactly to the total** shown on the "Done analyzing …" line.
+- The verbose `stdout`/`stderr` dump (command args, paths, `-DEV` output) no longer floods the log on every run. It is still available on demand from the **Display Analyzer Output Files** toolbar button (log icon).
+- The summary is written to its own **`analyze.log`** file and can be reloaded any time with the new **Display Analyze Summary** toolbar button (document icon).
+- The log now **clears at the start** of each analyze, so every run shows a fresh, self-contained summary (and never clears mid-run).
+
 ### 3.2.5
 LLM Prompts help tree: hover descriptions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.5",
+    "version": "3.2.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.5",
+            "version": "3.2.6",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.6",
+    "version": "3.2.7",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.5",
+    "version": "3.2.6",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -1634,6 +1634,14 @@
                 }
             },
             {
+                "command": "logView.analyzeSummary",
+                "title": "Display Analyze Summary",
+                "icon": {
+                    "light": "resources/light/document.svg",
+                    "dark": "resources/dark/document.svg"
+                }
+            },
+            {
                 "command": "logView.updateDebug",
                 "title": "Toggle Update Trace",
                 "icon": {
@@ -2241,29 +2249,34 @@
                     "group": "navigation@2"
                 },
                 {
-                    "command": "logView.analyzerOuts",
+                    "command": "logView.analyzeSummary",
                     "when": "view == logView",
                     "group": "navigation@3"
                 },
                 {
-                    "command": "logView.makeAna",
+                    "command": "logView.analyzerOuts",
                     "when": "view == logView",
                     "group": "navigation@4"
                 },
                 {
-                    "command": "logView.conceptualGrammar",
+                    "command": "logView.makeAna",
                     "when": "view == logView",
                     "group": "navigation@5"
                 },
                 {
-                    "command": "logView.timing",
+                    "command": "logView.conceptualGrammar",
                     "when": "view == logView",
                     "group": "navigation@6"
                 },
                 {
-                    "command": "logView.clear",
+                    "command": "logView.timing",
                     "when": "view == logView",
                     "group": "navigation@7"
+                },
+                {
+                    "command": "logView.clear",
+                    "when": "view == logView",
+                    "group": "navigation@8"
                 },
                 {
                     "command": "logView.updateDebug",

--- a/src/logView.ts
+++ b/src/logView.ts
@@ -86,6 +86,7 @@ export class LogView {
 		vscode.commands.registerCommand('logView.checkUpdates', () => this.checkUpdates());
 		vscode.commands.registerCommand('logView.updateDebug', () => this.updateDebug());
 		vscode.commands.registerCommand('logView.analyzerOuts', () => this.loadAnalyzerOuts());
+		vscode.commands.registerCommand('logView.analyzeSummary', () => this.loadAnalyzeSummary());
 		vscode.commands.registerCommand('logView.enginePath', () => this.enginePath());
 
 		this.exists = false;
@@ -154,9 +155,14 @@ export class LogView {
 		const outFile = vscode.Uri.file(path.join(outputDir, 'stdout.log'));
 		const errFile = vscode.Uri.file(path.join(outputDir, 'stderr.log'));
 		this.addMessage('STD OUT FILE: ' + errFile.fsPath, logLineType.ANALYER_OUTPUT, errFile);
-		this.addLogFile(outFile, logLineType.ANALYER_OUTPUT, '   ');
+		this.addLogFile(outFile, logLineType.ANALYER_OUTPUT, '   ', false, !clear);
 		this.addMessage('ERROR FILE: ' + errFile.fsPath, logLineType.ANALYER_OUTPUT, errFile);
-		this.addLogFile(errFile, logLineType.ANALYER_OUTPUT, '   ');
+		this.addLogFile(errFile, logLineType.ANALYER_OUTPUT, '   ', false, !clear);
+	}
+
+	public loadAnalyzeSummary() {
+		this.clearLogs();
+		this.addLogFile(visualText.analyzer.getOutputDirectory('analyze.log'), logLineType.LOGFILE, '', false, true);
 	}
 
 	private loadTimingLog() {
@@ -170,17 +176,18 @@ export class LogView {
 		this.addLogFile(visualText.analyzer.treeFile('cgerr'), logLineType.LOGFILE);
 	}
 
-	public makeAna(): boolean {
-		this.clearLogs();
+	public makeAna(clear: boolean = true): boolean {
+		if (clear)
+			this.clearLogs();
 		let errFlag = false
 		if (logView.syntaxErrorsLog('cgerr'))
-			errFlag = logView.addLogFile(visualText.analyzer.treeFile('cgerr'), logLineType.LOGFILE, '', true);
-		return errFlag || this.loadMakeAna();
+			errFlag = logView.addLogFile(visualText.analyzer.treeFile('cgerr'), logLineType.LOGFILE, '', true, !clear);
+		return errFlag || this.loadMakeAna(clear);
 	}
 
-	public loadMakeAna(): boolean {
+	public loadMakeAna(clear: boolean = true): boolean {
 		const errorLog = visualText.analyzer.getOutputDirectory('err.log');
-		const errFlag = this.addLogFile(errorLog, logLineType.LOGFILE);
+		const errFlag = this.addLogFile(errorLog, logLineType.LOGFILE, '', false, !clear);
 		const makeFlag = this.addLogFile(visualText.analyzer.treeFile('make_ana'), logLineType.LOGFILE, '', true, true);
 		return errFlag || makeFlag;
 	}

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -91,6 +91,7 @@ export class NLPFile extends TextFile {
 			const filename = path.basename(filepath.fsPath);
 			const typeStr = dirfuncs.isDir(filepath.fsPath) ? 'directory' : 'file';
 			const analyzeStart = Date.now();
+			logView.clearLogs();
 			logView.addMessage('Analyzing ' + typeStr + ': ' + filename, logLineType.ANALYER_OUTPUT, filepath);
 			vscode.commands.executeCommand('logView.refreshAll');
 			outputView.setType(outputFileType.ALL);
@@ -128,7 +129,9 @@ export class NLPFile extends TextFile {
 
 			return new Promise(resolve => {
 				nlpStatusBar.analyzerButton(false);
+				const execStart = Date.now();
 				visualText.processID = cp.execFile(exe, args, (err, stdout, stderr) => {
+					const procWall = Date.now() - execStart;
 					const outputDir = path.join(visualText.getCurrentAnalyzer().fsPath, "output");
 					const outFile = vscode.Uri.file(path.join(outputDir, 'stdout.log'));
 					const errFile = vscode.Uri.file(path.join(outputDir, 'stderr.log'));
@@ -145,24 +148,57 @@ export class NLPFile extends TextFile {
 						visualText.nlp.setAnalyzerStatus(filepath, analyzerStatus.FAILED);
 						nlpStatusBar.resetAnalyzerButton();
 						if (syntaxError)
-							logView.loadMakeAna();
-						else if (!logView.makeAna())
+							logView.loadMakeAna(false);
+						else if (!logView.makeAna(false))
 							logView.loadAnalyzerOuts(false);
 
 						vscode.commands.executeCommand('outputView.refreshAll');
 						vscode.commands.executeCommand('logView.refreshAll');
 						resolve('Failed');
 					} else {
-						logView.loadAnalyzerOuts(false);
-						const typeStr = dirfuncs.isDir(filestr) ? 'directory' : 'file';
-						const secs = ((Date.now() - analyzeStart) / 1000).toFixed(2);
-						logView.addMessage('Done analyzing ' + typeStr + ': ' + filename + '  (' + secs + ' sec)', logLineType.ANALYER_OUTPUT, vscode.Uri.file(filestr));
+						const engineOut = (stdout || '') + '\n' + (stderr || '');
+						// Flat, additive timing breakdown. Every segment is disjoint, so the
+						// segments sum exactly to the total wall-clock time.
+						const round2 = (n: number) => Math.round(n * 100) / 100;
+						const totalRaw = (Date.now() - analyzeStart) / 1000;
+						const setupRaw = (execStart - analyzeStart) / 1000;   // saveAll, empty dirs, staging DLLs
+						const procRaw = procWall / 1000;                      // whole nlp.exe process
+						const postRaw = totalRaw - setupRaw - procRaw;        // parsing, writes, view refreshes
+						// Engine's own sub-timings (measured inside nlp.exe, nested in procRaw).
+						const kbMatch = engineOut.match(/Loaded knowledge base:\s*([0-9.]+)/);
+						const execMatch = engineOut.match(/Exec analyzer time\s*=\s*([0-9.]+)/);
+						const kbSec = kbMatch ? parseFloat(kbMatch[1]) : 0;
+						const execSec = execMatch ? parseFloat(execMatch[1]) : 0;
+						const rTotal = round2(totalRaw);
+						const rSetup = round2(setupRaw);
+						const rKb = round2(kbSec);
+						const rExec = round2(execSec);
+						const rPost = round2(postRaw);
+						// Everything left in the process that isn't KB load or the analyze loop:
+						// process startup, grammar/sequence/DLL loading, shutdown. Also absorbs rounding.
+						const rEngine = round2(rTotal - rSetup - rKb - rExec - rPost);
+						const secs = rTotal.toFixed(2);
+						const summary: string[] = ['Analyzing ' + typeStr + ': ' + filename];
+						summary.push('Setup (extension): ' + rSetup.toFixed(2) + ' sec');
+						summary.push('Engine startup + load: ' + rEngine.toFixed(2) + ' sec');
+						if (kbMatch)
+							summary.push('Loaded knowledge base: ' + rKb.toFixed(2) + ' sec');
+						if (execMatch)
+							summary.push('Exec analyzer time: ' + rExec.toFixed(2) + ' sec');
+						summary.push('Post-processing (extension): ' + rPost.toFixed(2) + ' sec');
+						summary.push('Done analyzing ' + typeStr + ': ' + filename + '  (' + secs + ' sec)');
+						// Persist the concise timing summary to its own log file (retrievable via the toolbar).
+						dirfuncs.writeFile(visualText.analyzer.getOutputDirectory('analyze.log').fsPath, summary.join('\n') + '\n');
+						// The "Analyzing" line is already live in the log; show the rest.
+						for (const line of summary.slice(1))
+							logView.addMessage(line, logLineType.ANALYER_OUTPUT, vscode.Uri.file(filestr));
 						visualText.analyzer.saveCurrentFile(filepath);
 						vscode.commands.executeCommand('textView.refreshAll');
 						vscode.commands.executeCommand('outputView.refreshAll');
 						vscode.commands.executeCommand('sequenceView.refreshAll');
 						vscode.commands.executeCommand('analyzerView.refreshAll');
 						vscode.commands.executeCommand('kbView.refreshAll');
+						vscode.commands.executeCommand('logView.refreshAll');
 						visualText.nlp.setAnalyzerStatus(filepath, analyzerStatus.DONE);
 						nlpStatusBar.resetAnalyzerButton();
 						resolve('Processed');

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -663,8 +663,18 @@ export class VisualText {
                             if (visualText.versionCompare(repoVersion, exeVersion) > 0) {
                                 newer = true;
                             }
-                        } else {
+                        } else if (!fs.existsSync(op.local)) {
+                            // No engine installed yet -> download it. (A present
+                            // exe is handled by the branches above/below.)
                             newer = true;
+                        } else {
+                            // Exe is present but its version couldn't be read (or
+                            // the repo version is unknown). Do NOT assume "newer":
+                            // that re-downloaded the engine on every startup when
+                            // `nlp.exe --version` returned empty (e.g. a transient
+                            // spawn/ICU hiccup), producing an endless update loop.
+                            if (visualText.debug)
+                                visualText.debugMessage('Skipping engine update: version undetermined (exe=[' + exeVersion + '] repo=[' + repoVersion + '])', logLineType.UPDATER);
                         }
                         op.status = upStat.DONE;
                     }
@@ -1047,25 +1057,38 @@ export class VisualText {
         dirfuncs.changeMod(op.local, 755);
         visualText.exeEngineVersion = '';
         const cp = require('child_process');
-        return new Promise((resolve, reject) => {
-            const child = cp.spawn(op.local, ['--version']);
-            const stdOut = "";
-            const stdErr = "";
-            child.stdout.on("data", (data) => {
-                const versionStr = data.toString();
-                if (debug) visualText.debugMessage('version str: ' + versionStr, logLineType.UPDATER);
-                const tokens = versionStr.split('\r\n');
-                if (tokens.length) {
-                    if (tokens.length == 1)
-                        visualText.exeEngineVersion = versionStr;
-                    else
-                        visualText.exeEngineVersion = tokens[tokens.length - 2];
-                    if (debug) visualText.debugMessage('version found: ' + visualText.exeEngineVersion, logLineType.UPDATER);
-                }
+        return new Promise((resolve) => {
+            let stdout = '';
+            let settled = false;
+            // Resolve exactly once, from the FULL accumulated output. Resolving on
+            // the first stdout chunk (or never, on spawn failure) is what left
+            // exeEngineVersion empty and drove the perpetual re-download loop.
+            const finish = () => {
+                if (settled) return;
+                settled = true;
+                // `nlp.exe --version` prints just the version; take the last
+                // non-empty line and strip CR/LF/whitespace either way.
+                const lines = stdout.split(/\r?\n/).map(s => s.trim()).filter(s => s.length);
+                visualText.exeEngineVersion = lines.length ? lines[lines.length - 1] : '';
+                if (debug) visualText.debugMessage('version found: [' + visualText.exeEngineVersion + ']', logLineType.UPDATER);
                 resolve(visualText.exeEngineVersion);
+            };
+            let child;
+            try {
+                child = cp.spawn(op.local, ['--version']);
+            } catch (err) {
+                visualText.debugMessage('fetchExeVersion spawn threw: ' + err, logLineType.UPDATER);
+                finish();
+                return;
+            }
+            child.stdout.on('data', (data) => { stdout += data.toString(); });
+            // --version exits non-zero by design, so key off 'close', not the exit
+            // code. 'error' fires if the exe can't be spawned at all.
+            child.on('close', () => finish());
+            child.on('error', (err) => {
+                visualText.debugMessage('fetchExeVersion spawn error: ' + err, logLineType.UPDATER);
+                finish();
             });
-        }).catch(err => {
-            visualText.debugMessage(err, logLineType.UPDATER);
         });
     }
 


### PR DESCRIPTION
## Summary

Cleans up the analyze Logging output (3.2.6). Previously the log dumped the full `-DEV` `stdout`/`stderr` (command args, paths — ~25 noisy lines) on every run and cleared unpredictably mid-run. Now each analyze shows a concise timing summary and keeps the raw output on demand.

## Changes

- **Concise, fully-additive timing breakdown** per analyze — `Setup`, `Engine startup + load`, `Loaded knowledge base`, `Exec analyzer time`, `Post-processing` — the segments **sum exactly** to the total on the `Done analyzing …` line (an earlier version mixed nested/overlapping numbers that didn't add up).
- **No more raw dump on every run.** The full `stdout`/`stderr` is still one click away via the existing **Display Analyzer Output Files** button (log icon).
- **New `analyze.log`** file written by the extension, reloadable via a new **Display Analyze Summary** toolbar button (document icon).
- **Clears at the start** of each analyze, so every run is fresh and self-contained; never clears mid-run.

## Files

- `src/nlp.ts` — build summary, extract engine timings, write `analyze.log`, additive breakdown, clear-on-start.
- `src/logView.ts` — `loadAnalyzeSummary()` + command; thread a no-clear flag so the analyze flow never clears mid-run.
- `package.json` — new `logView.analyzeSummary` command/icon/menu; version 3.2.6.
- `CHANGELOG.md` — 3.2.6 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
