### PR TITLE
feat: Knowledge Base template default + analyzer load timing (3.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.8
+Knowledge Base template default + analyzer load timing.
+
+- The **New Analyzer** template picker now floats the **Knowledge Base** template to the **top of the list**, shows it **pre-checked**, and labels it **(Recommended)** — so it is the default choice.
+- The analyze timing summary now reports **analyzer load time** — `Loaded analyzer:` (interpreted) or `Loaded compiled analyzer:` (compiled) — from the new engine output. This surfaces what was previously the largest unaccounted chunk of the total (building/loading the analyzer), and the breakdown still sums exactly to the total.
+
 ### 3.2.6
 Analyze log: clean timing summary with its own log file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.6",
+    "version": "3.2.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.6",
+            "version": "3.2.8",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.7",
+    "version": "3.2.8",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -152,7 +152,15 @@ export class Analyzer {
                         const readme = path.join(file.fsPath, "README.MD");
                         let descr: string, tit: string;
                         ({ title: tit, description: descr } = this.readDescription(readme));
-                        items.push({ label: tit, description: descr });
+                        const item: vscode.QuickPickItem = { label: tit, description: descr };
+                        if (basename === "Knowledge Base") {
+                            // Default choice: pre-check the Knowledge Base template and float it to the top.
+                            item.picked = true;
+                            item.description = descr && descr.length ? "(Recommended) " + descr : "(Recommended)";
+                            items.unshift(item);
+                        } else {
+                            items.push(item);
+                        }
                         dirMap[tit] = basename;
                     }
                 }

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -165,24 +165,31 @@ export class NLPFile extends TextFile {
 						const procRaw = procWall / 1000;                      // whole nlp.exe process
 						const postRaw = totalRaw - setupRaw - procRaw;        // parsing, writes, view refreshes
 						// Engine's own sub-timings (measured inside nlp.exe, nested in procRaw).
+						// The engine reports: KB load, analyzer load (compiled or interpreted),
+						// and the analyze loop itself.
 						const kbMatch = engineOut.match(/Loaded knowledge base:\s*([0-9.]+)/);
+						const anaMatch = engineOut.match(/Loaded (compiled analyzer|analyzer):\s*([0-9.]+)/);
 						const execMatch = engineOut.match(/Exec analyzer time\s*=\s*([0-9.]+)/);
 						const kbSec = kbMatch ? parseFloat(kbMatch[1]) : 0;
+						const anaSec = anaMatch ? parseFloat(anaMatch[2]) : 0;
 						const execSec = execMatch ? parseFloat(execMatch[1]) : 0;
 						const rTotal = round2(totalRaw);
 						const rSetup = round2(setupRaw);
 						const rKb = round2(kbSec);
+						const rAna = round2(anaSec);
 						const rExec = round2(execSec);
 						const rPost = round2(postRaw);
-						// Everything left in the process that isn't KB load or the analyze loop:
-						// process startup, grammar/sequence/DLL loading, shutdown. Also absorbs rounding.
-						const rEngine = round2(rTotal - rSetup - rKb - rExec - rPost);
+						// Process startup/shutdown left over after KB load, analyzer load, and the
+						// analyze loop. Also absorbs rounding so the column sums to the total.
+						const rEngine = round2(rTotal - rSetup - rKb - rAna - rExec - rPost);
 						const secs = rTotal.toFixed(2);
 						const summary: string[] = ['Analyzing ' + typeStr + ': ' + filename];
 						summary.push('Setup (extension): ' + rSetup.toFixed(2) + ' sec');
-						summary.push('Engine startup + load: ' + rEngine.toFixed(2) + ' sec');
+						summary.push('Engine startup: ' + rEngine.toFixed(2) + ' sec');
 						if (kbMatch)
 							summary.push('Loaded knowledge base: ' + rKb.toFixed(2) + ' sec');
+						if (anaMatch)
+							summary.push('Loaded ' + anaMatch[1] + ': ' + rAna.toFixed(2) + ' sec');
 						if (execMatch)
 							summary.push('Exec analyzer time: ' + rExec.toFixed(2) + ' sec');
 						summary.push('Post-processing (extension): ' + rPost.toFixed(2) + ' sec');


### PR DESCRIPTION
## Summary

Two analyzer-UX improvements (3.2.8), building on the analyze-timing work in #1050.

### Knowledge Base template is now the default
When creating a **New Analyzer**, the **Knowledge Base** template:
- appears at the **top** of the template picker,
- is **pre-checked**, and
- is labeled **(Recommended)** in its description.

So the common case is now a single Enter press.

### Analyzer load time in the timing summary
The engine (nlp.exe 3.6.4+) now reports analyzer load time. The analyze summary parses and shows it:
- `Loaded analyzer: … sec` (interpreted) or `Loaded compiled analyzer: … sec` (compiled).

This surfaces what was previously the **largest unaccounted chunk** of the total — building/loading the analyzer (huge for interpreted, small for compiled) — and the breakdown still **sums exactly to the total**. Degrades gracefully on older engines (the line is simply omitted).

## Files
- `src/analyzer.ts` — pre-check + float Knowledge Base template to top with (Recommended) label.
- `src/nlp.ts` — parse `[Loaded (compiled )?analyzer: … sec]` and add it to the additive breakdown.
- `package.json` / `package-lock.json` — version 3.2.8.
- `CHANGELOG.md` — 3.2.8 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
