### PR TITLE
fix: open LLM Prompts in a rendered preview (3.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.9
+LLM Prompts open in a rendered preview.
+
+- Clicking a prompt under **LLM Prompts** in the Help tree now opens a **rendered markdown preview** (with `{{variables}}` filled in), consistent with the other help items, instead of the raw markdown editor.
+- The raw copy-paste path is unchanged: the **Create Claude Prompt** toolbar button still opens the editable prompt text ready to paste into an LLM.
+
 ### 3.2.8
 Knowledge Base template default + analyzer load timing.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.8",
+    "version": "3.2.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.8",
+            "version": "3.2.9",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.8",
+    "version": "3.2.9",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -281,7 +281,26 @@ export class HelpView {
 
     openPrompt(item: HelpItem) {
         if (item && item.promptFile)
-            this.openPromptByFile(item.promptFile);
+            this.previewPromptByFile(item.promptFile);
+    }
+
+    // Render a prompt as a markdown preview (consistent with the other help
+    // items). Variables are filled and the tooltip marker dropped; the title
+    // line is kept so it renders as a heading. The processed text is written to
+    // a temp file because markdown.showPreview needs a file URI.
+    async previewPromptByFile(file: string) {
+        const full = path.join(this.promptsDir(), file);
+        if (!fs.existsSync(full)) {
+            vscode.window.showErrorMessage(`Prompt file not found: ${full}`);
+            return;
+        }
+        const raw = fs.readFileSync(full, 'utf8').replace(/<!--\s*desc:[\s\S]*?-->\s*/i, '');
+        const content = this.fillPromptVariables(raw).replace(/^\s+/, '');
+        const tmpDir = path.join(os.tmpdir(), 'visualtext-prompts');
+        if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+        const tmpFile = path.join(tmpDir, file);
+        fs.writeFileSync(tmpFile, content, 'utf8');
+        vscode.commands.executeCommand('markdown.showPreview', vscode.Uri.file(tmpFile));
     }
 
     // The toolbar button / quickstart link: open the first prompt in the library,


### PR DESCRIPTION
## Summary

Clicking a prompt under **LLM Prompts** in the Help tree opened the **raw** markdown file in an editor, unlike every other help item which opens a rendered preview. This makes prompts consistent with the rest of Help (3.2.9).

## Changes

- `openPrompt` (Help tree click) now calls a new `previewPromptByFile`: it fills `{{variables}}`, drops the `<!-- desc -->` tooltip marker, keeps the title line as a heading, writes the processed text to a temp file, and opens it with `markdown.showPreview` — a rendered preview like the other help pages.
- **Raw copy-paste path unchanged:** the *Create Claude Prompt* toolbar button (and the quickstart link) still open the editable prompt text via `openPromptByFile`, since that content is meant to be pasted straight into an LLM.

## Files
- `src/helpView.ts` — new `previewPromptByFile`; `openPrompt` uses it.
- `package.json` / `package-lock.json` — version 3.2.9.
- `CHANGELOG.md` — 3.2.9 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
