### PR TITLE
fix: mod-file race, rename-beside, no duplicate pass (3.2.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.14
+More issue-tracker bug fixes.
+
+- **#898** "Create Mod file when none" now awaits creation before appending, so the mod file is created and selected before the append (previously a race left it not working).
+- **#746** Renaming a text file now opens the renamed file **beside** the current editor.
+- **#807** Inserting an existing pass whose name is already in the sequence no longer adds a duplicate entry — the file is overwritten in place, keeping the existing pass position.
+
 ### 3.2.13
 Issue-tracker bug fixes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.13",
+    "version": "3.2.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.13",
+            "version": "3.2.14",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.13",
+    "version": "3.2.14",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -65,22 +65,24 @@ export class Analyzer {
         }
     }
 
-    async modCreate(uri: vscode.Uri) {
+    async modCreate(uri: vscode.Uri): Promise<boolean> {
+        let created = false;
         await vscode.window.showInputBox({ value: "filename", prompt: "Enter mod file name" }).then(newname => {
             if (newname) {
                 const filepath = path.join(uri.fsPath, newname + ".nlm");
                 if (fs.existsSync(filepath)) {
                     vscode.window.showWarningMessage("Mod file: " + filepath + " already exists");
-                    return false;
+                    return;
                 }
                 const modUri = vscode.Uri.file(filepath);
                 visualText.modFiles.push(modUri);
                 dirfuncs.writeFile(filepath, "# Description goes here");
                 visualText.setModFile(modUri);
                 vscode.commands.executeCommand("kbView.refreshAll");
-                return true;
+                created = true;
             }
         });
+        return created;
     }
 
     hasText(): boolean {

--- a/src/modFile.ts
+++ b/src/modFile.ts
@@ -39,13 +39,13 @@ export class ModFile extends TextFile {
 			items.push({label: 'Create', description: 'Create a new mod file'});
 			items.push({label: 'Abort', description: 'Abort this attempt' });
 
-			await vscode.window.showQuickPick(items, {title: 'Mod File', canPickMany: false, placeHolder: 'Choose create or abort'}).then(selection => {
+			await vscode.window.showQuickPick(items, {title: 'Mod File', canPickMany: false, placeHolder: 'Choose create or abort'}).then(async selection => {
 				if (typeof selection === undefined || !selection || selection.label == 'Abort')
                     retVal = false;
-                else {
-                    visualText.analyzer.modCreate(visualText.analyzer.getKBDirectory());
-                    retVal = true;                    
-                }
+                else
+                    // Await creation so the mod file exists and is selected before addFile
+                    // appends to it (#898). retVal follows whether a file was actually created.
+                    retVal = await visualText.analyzer.modCreate(visualText.analyzer.getKBDirectory());
 			});
         } else {
             const items: vscode.QuickPickItem[] = visualText.modFileList();

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -363,8 +363,14 @@ export class SequenceFile extends TextFile {
 				for (const pass of passes) {
 					const passPath = path.join(specDir,path.basename(pass.fsPath));
 					if (copy) {
-						fs.copyFileSync(pass.fsPath,passPath);								
-					}		
+						fs.copyFileSync(pass.fsPath,passPath);
+					}
+					// If a pass with this name is already in the sequence, the copy above
+					// overwrote its file in place -- keep its existing position/attributes
+					// instead of adding a second entry with the same name (#807).
+					if (this.findPassByFilename(path.basename(pass.fsPath))) {
+						continue;
+					}
 					pi = this.createPassItemFromFile(passPath);
 					row++;
 					this.passItems.splice(row,0,pi);

--- a/src/textView.ts
+++ b/src/textView.ts
@@ -247,7 +247,8 @@ export class FileSystemProvider implements vscode.TreeDataProvider<TextItem> {
 						newname = newname + path.extname(textItem.uri.fsPath);
 					const newfile = vscode.Uri.file(path.join(path.dirname(textItem.uri.fsPath), newname));
 					dirfuncs.rename(original.fsPath, newfile.fsPath);
-					vscode.window.showTextDocument(newfile);
+					// Open the renamed file beside the current editor (#746).
+					vscode.window.showTextDocument(newfile, { viewColumn: vscode.ViewColumn.Beside });
 
 					const logFolderOrig = vscode.Uri.file(path.join(original.fsPath + visualText.LOG_SUFFIX));
 					if (dirfuncs.isDir(logFolderOrig.fsPath)) {


### PR DESCRIPTION
Closes #898, #746, #807

## Summary

Three fixes that were pushed to the #1056 branch **after** it was merged, so they never made it into master. Re-landing them here (3.2.14).

## Fixes

- **#898 — "Create Mod file when none" race.** `getMod` called `async modCreate(...)` without awaiting, so `appendFile` ran before the mod file was created/selected. `modCreate` now returns whether a file was created, and `getMod` awaits it. (`analyzer.ts`, `modFile.ts`)
- **#746 — Open renamed file beside.** Renaming a text file opens it beside the current editor. (`textView.ts`)
- **#807 — Duplicate sequence entry on overwrite.** Inserting an existing pass whose name is already in the sequence overwrites the file in place (via `findPassByFilename`) instead of adding a second same-named entry. (`sequence.ts`)

## Version
3.2.13 → 3.2.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
