### PR TITLE
fix: clear visualText dir before VT-files update (#800, 3.2.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.15
+Fix VisualText files update leaving residual files.
+
+- **#800** Updating the VisualText files now removes the whole `visualText` directory before re-downloading, so stale/residual files no longer survive an update. The previous per-folder delete built a doubled `visualText/visualText/…` path that matched nothing and deleted nothing.
+
 ### 3.2.14
 More issue-tracker bug fixes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.14",
+    "version": "3.2.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.14",
+            "version": "3.2.15",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.14",
+    "version": "3.2.15",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -555,7 +555,17 @@ export class VisualText {
                             visualText.debugMessage('Deleting: ' + op.local, logLineType.UPDATER);
                             fs.unlinkSync(op.local);
                         }
-                        if (op.folders.length) {
+                        if (op.component == upComp.VT_FILES) {
+                            // #800: clear the entire visualText directory before re-downloading
+                            // so no stale/residual files survive. The generic per-folder delete
+                            // below built a doubled "visualText/visualText/..." path that never
+                            // existed, so it deleted nothing and left residual files behind.
+                            const vtDir = path.dirname(op.local);
+                            if (fs.existsSync(vtDir)) {
+                                visualText.debugMessage('Deleting VisualText dir: ' + vtDir, logLineType.UPDATER);
+                                dirfuncs.delDir(vtDir);
+                            }
+                        } else if (op.folders.length) {
                             for (const folder of op.folders) {
                                 const f = path.join(path.dirname(op.local), folder);
                                 if (fs.existsSync(f)) {


### PR DESCRIPTION
Closes #800

## Summary

Updating the VisualText files left residual files behind. Root cause: the updater's DELETE step for `VT_FILES` built a **doubled path**.

`op.folders` entries already carry the `visualText/` prefix (e.g. `visualText/Help`), and the delete then prepends `path.dirname(op.local)` which is *also* `…/visualText`:

```
path.join(dirname(op.local), "visualText/Help")
  = ".../nlp-engine/visualText/visualText/Help"   // doubled, never exists
```

So `fs.existsSync(f)` was always false and **nothing was deleted** — every file from the previous download (including folders not in the named list, like prompts/announcements/versions/misc/languages) survived.

## Fix

For `VT_FILES`, the DELETE now removes the **entire `visualText` directory** (`path.dirname(op.local)`) before the re-download, matching the request in #800 ("remove the visualtext directory before downloading"). The delete already runs before the download (it's unshifted ahead of it in `checkVTFilesVersion`), so the download re-creates the directory from `visualtext.zip`. Other components keep the generic per-folder delete unchanged.

## Testing note

Compiles clean. The end-to-end path (version mismatch → delete → download → unzip) should be validated with a live VT-files update (bump the VisualText files release or force an update) — I can't trigger the real GitHub-release update flow here.

## Version
3.2.14 → 3.2.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
