### PR TITLE
fix: clear-all-logs button + stamp MODIFIED on save (#349, #849, 3.2.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ### 3.2.16
-Fix Text view "clear all logs" button never showing.
+Text view clear-all-logs button + modified date on save.
 
 - **#349** The **clear-all-logs** button in the Text view title bar now appears when the analyzer has log directories. The `text.hasLogs` context that gates it was hardcoded to `false`, so the button (and its command) were never shown even though they existed.
+- **#849** Saving an NLP++ pass file (`.nlp`/`.rec`/`.pat`) now stamps its `# MODIFIED:` header line with the current date and time. Only files that already carry the header (created from the pass template) are touched, and the update is applied atomically with the save (no re-save loop).
 
 ### 3.2.15
 Fix VisualText files update leaving residual files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.16
+Fix Text view "clear all logs" button never showing.
+
+- **#349** The **clear-all-logs** button in the Text view title bar now appears when the analyzer has log directories. The `text.hasLogs` context that gates it was hardcoded to `false`, so the button (and its command) were never shown even though they existed.
+
 ### 3.2.15
 Fix VisualText files update leaving residual files.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.15",
+    "version": "3.2.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.15",
+            "version": "3.2.16",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.15",
+    "version": "3.2.16",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { VisualText } from './visualText';
 import { AnalyzerView } from './analyzerView';
 import { NLPCommands } from "./command";
@@ -30,7 +31,31 @@ export function activate(ctx: vscode.ExtensionContext): void {
     help.showStartupHelp();
 
     vscode.commands.executeCommand('setContext', 'textView.fastload', visualText.getTextFastLoad());
-      
+
+    // #849: stamp the "# MODIFIED:" header line with the current date/time when an
+    // NLP++ pass file is saved. onWillSaveTextDocument + waitUntil applies the edit
+    // atomically with the save, so there is no re-save loop and no on-disk conflict.
+    // Only files that already carry the header line (created from the pass template)
+    // are touched.
+    ctx.subscriptions.push(vscode.workspace.onWillSaveTextDocument(e => {
+        const ext = path.extname(e.document.fileName).toLowerCase();
+        if (ext !== '.nlp' && ext !== '.rec' && ext !== '.pat')
+            return;
+        const now = new Date();
+        const stamp = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() +
+            ' ' + now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds();
+        const newLine = '# MODIFIED: ' + stamp;
+        const max = Math.min(e.document.lineCount, 15);
+        for (let i = 0; i < max; i++) {
+            const line = e.document.lineAt(i);
+            if (/^#\s*MODIFIED:/i.test(line.text)) {
+                if (line.text.trimEnd() !== newLine)
+                    e.waitUntil(Promise.resolve([vscode.TextEdit.replace(line.range, newLine)]));
+                return;
+            }
+        }
+    }));
+
     if (visualText.getAutoUpdate())
         visualText.startUpdater();
     else

--- a/src/textView.ts
+++ b/src/textView.ts
@@ -134,10 +134,15 @@ export class FileSystemProvider implements vscode.TreeDataProvider<TextItem> {
 			}
 		}
 
-		let hasAllLogs = false;
-		if (!visualText.getTextFastLoad())
-			hasAllLogs = dirfuncs.hasLogDirs(dir, true);
-		vscode.commands.executeCommand('setContext', 'text.hasLogs', false);
+		// #349: enable the "clear all logs" title button when the analyzer has any
+		// log directories. Only set the context for the root input dir so expanding a
+		// logless subfolder doesn't hide the button. (Was hardcoded to false.)
+		if (dir.fsPath == visualText.analyzer.getInputDirectory().fsPath) {
+			let hasAllLogs = false;
+			if (!visualText.getTextFastLoad())
+				hasAllLogs = dirfuncs.hasLogDirs(dir, true);
+			vscode.commands.executeCommand('setContext', 'text.hasLogs', hasAllLogs);
+		}
 
 		if (visualText.getTextFastLoad()) {
 			const endTime = moment();


### PR DESCRIPTION
Closes #349, closes #849

## Summary

Two Text view / editor fixes (3.2.16).

## Fixes

- **#349 — Clear-all-logs button never showed.** The Text view's `textView.deleteAnalyzerLogs` title button is gated on the `text.hasLogs` context, but `getKeepers` computed the value into `hasAllLogs` and then called `setContext('text.hasLogs', …)` with a **hardcoded `false`**. Now sets the computed value, and only for the **root input dir** so expanding a logless subfolder doesn't hide the button. (`textView.ts`)
- **#849 — Stamp `# MODIFIED:` on save.** Saving an NLP++ pass file (`.nlp`/`.rec`/`.pat`) updates its `# MODIFIED:` header line with the current date/time. Implemented with `onWillSaveTextDocument` + `waitUntil`, so the edit is atomic with the save (no re-save loop, no on-disk conflict). Only files that already carry the header line (created from the pass template) are touched. (`extension.ts`)

## Version
3.2.15 → 3.2.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
