### PR TITLE
feat: prefix Find results with analyzer pass number (#787, 3.2.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.17
+Find Results: show pass numbers.
+
+- **#787** (partial) Find results in analyzer pass files are now prefixed with the **analyzer-sequence pass number**, so results read in pass order and the multi-pass progression is visible. Non-pass files (function libraries, input text) are unaffected.
+
 ### 3.2.16
 Text view clear-all-logs button + modified date on save.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.16",
+    "version": "3.2.17",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.16",
+            "version": "3.2.17",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.16",
+    "version": "3.2.17",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/findFile.ts
+++ b/src/findFile.ts
@@ -86,6 +86,11 @@ export class FindFile {
 		this.textFile.setFile(uri);
 		const filename = path.basename(uri.fsPath);
 		const escapedLower = escaped.toLowerCase();
+		// #787: when the file is an analyzer pass, prefix its results with the pass
+		// number so find results read in analyzer-sequence (pass) order and the
+		// multi-pass progression is visible. Computed once per file.
+		const passNum = visualText.analyzer.seqFile.findPassByFilename(filename);
+		const passTag = passNum > 0 ? `${passNum}  ` : '';
 
 		if (this.textFile.getText().toLowerCase().search(escapedLower) >= 0) {
 			let num = 0;
@@ -106,8 +111,8 @@ export class FindFile {
 					let text = line;
 					if (bracketsFlag)
 						text = line.replace(searchTerm,` <<${searchTerm}>> `);
-					const label = `${filename} [${num} ${pos}] ${line}`;
-					const newText = `${path.basename(uri.fsPath)} ${text}`;
+					const label = `${passTag}${filename} [${num} ${pos}] ${line}`;
+					const newText = `${passTag}${path.basename(uri.fsPath)} ${text}`;
 					this.finds.push({uri: uri, label: label, line: line, lineNum: num, pos: Number.parseInt(pos), highlighted: newText});
 				}
 				num++;


### PR DESCRIPTION
Advances #787 (does not fully close it)

## Summary

Find results in analyzer **pass files** are now prefixed with their **analyzer-sequence pass number**, so results read in pass order and the multi-pass progression is visible — the "toughest thing" called out in #787.

`searchFile` computes the pass number once per file via `findPassByFilename` and prefixes each match's display line with it when the file is a pass (`passNum > 0`). Non-pass files (function libraries, input text, arbitrary searches) are unaffected — no prefix.

## Scope

This covers the highest-value item in #787 (pass-number labeling / pass-order reading). The remaining #787 asks are **not** included and the issue stays open:
- rule number (`G("$rulenum")`), tab-aware char offset, orphan/inactive markers, and the full `X PASS RULE ELT | LINE,CHAR` format.

## Note on branch

Stacked on the #1059 branch (3.2.16) to keep versions/changelog sequential, so this PR's diff currently includes #1059's commits — it reduces to just the find change once #1059 merges. **Merge #1059 first.**

## Version
3.2.16 → 3.2.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
