### PR TITLE
feat: mark inactive/orphan passes in Find results (#787, 3.2.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.18
+Find Results: mark inactive and orphan passes.
+
+- **#787** (partial) Find results now mark **inactive** passes with `I` and **orphan** pass files (a `.nlp`/`.rec`/`.pat` in `spec/` not referenced by the analyzer sequence) with `O`, alongside the pass number added in 3.2.17. Remaining #787 items (rule number, tab-aware char offset, the full `X PASS RULE ELT | LINE,CHAR` format) are still open.
+
 ### 3.2.17
 Find Results: show pass numbers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.17",
+    "version": "3.2.18",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.17",
+            "version": "3.2.18",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.17",
+    "version": "3.2.18",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/findFile.ts
+++ b/src/findFile.ts
@@ -86,11 +86,19 @@ export class FindFile {
 		this.textFile.setFile(uri);
 		const filename = path.basename(uri.fsPath);
 		const escapedLower = escaped.toLowerCase();
-		// #787: when the file is an analyzer pass, prefix its results with the pass
-		// number so find results read in analyzer-sequence (pass) order and the
-		// multi-pass progression is visible. Computed once per file.
-		const passNum = visualText.analyzer.seqFile.findPassByFilename(filename);
-		const passTag = passNum > 0 ? `${passNum}  ` : '';
+		// #787: prefix results with the analyzer-sequence pass info so they read in
+		// pass order and show the multi-pass progression. The tag is "<mark><passNum>  "
+		// where <mark> is "I " for an inactive (disabled) pass, or "O " for an orphan
+		// pass file (a .nlp/.rec/.pat in spec/ not referenced by the sequence). Non-pass
+		// files (function libraries, input text) get no tag. Computed once per file.
+		const seqFile = visualText.analyzer.seqFile;
+		const passName = path.parse(filename).name;
+		const passItem = seqFile.getPasses().find(p => p.passNum > 0 && p.name == passName);
+		let passTag = '';
+		if (passItem)
+			passTag = (passItem.active ? '' : 'I ') + `${passItem.passNum}  `;
+		else if (path.dirname(uri.fsPath) == seqFile.getSpecDirectory().fsPath && /\.(nlp|rec|pat)$/i.test(filename))
+			passTag = 'O  ';
 
 		if (this.textFile.getText().toLowerCase().search(escapedLower) >= 0) {
 			let num = 0;


### PR DESCRIPTION
Advances #787 (does not fully close it)

## Summary

Builds on the pass-number labeling (3.2.17) with #787's orphan/inactive markers (spec items #5 and #6).

Find results now prefix each pass-file match with `<mark><passNum>`:
- **`I`** — the pass is **inactive** (disabled in the analyzer sequence, i.e. a leading `/`).
- **`O`** — the file is an **orphan**: a `.nlp`/`.rec`/`.pat` in `spec/` that is not referenced by the sequence.
- no mark — an active pass (just its number).

`searchFile` looks up the `PassItem` for the file once (`getPasses().find` by name), reads its `active` flag, and uses the spec directory + pass extension to detect orphans. Non-pass files (function libraries, input text) are unaffected.

## Remaining #787 (still open)
- Rule number (`G("$rulenum")`) — needs a static `@RULES` parser to map a line to its rule index.
- Tab-aware char offset, and the full `X PASS RULE ELT | LINE,CHAR` layout.

## Version
3.2.17 → 3.2.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
