### PR TITLE
feat: multi-select delete in the Text view (#755, 3.2.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.19
+Text view: delete multiple files/folders at once.
+
+- **#755** The Text view now supports **multi-select**: select several files/folders (Ctrl/Shift-click) and delete them in one action. The single-item delete (with its file/directory wording) is unchanged; multi-select shows a "Delete N selected items?" confirmation.
+
 ### 3.2.18
 Find Results: mark inactive and orphan passes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.18",
+    "version": "3.2.19",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.18",
+            "version": "3.2.19",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.18",
+    "version": "3.2.19",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/textView.ts
+++ b/src/textView.ts
@@ -296,7 +296,7 @@ export class TextView {
 
 	constructor(context: vscode.ExtensionContext) {
 		const treeDataProvider = new FileSystemProvider();
-		this.textView = vscode.window.createTreeView('textView', { treeDataProvider, showCollapseAll: true });
+		this.textView = vscode.window.createTreeView('textView', { treeDataProvider, showCollapseAll: true, canSelectMany: true });
 		vscode.commands.registerCommand('textView.refreshAll', () => treeDataProvider.refresh());
 		vscode.commands.registerCommand('textView.importFiles', (textItem) => treeDataProvider.importFiles(textItem));
 		vscode.commands.registerCommand('textView.existingFolder', (textItem) => treeDataProvider.existingFolder(textItem));
@@ -318,8 +318,8 @@ export class TextView {
 		vscode.commands.registerCommand('textView.newText', (textItem) => this.newText(textItem, false));
 		vscode.commands.registerCommand('textView.newDirTop', (textItem) => this.newDir(textItem, true));
 		vscode.commands.registerCommand('textView.newDir', (textItem) => this.newDir(textItem, false));
-		vscode.commands.registerCommand('textView.deleteFile', (textItem) => this.deleteFile(textItem));
-		vscode.commands.registerCommand('textView.deleteDir', (textItem) => this.deleteFile(textItem));
+		vscode.commands.registerCommand('textView.deleteFile', (textItem, allItems) => this.deleteFile(textItem, allItems));
+		vscode.commands.registerCommand('textView.deleteDir', (textItem, allItems) => this.deleteFile(textItem, allItems));
 		vscode.commands.registerCommand('textView.deleteFileLogs', (textItem) => this.deleteFileLogs(textItem));
 		vscode.commands.registerCommand('textView.deleteAnalyzerLogs', () => this.deleteAnalyzerLogs());
 		vscode.commands.registerCommand('textView.splitDir', (textItem) => this.splitDir(textItem));
@@ -655,21 +655,36 @@ export class TextView {
 		}
 	}
 
-	private deleteFile(textItem: TextItem): void {
+	private deleteFile(textItem: TextItem, allItems?: TextItem[]): void {
 		if (visualText.hasWorkspaceFolder()) {
-			const items: vscode.QuickPickItem[] = [];
-			const isDir = dirfuncs.isDir(textItem.uri.fsPath);
-			const kind = isDir ? 'directory' : 'file';
-			let deleteDescr = '';
-			const filename = path.basename(textItem.uri.fsPath);
-			deleteDescr = deleteDescr.concat('Delete ', kind, ' \'', filename, '\'?');
-			items.push({ label: 'Yes', description: deleteDescr });
-			items.push({ label: 'No', description: 'Do not delete ' + filename });
+			// Multi-select: when several tree items are selected, VSCode passes the
+			// whole selection as the second argument; delete them all (#755).
+			let targets = (allItems && allItems.length) ? allItems : (textItem ? [textItem] : []);
+			if (textItem && !targets.some(t => t.uri.fsPath == textItem.uri.fsPath))
+				targets = [textItem, ...targets];
+			if (targets.length == 0)
+				return;
 
-			vscode.window.showQuickPick(items, { title: isDir ? 'Delete Directory' : 'Delete File', canPickMany: false, placeHolder: 'Choose Yes or No' }).then(selection => {
+			const items: vscode.QuickPickItem[] = [];
+			let title: string;
+			if (targets.length > 1) {
+				title = 'Delete Items';
+				items.push({ label: 'Yes', description: 'Delete ' + targets.length + ' selected items?' });
+				items.push({ label: 'No', description: 'Do not delete the selected items' });
+			} else {
+				const isDir = dirfuncs.isDir(targets[0].uri.fsPath);
+				const kind = isDir ? 'directory' : 'file';
+				const filename = path.basename(targets[0].uri.fsPath);
+				title = isDir ? 'Delete Directory' : 'Delete File';
+				items.push({ label: 'Yes', description: 'Delete ' + kind + ' \'' + filename + '\'?' });
+				items.push({ label: 'No', description: 'Do not delete ' + filename });
+			}
+
+			vscode.window.showQuickPick(items, { title: title, canPickMany: false, placeHolder: 'Choose Yes or No' }).then(selection => {
 				if (!selection || selection.label == 'No')
 					return;
-				visualText.fileOps.addFileOperation(textItem.uri, textItem.uri, [fileOpRefresh.TEXT], fileOperation.DELETE);
+				for (const target of targets)
+					visualText.fileOps.addFileOperation(target.uri, target.uri, [fileOpRefresh.TEXT], fileOperation.DELETE);
 				visualText.fileOps.startFileOps();
 			});
 		}


### PR DESCRIPTION
Closes #755

## Summary

The Text view now supports **multi-select delete** — select several files and/or folders and remove them in one action.

## Changes (`textView.ts`)

- The Text view tree is created with `canSelectMany: true`, so you can Ctrl/Shift-click multiple items.
- The `deleteFile` / `deleteDir` commands now receive VSCode's full selection as the second argument and delete every selected item.
- **Single-item behavior is unchanged** — it still shows the file/directory-specific confirmation ("Delete directory 'x'?"). Multi-select shows a "Delete N selected items?" confirmation.
- Defensive: the right-clicked item is always included even if VSCode passes it separately from the selection.

## Version
3.2.18 → 3.2.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
