### PR TITLE
fix: spaces in paths, missing seq file, dict-error line, find options (3.2.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.21
+Issue fixes: spaces in paths, missing sequence file, dict-error line, find options.
+
+- **#123** File/folder names with **spaces** now work — the Explore command and the Python-pass runner quote their paths instead of passing them unquoted to the shell.
+- **#770** A missing `spec/` directory or `analyzer.seq` no longer throws/blanks the views — `dirfuncs` guards against reading a non-existent directory, and a clear "Analyzer sequence file missing" warning is shown.
+- **#878** Double-clicking a **dictionary error** in the log now jumps to the correct line — a `.dict` error reports the dict line number as its first token, which was being ignored.
+- **#157** Find now supports **case-sensitive** and **whole-word** matching via the `nlp.findCaseSensitive` and `nlp.findWholeWord` settings (both off by default, so the default behavior is unchanged).
+
 ### 3.2.20
 Help view: Helpful Links.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Issue fixes: spaces in paths, missing sequence file, dict-error line, find optio
 - **#770** A missing `spec/` directory or `analyzer.seq` no longer throws/blanks the views — `dirfuncs` guards against reading a non-existent directory, and a clear "Analyzer sequence file missing" warning is shown.
 - **#878** Double-clicking a **dictionary error** in the log now jumps to the correct line — a `.dict` error reports the dict line number as its first token, which was being ignored.
 - **#157** Find now supports **case-sensitive** and **whole-word** matching via the `nlp.findCaseSensitive` and `nlp.findWholeWord` settings (both off by default, so the default behavior is unchanged).
+- **#974** **Duplicate Line** (Ctrl+Shift+D) no longer collapses `\\` to `\` — the duplicated line is inserted as literal text so backslashes are preserved.
 
 ### 3.2.20
 Help view: Helpful Links.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.20",
+    "version": "3.2.21",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.20",
+            "version": "3.2.21",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.20",
+    "version": "3.2.21",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -3239,6 +3239,18 @@
                     "scope": "resource",
                     "default": false,
                     "description": "Run regression tests by shelling out to nlp_regress.py in a terminal instead of the built-in runner (which streams results into the NLP++ log view)."
+                },
+                "nlp.findCaseSensitive": {
+                    "type": "boolean",
+                    "scope": "resource",
+                    "default": false,
+                    "description": "Find: match case (case-sensitive search). Off by default."
+                },
+                "nlp.findWholeWord": {
+                    "type": "boolean",
+                    "scope": "resource",
+                    "default": false,
+                    "description": "Find: match whole word only. Off by default."
                 },
                 "user.name": {
                     "type": "string",

--- a/src/dirfuncs.ts
+++ b/src/dirfuncs.ts
@@ -139,6 +139,7 @@ export namespace dirfuncs {
 
     export function getDirectoryTypes(folder: vscode.Uri): {uri: vscode.Uri, type: vscode.FileType}[] {
         const dirsAndTypes = Array();
+        if (!fs.existsSync(folder.fsPath)) return dirsAndTypes;   // missing dir (e.g. spec/ gone) -> empty, no throw (#770)
         const filenames = fs.readdirSync(folder.fsPath);
         for (const filename of filenames) {
             if (!filename.startsWith('.')) {
@@ -171,6 +172,7 @@ export namespace dirfuncs {
 
     export function getFiles(folder: vscode.Uri, filter: string[]=[], getType: getFileTypes=getFileTypes.FILES, recurse: boolean=false): vscode.Uri[] {
         const fileUris: vscode.Uri[] = new Array();
+        if (!fs.existsSync(folder.fsPath)) return fileUris;   // missing dir (e.g. spec/ gone) -> empty, no throw (#770)
         const filenames = fs.readdirSync(folder.fsPath);
         for (const filename of filenames) {
             if (!filename.startsWith('.')) {

--- a/src/findFile.ts
+++ b/src/findFile.ts
@@ -85,7 +85,13 @@ export class FindFile {
 			return;
 		this.textFile.setFile(uri);
 		const filename = path.basename(uri.fsPath);
-		const escapedLower = escaped.toLowerCase();
+		// #157: optional case-sensitive / whole-word matching (settings; default off, so
+		// the behaviour is unchanged -- case-insensitive substring).
+		const findConfig = vscode.workspace.getConfiguration('nlp');
+		const caseSensitive = findConfig.get<boolean>('findCaseSensitive', false);
+		const wholeWord = findConfig.get<boolean>('findWholeWord', false);
+		const rx = new RegExp(wholeWord ? '\\b' + escaped + '\\b' : escaped, caseSensitive ? '' : 'i');
+		const termLen = searchTerm.length;
 		// #787: prefix results with the analyzer-sequence pass info so they read in
 		// pass order and show the multi-pass progression. The tag is "<mark><passNum>  "
 		// where <mark> is "I " for an inactive (disabled) pass, or "O " for an orphan
@@ -100,25 +106,24 @@ export class FindFile {
 		else if (path.dirname(uri.fsPath) == seqFile.getSpecDirectory().fsPath && /\.(nlp|rec|pat)$/i.test(filename))
 			passTag = 'O  ';
 
-		if (this.textFile.getText().toLowerCase().search(escapedLower) >= 0) {
+		if (this.textFile.getText().search(rx) >= 0) {
 			let num = 0;
 			for (let line of this.textFile.getLines()) {
-				const lineLower = line.toLowerCase();
-				const pos = lineLower.search(escapedLower);
+				const pos = line.search(rx);
 				if (pos >= 0) {
-					if (line.length + escapedLower.length > context) {
+					if (line.length + termLen > context) {
 						const half = context / 2;
 						if (line.length - pos < half) {
 							line = line.substring(line.length-context-1,context);
 						} else if (pos > half) {
-							line = line.substring(pos-half,context+escapedLower.length);								
+							line = line.substring(pos-half,context+termLen);
 						} else {
 							line = line.substring(0,context);
 						}
 					}
 					let text = line;
 					if (bracketsFlag)
-						text = line.replace(searchTerm,` <<${searchTerm}>> `);
+						text = line.replace(rx, m => ` <<${m}>> `);
 					const label = `${passTag}${filename} [${num} ${pos}] ${line}`;
 					const newText = `${passTag}${path.basename(uri.fsPath)} ${text}`;
 					this.finds.push({uri: uri, label: label, line: line, lineNum: num, pos: Number.parseInt(pos), highlighted: newText});

--- a/src/logView.ts
+++ b/src/logView.ts
@@ -277,6 +277,9 @@ export class LogView {
 					const filename = tokens[tokens.length - 2];
 					const filePath = path.join(visualText.analyzer.getKBDirectory().fsPath, filename);
 					uri = vscode.Uri.file(filePath);
+					// A .dict error line is "<dictLine> <col> [msg - file.dict]" -- the FIRST
+					// number is the line in the dict file, so double-click lands there (#878).
+					lineNum = passNum;
 					type = logLineType.SYNTAX_ERROR;
 					icon = this.typeIcon(logLineType.SYNTAX_ERROR);
 				}

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -591,8 +591,9 @@ export class NLPFile extends TextFile {
 			let line = lines[position.line];
 			const posEnd = new vscode.Position(position.line + 1, 0);
 			const rang = new vscode.Selection(posEnd, posEnd);
-			line = line.replace(/\$/g, '\\$');
-			const snippet = new vscode.SnippetString(line);
+			// appendText escapes snippet metacharacters (\, $, }) so a literal "\\" is
+			// preserved instead of collapsing to "\" (#974).
+			const snippet = new vscode.SnippetString().appendText(line);
 			editor.insertSnippet(snippet, rang);
 			editor.selection = rang;
 		}

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -124,6 +124,12 @@ export class SequenceFile extends TextFile {
 			this.setSpecDir(specDir);
 
 		const anaFile = path.join(specDir,visualText.ANALYZER_SEQUENCE_FILE);
+		// Surface a missing sequence file instead of rendering a silent empty tree (#770).
+		if (!fs.existsSync(anaFile)) {
+			this.passItems = [];
+			vscode.window.showWarningMessage('Analyzer sequence file missing: ' + anaFile);
+			return;
+		}
 		super.setFile(vscode.Uri.file(anaFile),true);
 		let passNum = 1;
 		this.passItems = [];

--- a/src/textFile.ts
+++ b/src/textFile.ts
@@ -84,7 +84,8 @@ export class TextFile {
 
     runPythonCode(editor: vscode.TextEditor, pythonScriptPath: string) {
         const inputFilePath = editor.document.uri.fsPath;
-        const command = `python ${pythonScriptPath} ${inputFilePath}`;
+        // Quote the paths so a script or input file with spaces runs correctly (#123).
+        const command = `python "${pythonScriptPath}" "${inputFilePath}"`;
 
         // Execute the command
         exec(command, (error, stdout, stderr) => {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1444,7 +1444,8 @@ export class VisualText {
             platformCmd = 'open';
         }
         if (platformCmd != '') {
-            const cmd = platformCmd + ' ' + dir;
+            // Quote the path so folders/files with spaces open correctly (#123).
+            const cmd = platformCmd + ' "' + dir + '"';
             const cp = require('child_process');
             cp.exec(cmd, (err, stdout, stderr) => {
                 console.log('stdout: ' + stdout);


### PR DESCRIPTION
Closes #123, closes #770, closes #878, closes #157, closes #974

Five fixes found by investigating the open backlog (3.2.21).

- **#123** filenames with spaces (quote paths in Explore + python-pass runner).
- **#770** missing spec/ or analyzer.seq no longer throws/blanks the views (dirfuncs guards + warning).
- **#878** dictionary-error double-click lands on the right line (first token is the dict line number).
- **#157** Find case-sensitive / whole-word via nlp.findCaseSensitive / nlp.findWholeWord settings (off by default).
- **#974** Duplicate Line (Ctrl+Shift+D) preserves backslashes — inserted via SnippetString().appendText so \ is not collapsed to \.

Rebased onto master 3.2.20 (Helpful Links); this is 3.2.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)