### PR TITLE
feat: Insert Python Library Pass (json2kbb converter, #882, 3.2.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.22
+Insert Python Library Pass.
+
+- **#882** New **Insert Python Library Pass** on the sequence view: pick a script from the shared `visualText/python/` library (shown with its `# DESC:` descriptor) and it's copied into the analyzer's `spec/` and added to the sequence as a python pass — including a "before the tokenizer" variant on the tokenizer menu. The generic **Insert Python Pass** (blank stub) is unchanged.
+- Ships with a **`json2kbb.py`** library script that converts a JSON input file to a KBB in `kb/user/` (the inverse of `KBFuncs.nlp`'s `JsonKB`), so an analyzer can build a KBB from JSON before processing. (Requires the companion VisualText-files release for the script + descriptors.)
+
 ### 3.2.21
 Issue fixes: spaces in paths, missing sequence file, dict-error line, find options.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.21",
+    "version": "3.2.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.21",
+            "version": "3.2.22",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.21",
+    "version": "3.2.22",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -1088,6 +1088,22 @@
             {
                 "command": "sequenceView.insertPythonBeforeTokenize",
                 "title": "Insert Python Pass Before Tokenizer",
+                "icon": {
+                    "light": "resources/light/python.svg",
+                    "dark": "resources/dark/python.svg"
+                }
+            },
+            {
+                "command": "sequenceView.insertPythonLibrary",
+                "title": "Python Library",
+                "icon": {
+                    "light": "resources/light/python.svg",
+                    "dark": "resources/dark/python.svg"
+                }
+            },
+            {
+                "command": "sequenceView.insertPythonLibraryBeforeTokenize",
+                "title": "Insert Python Library Pass Before Tokenizer",
                 "icon": {
                     "light": "resources/light/python.svg",
                     "dark": "resources/dark/python.svg"
@@ -2428,6 +2444,10 @@
                 {
                     "command": "sequenceView.insertPython",
                     "group": "edit@4"
+                },
+                {
+                    "command": "sequenceView.insertPythonLibrary",
+                    "group": "edit@5"
                 }
             ],
             "librarypass": [
@@ -2685,6 +2705,11 @@
                     "command": "sequenceView.insertPythonBeforeTokenize",
                     "when": "view == sequenceView && viewItem =~ /.*tokenize.*/",
                     "group": "tokenize@0"
+                },
+                {
+                    "command": "sequenceView.insertPythonLibraryBeforeTokenize",
+                    "when": "view == sequenceView && viewItem =~ /.*tokenize.*/",
+                    "group": "tokenize@1"
                 },
                 {
                     "command": "sequenceView.tokenize",

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -459,6 +459,60 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 		}
 	}
 
+	// Insert a python pass from the shared library (visualText/python/*.py). The
+	// chosen script is copied into the analyzer's spec/ and added to the sequence
+	// as a python pass. The generic "Insert Python Pass" (blank stub) still exists.
+	insertPythonLibrary(seqItem: SequenceItem, before: boolean = false): void {
+		if (!visualText.hasWorkspaceFolder())
+			return;
+		const pyDir = visualText.getVisualTextDirectory('python');
+		if (!dirfuncs.isDir(pyDir)) {
+			vscode.window.showWarningMessage('No python library folder found: ' + pyDir);
+			return;
+		}
+		const scripts = this.listLibraryPython(pyDir);
+		if (!scripts.length) {
+			vscode.window.showWarningMessage('No python scripts found in ' + pyDir);
+			return;
+		}
+		const items: vscode.QuickPickItem[] = scripts.map(s => ({ label: s.name, description: s.desc }));
+		const title = before ? 'Insert Python Library Pass Before Tokenizer' : 'Insert Python Library Pass';
+		vscode.window.showQuickPick(items, { title: title, placeHolder: 'Choose a python script to insert as a pass' }).then(sel => {
+			if (!sel)
+				return;
+			const src = path.join(pyDir, sel.label + '.py');
+			const dest = path.join(visualText.analyzer.getSpecDirectory().fsPath, sel.label + '.py');
+			try {
+				fs.copyFileSync(src, dest);
+			} catch (err: any) {
+				vscode.window.showErrorMessage('Could not copy python script: ' + err.message);
+				return;
+			}
+			// The library file now lives in spec/; insertNewPythonPass reuses it
+			// (createNewPythonFile only writes a stub when the file is absent).
+			visualText.analyzer.seqFile.insertNewPythonPass(seqItem, sel.label, before);
+			vscode.commands.executeCommand('sequenceView.refreshAll');
+		});
+	}
+
+	// List the python library scripts with their "# DESC:" descriptor line
+	// (scanned near the top of each file) for the picker.
+	listLibraryPython(dir: string): { name: string, desc: string }[] {
+		const result: { name: string, desc: string }[] = [];
+		for (const f of fs.readdirSync(dir)) {
+			if (!f.toLowerCase().endsWith('.py'))
+				continue;
+			const raw = fs.readFileSync(path.join(dir, f), 'utf8');
+			let desc = '';
+			for (const line of raw.split(/\r?\n/).slice(0, 15)) {
+				const m = line.match(/^#\s*DESC:\s*(.*)$/i);
+				if (m) { desc = m[1].trim(); break; }
+			}
+			result.push({ name: path.parse(f).name, desc: desc });
+		}
+		return result.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
 	renameTopComment(passFile: vscode.Uri) {
 		const textFile = new TextFile();
 		textFile.setFile(passFile);
@@ -640,6 +694,8 @@ export class SequenceView {
 		vscode.commands.registerCommand('sequenceView.insertDecl', (seqItem) => treeDataProvider.insertDecl(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertPython', (seqItem) => treeDataProvider.insertPython(seqItem));
 		vscode.commands.registerCommand('sequenceView.insertPythonBeforeTokenize', (seqItem) => treeDataProvider.insertPython(seqItem, true));
+		vscode.commands.registerCommand('sequenceView.insertPythonLibrary', (seqItem) => treeDataProvider.insertPythonLibrary(seqItem));
+		vscode.commands.registerCommand('sequenceView.insertPythonLibraryBeforeTokenize', (seqItem) => treeDataProvider.insertPythonLibrary(seqItem, true));
 		vscode.commands.registerCommand('sequenceView.insertLibrary', (seqItem) => treeDataProvider.insertLibraryPass(seqItem));
 		vscode.commands.registerCommand('sequenceView.libraryKBFuncs', (seqItem) => treeDataProvider.libraryKBFuncs(seqItem));
 		vscode.commands.registerCommand('sequenceView.libraryTreeFuncs', (seqItem) => treeDataProvider.libraryTreeFuncs(seqItem));


### PR DESCRIPTION
Closes #882

## Summary

Adds **Insert Python Library Pass** to the sequence view: pick a script from the shared `visualText/python/` library and it's inserted into the analyzer sequence as a python pass. This is the mechanism for the #882 "json→KBB converter" — it ships as a library script (`json2kbb.py`) you insert as a pre-tokenize pass.

Companion VisualText-files PR: VisualText/visualtext-files#186 (adds `json2kbb.py` + `# DESC:` headers).

## How it works

- New command **"Insert Python Library Pass"** (in the sequence-type submenu, next to the generic "Python"), plus an **"...Before Tokenizer"** variant on the tokenizer's context menu (so a converter can run on the raw input).
- It lists the `.py` files in `visualText/python/`, each shown with its **`# DESC:`** descriptor line, in a QuickPick.
- On pick: the script is copied into the analyzer's `spec/` as `<name>.py` and added to the sequence as `python <name>`. It reuses the existing `insertNewPythonPass` (whose `createNewPythonFile` only writes a stub when the file is absent, so the copied library content is preserved).
- The existing generic **Insert Python Pass** (blank `pyfiller` stub) is unchanged — they coexist.

## Files
- `src/sequenceView.ts` — `insertPythonLibrary` + `listLibraryPython` + command registrations.
- `package.json` — two command defs + menu entries; version 3.2.22.
- `CHANGELOG.md` — 3.2.22 notes.

Note: the picker is populated from the installed `visualText/python/` folder, which is refreshed by a VisualText-files release (#186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
