### PR TITLE
fix: unstick VisualText-files update (revert #800 whole-dir delete, 3.2.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.23
+Fix VisualText files update getting stuck.
+
+- Reverts #800's "delete the whole `visualText` directory before downloading". That left the directory empty whenever the following download/unzip stalled, and the missing files re-triggered the updater, so the unzip got stuck in a loop. The updater no longer deletes the directory; the unzip refreshes files in place.
+
 ### 3.2.22
 Insert Python Library Pass.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.22",
+    "version": "3.2.23",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.22",
+            "version": "3.2.23",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.22",
+    "version": "3.2.23",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -555,17 +555,13 @@ export class VisualText {
                             visualText.debugMessage('Deleting: ' + op.local, logLineType.UPDATER);
                             fs.unlinkSync(op.local);
                         }
-                        if (op.component == upComp.VT_FILES) {
-                            // #800: clear the entire visualText directory before re-downloading
-                            // so no stale/residual files survive. The generic per-folder delete
-                            // below built a doubled "visualText/visualText/..." path that never
-                            // existed, so it deleted nothing and left residual files behind.
-                            const vtDir = path.dirname(op.local);
-                            if (fs.existsSync(vtDir)) {
-                                visualText.debugMessage('Deleting VisualText dir: ' + vtDir, logLineType.UPDATER);
-                                dirfuncs.delDir(vtDir);
-                            }
-                        } else if (op.folders.length) {
+                        // NOTE: do NOT delete the whole visualText directory here. That
+                        // (#800) left the directory empty if the subsequent download/unzip
+                        // stalled, and the missing files re-triggered the updater, so the
+                        // unzip got stuck in a loop. The unzip overwrites files in place, so
+                        // a fresh download simply refreshes them. (Residual files from an
+                        // older release are tolerated; clearing them safely is future work.)
+                        if (op.folders.length) {
                             for (const folder of op.folders) {
                                 const f = path.join(path.dirname(op.local), folder);
                                 if (fs.existsSync(f)) {


### PR DESCRIPTION
## Summary

Fixes the VisualText-files **update getting stuck at "Unzipping"**. Reverts #800.

## Root cause

#800 made the updater **delete the entire `visualText` directory** before re-downloading. When the subsequent download/unzip stalled, the directory was left **empty** (only the freshly-downloaded `visualtext.zip` + a partial extraction), and the now-missing files re-triggered the updater's download/delete — so the unzip looped/stuck and the `visualText` dir stayed broken.

Observed on a user's install: `visualText/` contained only `analyzer-templates/` + `visualtext.zip`; the zip itself was valid (2168 entries, extracts in seconds).

## Fix

The updater no longer deletes the `visualText` directory. `extract-zip` overwrites files in place, so a fresh download simply refreshes them — the pre-#800 (safe) behavior. Residual files from an older release are tolerated again; clearing them safely (without a destructive pre-delete) is future work — see reopened #800.

## Version
→ 3.2.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
