### PR TITLE
fix: updater multi-version loop — check the engine dir it downloads to (#481, 3.2.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.24
+Fix update loop with multiple extension versions installed.
+
+- The updater's existence check now uses the same engine directory the download/unzip target (`engineDirectory()`). Previously it used `getExtensionPath()`, which could resolve to a **different installed version**, so with several `dehilster.nlp-*` versions present the check looked in one directory while the download populated another — the update never registered as complete and the unzip looped. (Related: #481.)
+
 ### 3.2.23
 Fix VisualText files update getting stuck.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.23",
+    "version": "3.2.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.23",
+            "version": "3.2.24",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.23",
+    "version": "3.2.24",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -508,7 +508,13 @@ export class VisualText {
             case upStat.START:
                 switch (op.operation) {
                     case upOp.CHECK_EXISTS:
-                        const endDir = path.join(visualText.getExtensionPath().fsPath, visualText.NLPENGINE_REPO);
+                        // Use the SAME engine directory the download/unzip target
+                        // (engineDirectory(), based on this.version). getExtensionPath()
+                        // can resolve to a different installed version, so with multiple
+                        // versions installed the check looked in one dir while the download
+                        // populated another -- the update never registered as done and the
+                        // unzip looped. (See #481.)
+                        const endDir = visualText.engineDirectory().fsPath;
                         if (op.folders.length && endDir) {
                             let missingOne = false;
                             for (const folder of op.folders) {


### PR DESCRIPTION
## Summary

Fixes the VisualText-files update **looping/stuck at "Unzipping"** when multiple `dehilster.nlp-*` extension versions are installed.

## Root cause

The updater's `CHECK_EXISTS` step used `getExtensionPath()` to build the directory it checks for existing files. `getExtensionPath()` (via `extensionItems[latestExtIndex]`) can resolve to a **different installed version** than `engineDirectory()` (which is based on `this.version`) that the download/unzip actually target.

On an install with 3.2.6 + 3.2.20 + 3.2.23 present, the check looked in `…/dehilster.nlp-3.2.6/nlp-engine` while the download/unzip populated `…/dehilster.nlp-3.2.23/nlp-engine`. The update therefore never registered as complete, and the unzip looped — matching the reported log (`Extension path: …3.2.6` but `Unzipping: …3.2.23…`).

## Fix

`CHECK_EXISTS` now uses `engineDirectory().fsPath` — the same directory the download/unzip target — so the check and the download always agree, even with multiple versions installed. Related: #481.

## Version
→ 3.2.24.

Note: users should still keep a single installed version where possible; this makes the updater robust when they don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
