### PR TITLE
feat: menu tweaks, JSON icon, orphan python fix (3.2.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.25
+Menu tweaks, JSON icon, and orphan-python fix.
+
+- **Toggle Auto Update** added to the Logging view's `⋯` menu (next to Toggle Update Trace), so auto-update can be turned on/off without editing settings.
+- **KB view**: "Explore KB Folder" added to the title `⋯` menu, and the help **Video** moved from the title bar into the `⋯` menu.
+- **Output view**: "Explore Folder" added to the title `⋯` menu.
+- **JSON files** now show a `{ }` JSON icon in the tree.
+- **Orphan passes**: clicking the orphan button now shows **python (`.py`) passes** too (previously only `.nlp`/`.pat`), and the orphan check no longer misclassifies them. The same fix applies to Delete Orphans.
+
 ### 3.2.24
 Fix update loop with multiple extension versions installed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.2.24",
+    "version": "3.2.25",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.2.24",
+            "version": "3.2.25",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.24",
+    "version": "3.2.25",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {
@@ -1674,6 +1674,14 @@
                 }
             },
             {
+                "command": "logView.toggleAutoUpdate",
+                "title": "Toggle Auto Update",
+                "icon": {
+                    "light": "resources/light/update.svg",
+                    "dark": "resources/dark/update.svg"
+                }
+            },
+            {
                 "command": "logView.checkUpdates",
                 "title": "Check for updates",
                 "icon": {
@@ -2098,9 +2106,14 @@
                     "group": "navigation@4"
                 },
                 {
+                    "command": "kbView.explore",
+                    "when": "view == kbView",
+                    "group": "second@0"
+                },
+                {
                     "command": "kbView.video",
                     "when": "view == kbView",
-                    "group": "navigation@6"
+                    "group": "second@2"
                 },
                 {
                     "command": "kbView.langLibs",
@@ -2258,6 +2271,11 @@
                     "group": "navigation@5"
                 },
                 {
+                    "command": "outputView.explore",
+                    "when": "view == outputView",
+                    "group": "secondary@5"
+                },
+                {
                     "command": "outputView.video",
                     "when": "view == outputView",
                     "group": "secondary@6"
@@ -2304,6 +2322,11 @@
                 },
                 {
                     "command": "logView.updateDebug",
+                    "when": "view == logView",
+                    "group": "third"
+                },
+                {
+                    "command": "logView.toggleAutoUpdate",
                     "when": "view == logView",
                     "group": "third"
                 },

--- a/resources/dark/json.svg
+++ b/resources/dark/json.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g fill="none" stroke="#00aeef" stroke-width="42" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M188 88 C132 88 132 148 132 200 C132 240 96 256 76 256 C96 256 132 272 132 312 C132 364 132 424 188 424"/>
+    <path d="M324 88 C380 88 380 148 380 200 C380 240 416 256 436 256 C416 256 380 272 380 312 C380 364 380 424 324 424"/>
+  </g>
+</svg>

--- a/resources/light/json.svg
+++ b/resources/light/json.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g fill="none" stroke="#2e3192" stroke-width="42" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M188 88 C132 88 132 148 132 200 C132 240 96 256 76 256 C96 256 132 272 132 312 C132 364 132 424 188 424"/>
+    <path d="M324 88 C380 88 380 148 380 200 C380 240 416 256 436 256 C416 256 380 272 380 312 C380 364 380 424 324 424"/>
+  </g>
+</svg>

--- a/src/logView.ts
+++ b/src/logView.ts
@@ -85,6 +85,7 @@ export class LogView {
 		vscode.commands.registerCommand('logView.updaterHelp', () => this.updaterHelp());
 		vscode.commands.registerCommand('logView.checkUpdates', () => this.checkUpdates());
 		vscode.commands.registerCommand('logView.updateDebug', () => this.updateDebug());
+		vscode.commands.registerCommand('logView.toggleAutoUpdate', () => this.toggleAutoUpdate());
 		vscode.commands.registerCommand('logView.analyzerOuts', () => this.loadAnalyzerOuts());
 		vscode.commands.registerCommand('logView.analyzeSummary', () => this.loadAnalyzeSummary());
 		vscode.commands.registerCommand('logView.enginePath', () => this.enginePath());
@@ -129,6 +130,22 @@ export class LogView {
 				return;
 			}
 			visualText.debug = selection.label === arfirm ? true : false;
+		});
+	}
+
+	toggleAutoUpdate() {
+		const items: vscode.QuickPickItem[] = [];
+		const on = 'Turn ON auto update';
+		const current = visualText.getAutoUpdate() ? ' (currently ON)' : ' (currently OFF)';
+		items.push({ label: on, description: 'automatically update the engine and VisualText files on load/reload' });
+		items.push({ label: 'Turn OFF auto update', description: 'do not auto update on load/reload' });
+		vscode.window.showQuickPick(items, { title: 'Auto Update' + current, canPickMany: false, placeHolder: 'Choose ON or Off' }).then(selection => {
+			if (!selection) {
+				return;
+			}
+			const enable = selection.label === on;
+			visualText.setAutoUpdate(enable);
+			vscode.window.showInformationMessage('Auto update is now ' + (enable ? 'ON' : 'OFF'));
 		});
 	}
 

--- a/src/outputView.ts
+++ b/src/outputView.ts
@@ -207,10 +207,9 @@ export class OutputView {
 	deleteOrphans(): void {
 		if (visualText.hasWorkspaceFolder()) {
 			const files: vscode.Uri[] = [];
-			const nlpFiles = dirfuncs.getFiles(visualText.analyzer.getSpecDirectory(), ['.pat', '.nlp']);
+			const nlpFiles = dirfuncs.getFiles(visualText.analyzer.getSpecDirectory(), ['.pat', '.nlp', '.py']);
 			for (const nlpFile of nlpFiles) {
-				if (visualText.analyzer.seqFile.isOrphan(path.basename(nlpFile.fsPath, '.nlp')) == true &&
-					visualText.analyzer.seqFile.isOrphan(path.basename(nlpFile.fsPath, '.pat')) == true) {
+				if (visualText.analyzer.seqFile.isOrphan(path.parse(nlpFile.fsPath).name) == true) {
 					files.push(nlpFile);
 				}
 			}
@@ -301,10 +300,11 @@ export class OutputView {
 				this.outputFiles = this.outputFiles.concat(kbFiles);
 			}
 			else if (this.type == outputFileType.NLP) {
-				const nlpFiles = dirfuncs.getFiles(visualText.analyzer.getSpecDirectory(), ['.pat', '.nlp']);
+				// Include python passes (.py) alongside .nlp/.pat, and test orphan status
+				// by the extension-stripped pass name so .py files are classified correctly.
+				const nlpFiles = dirfuncs.getFiles(visualText.analyzer.getSpecDirectory(), ['.pat', '.nlp', '.py']);
 				for (const nlpFile of nlpFiles) {
-					if (visualText.analyzer.seqFile.isOrphan(path.basename(nlpFile.fsPath, '.nlp')) == true &&
-						visualText.analyzer.seqFile.isOrphan(path.basename(nlpFile.fsPath, '.pat')) == true) {
+					if (visualText.analyzer.seqFile.isOrphan(path.parse(nlpFile.fsPath).name) == true) {
 						this.outputFiles.push(nlpFile);
 					}
 				}

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1517,6 +1517,8 @@ export class VisualText {
             icon = 'test.svg';
         } else if (filename.endsWith('.py')) {
             icon = 'python.svg';
+        } else if (filename.endsWith('.json')) {
+            icon = 'json.svg';
         } else if (filename.endsWith('.dll') || filename.endsWith('.so') || filename.endsWith('.dylib')) {
             icon = 'library.svg';
         } else {


### PR DESCRIPTION
## Summary

A batch of UI tweaks and two fixes (3.2.25).

## Changes

- **Toggle Auto Update** in the Logging view's `⋯` menu (next to Toggle Update Trace) — turn auto-update on/off without editing settings (`logView.toggleAutoUpdate` → `setAutoUpdate`).
- **KB view**: "Explore KB Folder" added to the title `⋯` menu; the help **Video** moved from the title bar into `⋯`.
- **Output view**: "Explore Folder" added to the title `⋯` menu.
- **JSON icon**: `.json` files show a `{ }` icon in the tree (`fileIconFromExt` + new `resources/{light,dark}/json.svg`).
- **Orphan passes fix**: the orphan button (and Delete Orphans) previously only scanned `.nlp`/`.pat` in `spec/` and its double-`basename` check misclassified other extensions, so **python (`.py`) orphan passes never showed**. Now it includes `.py` and tests orphan status via the extension-stripped pass name (`path.parse(...).name`).

## Version
→ 3.2.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
