### PR TITLE
fix: updater no longer gets stuck unzipping visualtext.zip (3.2.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.26
+Fix the updater getting stuck while unzipping `visualtext.zip`.
+
+- The unzip now extracts into a temporary sibling directory and only moves each top-level entry into the engine directory **after the full extraction succeeds**. Previously the extraction wrote directly into the engine dir, so an interrupted unzip (e.g. a window reload mid-extraction) left a **partial tree** that looked like a complete install. The leftover `.zip` then made the updater skip the download and jump straight back to the unzip, which was interrupted again — an endless "stuck on unzipping" loop. The source `.zip` is now deleted only after everything is moved into place, so any re-run re-extracts cleanly from scratch.
+- **KB view**: `.json` files placed in `kb/user` now appear in the tree (with the JSON icon), so JSON data fed to an analyzer for the `json2kbb` pass is visible alongside the `.kbb` files it generates.
+
 ### 3.2.25
 Menu tweaks, JSON icon, and orphan-python fix.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.25",
+    "version": "3.2.26",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/kbView.ts
+++ b/src/kbView.ts
@@ -96,7 +96,9 @@ export class FileSystemProvider implements vscode.TreeDataProvider<KBItem> {
 		const entries = dirfuncs.getDirectoryTypes(dir);
 		visualText.mod.clear();
 		visualText.modFiles = [];
-		const order = ['.dict', '.dictt', '.kbb', '.kbbb', '.nlm', '.test', '.txt'];
+		// .json is listed so JSON sources placed in kb/user (converted to .kbb by the
+		// json2kbb python pass) are visible alongside the KB files they generate.
+		const order = ['.dict', '.dictt', '.kbb', '.kbbb', '.nlm', '.json', '.test', '.txt'];
 
 		for (const ext of order) {
 			for (const entry of entries) {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -842,6 +842,24 @@ export class VisualText {
         })();
     }
 
+    // Move a single extracted entry into its final location, replacing any
+    // existing file/dir. src and dst live on the same volume (the temp dir is a
+    // child of the engine dir), so renameSync is atomic and fast; the cpSync
+    // fallback only covers a transient Windows lock on the destination.
+    private moveIntoPlace(src: string, dst: string) {
+        if (fs.existsSync(dst)) {
+            if (fs.statSync(dst).isDirectory()) dirfuncs.delDir(dst);
+            else fs.unlinkSync(dst);
+        }
+        try {
+            fs.renameSync(src, dst);
+        } catch (e) {
+            fs.cpSync(src, dst, { recursive: true });
+            if (fs.statSync(src).isDirectory()) dirfuncs.delDir(src);
+            else fs.unlinkSync(src);
+        }
+    }
+
     unzip(op: updateOp) {
         (async () => {
             const vtFileDir = path.dirname(op.local);
@@ -850,36 +868,43 @@ export class VisualText {
                 ? path.join(vtFileDir, path.basename(op.remote))
                 : op.local;
 
+            // Extract into a temp sibling dir first, then move each top-level
+            // entry into place only after the FULL extraction succeeds. An
+            // interrupted or partial unzip therefore never lands in the engine
+            // dir, so it can't masquerade as a complete install and re-trigger
+            // the download->unzip retry loop that left the updater stuck. The
+            // source zip is only deleted after everything is moved into place,
+            // so a re-run always re-extracts cleanly from scratch. (See #1070.)
+            const tmpDir = path.join(vtFileDir, '.vt-unzip-tmp');
             const extract = require('extract-zip')
             try {
-                this.debugMessage('Unzipping: ' + toPath, logLineType.UPDATER);
-                await extract(toPath, { dir: vtFileDir });
+                if (fs.existsSync(tmpDir)) dirfuncs.delDir(tmpDir);
+                fs.mkdirSync(tmpDir, { recursive: true });
+
+                this.debugMessage('Unzipping (this can take ~15s): ' + toPath, logLineType.UPDATER);
+                await extract(toPath, { dir: tmpDir });
                 this.debugMessage('UNZIPPED: ' + toPath, logLineType.UPDATER);
 
+                // exe zips wrap their payload in a single subfolder; flatten it.
+                let srcRoot = tmpDir;
                 if (isLinuxExeZip) {
-                    const subfolder = path.join(vtFileDir, path.basename(toPath, '.zip'));
-                    if (fs.existsSync(subfolder)) {
-                        for (const f of fs.readdirSync(subfolder)) {
-                            const src = path.join(subfolder, f);
-                            const dst = f === 'nlpl.exe'
-                                ? path.join(vtFileDir, visualText.NLP_EXE)
-                                : path.join(vtFileDir, f);
-                            if (fs.existsSync(dst)) {
-                                const stat = fs.statSync(dst);
-                                if (stat.isDirectory()) dirfuncs.delDir(dst);
-                                else fs.unlinkSync(dst);
-                            }
-                            fs.renameSync(src, dst);
-                        }
-                        dirfuncs.delDir(subfolder);
-                    }
+                    const subfolder = path.join(tmpDir, path.basename(toPath, '.zip'));
+                    if (fs.existsSync(subfolder)) srcRoot = subfolder;
+                }
+                for (const f of fs.readdirSync(srcRoot)) {
+                    const dst = (isLinuxExeZip && f === 'nlpl.exe')
+                        ? path.join(vtFileDir, visualText.NLP_EXE)
+                        : path.join(vtFileDir, f);
+                    visualText.moveIntoPlace(path.join(srcRoot, f), dst);
                 }
 
+                dirfuncs.delDir(tmpDir);
                 op.status = upStat.DONE;
                 dirfuncs.delFile(toPath);
             }
             catch (err) {
                 this.debugMessage('Could not unzip file: ' + toPath + '\n' + err, logLineType.UPDATER);
+                if (fs.existsSync(tmpDir)) dirfuncs.delDir(tmpDir);
                 op.status = upStat.FAILED;
             }
         })();


### PR DESCRIPTION
## Summary

Fixes the recurring **"stuck on unzipping `visualtext.zip`"** updater hang, plus lists `.json` files in the KB view. Ships as **3.2.26**.

## The updater hang (root cause)

The download always completed fine (the 14.6 MB zip was intact). The failure was in the **unzip**, which wrote directly into the engine directory:

- `unzip()` is a fire-and-forget async. If the window reloads/closes mid-extraction, the extraction is orphaned partway and the source `.zip` is **not** deleted (that only happens on success).
- Next launch: the existence check sees engine folders still missing → `DOWNLOAD` op → but the zip already exists, so it **skips the download and jumps straight back to the unzip** ([visualText.ts:546](src/visualText.ts#L546)).
- That unzip gets interrupted again. Each pass leaves a **partial tree** that looks like progress but never completes — an endless loop. (Observed on this machine: the engine dir contained only the first of eight top-level folders.)

## The fix

`unzip()` now:
1. Extracts into a temp sibling dir (`.vt-unzip-tmp/`).
2. Moves each top-level entry into the engine dir **only after the full extraction resolves** (atomic `renameSync` on the same volume, with a `cpSync` fallback).
3. Deletes the source `.zip` **only after** everything is in place.

So an interrupted unzip never lands in the engine dir, can't masquerade as a complete install, and any re-run re-extracts cleanly from scratch. The existing `updaterID` guard already prevents a second concurrent run.

## Also

- **KB view** now lists `.json` files placed in `kb/user` (with the JSON icon), so JSON fed to an analyzer for the `json2kbb` pass is visible alongside the `.kbb` files it generates. ([kbView.ts](src/kbView.ts))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
