### PR TITLE
refactor: retire Insert Analyzer Block(s); drop dependency on visualtext-files/analyzers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1126,14 +1126,6 @@
                 }
             },
             {
-                "command": "sequenceView.insertAnalyzerBlock",
-                "title": "Insert Analyzer Block(s)",
-                "icon": {
-                    "light": "resources/light/file-code.svg",
-                    "dark": "resources/dark/file-code.svg"
-                }
-            },
-            {
                 "command": "sequenceView.deleteFolder",
                 "title": "Delete Folder",
                 "icon": {
@@ -2658,11 +2650,6 @@
                     "command": "sequenceView.insertOrphan",
                     "when": "view == sequenceView",
                     "group": "atop@4"
-                },
-                {
-                    "command": "sequenceView.insertAnalyzerBlock",
-                    "when": "view == sequenceView && viewItem =~ /.*outside.*/",
-                    "group": "atop@5"
                 },
                 {
                     "command": "sequenceView.newFolder",

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -142,9 +142,6 @@ export class Analyzer {
             const items: vscode.QuickPickItem[] = [];
 
             let fromDir = path.join(visualText.getVisualTextDirectory("analyzer-templates"));
-            if (!dirfuncs.isDir(fromDir)) {
-                fromDir = path.join(visualText.getVisualTextDirectory("analyzers"));
-            }
             if (dirfuncs.isDir(fromDir)) {
                 const files = dirfuncs.getDirectories(vscode.Uri.file(fromDir));
                 const dirMap: { [key: string]: string } = {};

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -271,7 +271,7 @@ export class HelpView {
             engineExe: path.join(engineDir, exeName),
             engineDir: engineDir,
             visualTextDir: visualText.getVisualTextDirectory(),
-            analyzersDir: visualText.getVisualTextDirectory('analyzers'),
+            analyzersDir: visualText.getBlockAnalyzersPath().fsPath,
             templatesDir: visualText.getVisualTextDirectory('analyzer-templates'),
             languagesDir: visualText.getVisualTextDirectory('languages'),
             miscDir: visualText.getVisualTextDirectory('misc'),

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -723,7 +723,6 @@ export class SequenceView {
 		vscode.commands.registerCommand('sequenceView.toggleActive', (seqItem) => this.toggleActive(seqItem));
 		vscode.commands.registerCommand('sequenceView.modAdd', () => this.modAdd());
 		vscode.commands.registerCommand('sequenceView.video', () => this.video());
-		vscode.commands.registerCommand('sequenceView.insertAnalyzerBlock', (seqItem) => this.insertAnalyzerBlocks(seqItem));
 		vscode.commands.registerCommand('sequenceView.compareSisters', (seqItem) => this.compareSisters(seqItem));
 		vscode.commands.registerCommand('sequenceView.copyContext', (seqItem) => this.copyContext(seqItem));
 		vscode.commands.registerCommand('sequenceView.compareLibrary', (seqItem) => this.compareLibrary(seqItem));
@@ -800,43 +799,6 @@ export class SequenceView {
 					vscode.commands.executeCommand('sequenceView.refreshAll');
 					return true;
 				});
-			}
-		}
-	}
-
-	insertAnalyzerBlocks(seqItem: SequenceItem): void {
-		if (visualText.getWorkspaceFolder()) {
-			const items: vscode.QuickPickItem[] = [];
-			const fromDir = path.join(visualText.getVisualTextDirectory('analyzers'));
-			if (dirfuncs.isDir(fromDir)) {
-				const files = dirfuncs.getDirectories(vscode.Uri.file(fromDir));
-				for (const file of files) {
-					if (dirfuncs.isDir(file.fsPath)) {
-						const readme = path.join(file.fsPath, "README.MD");
-						let descr: string, tit: string;
-						({ title: tit, description: descr } = visualText.analyzer.readDescription(readme));
-						items.push({ label: tit, description: descr });
-					}
-				}
-				vscode.window.showQuickPick(items, { title: 'Insert Analyzer', canPickMany: true, placeHolder: 'Choose analyzer blocks to insert' }).then(selections => {
-					if (!selections)
-						return false;
-					let row = seqItem.row;
-					if (seqItem.type.localeCompare('folder') == 0)
-						row = visualText.analyzer.seqFile.getLastItemInFolder(row).row;
-					const toDir = visualText.analyzer.getAnalyzerDirectory().fsPath;
-					visualText.fileOps.addFileOperation(vscode.Uri.file(fromDir), vscode.Uri.file(toDir), [fileOpRefresh.ANALYZER], fileOperation.ANASEL, row.toString());
-					for (const selection of selections) {
-						if (selection.description)
-							this.insertAnalyzerBlock(fromDir, toDir, selection.label);
-					}
-					visualText.fileOps.startFileOps();
-					vscode.commands.executeCommand('sequenceView.refreshAll');
-					return true;
-				});
-
-			} else {
-				vscode.window.showWarningMessage('No analyzers found in ' + fromDir);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Retires the **Insert Analyzer Block(s)** command and removes the extension's remaining dependencies on the top-level `visualtext-files/analyzers` folder, so that folder can be deleted (VisualText/visualtext-files#149).

Those insert-block analyzers (Email Addresses, Telephone Numbers, Date and Times, URLs, Address Parser, Paragraphs Sentences) live **only** in `visualtext-files/analyzers`; there is no equivalent flat collection to repoint to, so the command is retired rather than repointed.

## Changes

- **Retire `sequenceView.insertAnalyzerBlock` command** — removes the registration, the `insertAnalyzerBlocks` handler (which scanned `getVisualTextDirectory('analyzers')`), and the `package.json` command + menu contributions.
  - The `insertAnalyzerBlock` **helper is kept** — the New Analyzer multi-select flow (`analyzer.ts`) still calls it with `analyzer-templates`.
- **helpView** — the Claude prompt `{{analyzersDir}}` now points at `getBlockAnalyzersPath()` (the example analyzers under `nlp-engine/analyzers`, i.e. the "Load Example Analyzers" set) instead of the retired folder.
- **analyzer** — drop the New Analyzer fallback to `getVisualTextDirectory('analyzers')`; `analyzer-templates` is the source.

## Verification

- `tsc --noEmit` passes clean.
- No remaining references to `getVisualTextDirectory('analyzers')` or `insertAnalyzerBlocks` in `src/` or `package.json`.
- `package.json` validates as JSON.

## Follow-up

A companion PR on `visualtext-files` deletes the now-unused `analyzers/` folder. Note: `dist/` is not rebuilt in this PR (source only) — bundle before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)