### PR TITLE
fixes: updater analyzer-templates + hier.kb, Python Library menu, numbered-comment reformatting (#1065) — 3.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.30
+Sequence view menu tweak.
+
+- **Sequence view menu**: the **Python Library** pass insert moved into the **Library Pass** submenu (it's a library pass), listed first — just under the "Library Pass" heading — instead of in the new-pass type menu.
+
 ### 3.2.29
 Stop the updater from re-downloading the VisualText files every cycle.
 
 - The VT files existence check still looked for a `visualText/analyzers` folder, but that folder was **renamed to `analyzer-templates`** in the visualtext files. The stale name was never found, so the updater treated the VisualText files as permanently missing and re-downloaded/re-unzipped them on every update check. The check now looks for `analyzer-templates`.
 - The `hier.kb` sync (`checkHierFile`) also pointed at the removed `analyzers/basic` template; it now reads the baseline from the `Bare Minimum` template under `analyzer-templates` (resolved via the installed engine dir), so a stale analyzer's `hier.kb` is refreshed again.
-- **Sequence view menu**: the **Python Library** pass insert moved into the **Library Pass** submenu (it's a library pass), listed first — just under the "Library Pass" heading — instead of in the new-pass type menu.
 
 ### 3.2.28
 Fix the unzip hang on large engine libraries (the real root cause).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 Stop the updater from re-downloading the VisualText files every cycle.
 
 - The VT files existence check still looked for a `visualText/analyzers` folder, but that folder was **renamed to `analyzer-templates`** in the visualtext files. The stale name was never found, so the updater treated the VisualText files as permanently missing and re-downloaded/re-unzipped them on every update check. The check now looks for `analyzer-templates`.
+- The `hier.kb` sync (`checkHierFile`) also pointed at the removed `analyzers/basic` template; it now reads the baseline from the `Bare Minimum` template under `analyzer-templates` (resolved via the installed engine dir), so a stale analyzer's `hier.kb` is refreshed again.
 
 ### 3.2.28
 Fix the unzip hang on large engine libraries (the real root cause).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Stop the updater from re-downloading the VisualText files every cycle.
 
 - The VT files existence check still looked for a `visualText/analyzers` folder, but that folder was **renamed to `analyzer-templates`** in the visualtext files. The stale name was never found, so the updater treated the VisualText files as permanently missing and re-downloaded/re-unzipped them on every update check. The check now looks for `analyzer-templates`.
 - The `hier.kb` sync (`checkHierFile`) also pointed at the removed `analyzers/basic` template; it now reads the baseline from the `Bare Minimum` template under `analyzer-templates` (resolved via the installed engine dir), so a stale analyzer's `hier.kb` is refreshed again.
+- **Sequence view menu**: the **Python Library** pass insert moved into the **Library Pass** submenu (it's a library pass), listed first — just under the "Library Pass" heading — instead of in the new-pass type menu.
 
 ### 3.2.28
 Fix the unzip hang on large engine libraries (the real root cause).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.29
+Stop the updater from re-downloading the VisualText files every cycle.
+
+- The VT files existence check still looked for a `visualText/analyzers` folder, but that folder was **renamed to `analyzer-templates`** in the visualtext files. The stale name was never found, so the updater treated the VisualText files as permanently missing and re-downloaded/re-unzipped them on every update check. The check now looks for `analyzer-templates`.
+
 ### 3.2.28
 Fix the unzip hang on large engine libraries (the real root cause).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.28",
+    "version": "3.2.29",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/package.json
+++ b/package.json
@@ -2459,13 +2459,13 @@
                 {
                     "command": "sequenceView.insertPython",
                     "group": "edit@4"
-                },
-                {
-                    "command": "sequenceView.insertPythonLibrary",
-                    "group": "edit@5"
                 }
             ],
             "librarypass": [
+                {
+                    "command": "sequenceView.insertPythonLibrary",
+                    "group": "edit@0"
+                },
                 {
                     "command": "sequenceView.libraryKBFuncs",
                     "group": "edit@1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.29",
+    "version": "3.2.30",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -318,9 +318,12 @@ export class Analyzer {
         const hierPath = path.join(kbPath.fsPath, "hier.kb");
         if (fs.existsSync(hierPath)) {
             const currHierText = new TextFile(hierPath);
-            visualText.getExtensionDirs();
-            const extPath = visualText.getExtensionPath();
-            const extHierPath = path.join(extPath.fsPath, "nlp-engine", "visualtext", "analyzers", "basic", "kb", "user", "hier.kb");
+            // The 'basic' analyzer was replaced by the 'Bare Minimum' template
+            // (which carries the same baseline hier.kb shared by most templates)
+            // under analyzer-templates. Resolve via the installed engine dir
+            // rather than getExtensionPath(), which can point at a different
+            // installed version when several are present.
+            const extHierPath = path.join(visualText.getVisualTextDirectory("analyzer-templates"), "Bare Minimum", "kb", "user", "hier.kb");
             if (fs.existsSync(extHierPath)) {
                 const basicHierText = new TextFile(extHierPath);
                 if (basicHierText.getText() != currHierText.getText()) {

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -378,7 +378,10 @@ export class VisualText {
                 visualText.zipFiles(op, visualText.NLPENGINE_REPO, '', visualText.NLPENGINE_COMPILE_FILES_ASSET, ['include', 'lib']);
                 break;
             case upComp.VT_FILES:
-                visualText.zipFiles(op, visualText.VISUALTEXT_FILES_REPO, 'visualText', visualText.VISUALTEXT_FILES_ASSET, [visualText.ANALYZER_SEQUENCE_FOLDER, 'Help', 'analyzers']);
+                // 'analyzer-templates' replaced the old 'analyzers' folder in the
+                // visualtext.zip; checking the stale name made VT_FILES look
+                // permanently missing, so the updater re-downloaded it every cycle.
+                visualText.zipFiles(op, visualText.VISUALTEXT_FILES_REPO, 'visualText', visualText.VISUALTEXT_FILES_ASSET, [visualText.ANALYZER_SEQUENCE_FOLDER, 'Help', 'analyzer-templates']);
                 break;
             case upComp.ANALYZER_FILES:
                 visualText.zipFiles(op, visualText.ANALYZERS_REPO, 'analyzers', visualText.ANALYZERS_ASSET, ['']);


### PR DESCRIPTION
## Summary

Fixes the updater **constantly re-downloading the VisualText files** even when they're up to date, plus the related stale `hier.kb` sync. Both stem from the `analyzers` → `analyzer-templates` rename in the visualtext files. Ships as **3.2.29**.

## Fixes

**1. Constant VT_FILES re-download.** ([visualText.ts:384](src/visualText.ts#L384))
The `VT_FILES` existence check verified `[spec, Help, analyzers]`, but `analyzers` was renamed to `analyzer-templates`. The old folder no longer exists, so the check reported the VisualText files as missing every cycle → download → unzip → repeat. Now checks `analyzer-templates`.

**2. `hier.kb` sync pointed at the removed `basic` analyzer.** ([analyzer.ts:323](src/analyzer.ts#L323))
`checkHierFile` read its baseline from `nlp-engine/visualtext/analyzers/basic/kb/user/hier.kb`, which no longer exists — so it silently stopped refreshing a stale analyzer's `hier.kb`. It now reads from the **`Bare Minimum`** template under `analyzer-templates` (the same baseline `hier.kb` shared by 9 of the templates), resolved via the installed engine dir instead of `getExtensionPath()` (which can point at a different installed version).

The rest of the extension already used `analyzer-templates` ([analyzer.ts:144](src/analyzer.ts#L144), [helpView.ts:275](src/helpView.ts#L275)); these were the two stale references left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
