### PR TITLE
feat: move Insert Python Library Pass Before Tokenizer just after Library pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 Fix rule reformatting of numbered comments that carry annotations.
 
 - Reformatting a rule whose element comments include an annotation after the node number — e.g. `_amount ### (2) beginning of year` — no longer keeps the old number in the comment and append a second one (`### (2) beginning of year (2)`). The reformatter now recognizes the auto-generated `(N)` whether it was written just after `###` (number-first) or at the end (number-last), strips it, and re-emits the comment as `### (N) annotation`, preserving the user's text. A parenthesized number in the *middle* of an annotation (e.g. `### see rule (3) for details`) is left untouched. ([#1065](https://github.com/VisualText/vscode-nlp/issues/1065))
+- **Sequence view menu**: **Insert Python Library Pass Before Tokenizer** moved up to just after the **Library Pass** submenu (it previously sat down in the tokenize group). It still appears only when right-clicking a tokenizer pass.
 
 ### 3.2.30
 Sequence view menu tweak.

--- a/package.json
+++ b/package.json
@@ -2637,19 +2637,24 @@
                     "group": "atop@1"
                 },
                 {
-                    "command": "sequenceView.insert",
-                    "when": "view == sequenceView",
+                    "command": "sequenceView.insertPythonLibraryBeforeTokenize",
+                    "when": "view == sequenceView && viewItem =~ /.*tokenize.*/",
                     "group": "atop@2"
                 },
                 {
-                    "command": "sequenceView.insertSister",
+                    "command": "sequenceView.insert",
                     "when": "view == sequenceView",
                     "group": "atop@3"
                 },
                 {
-                    "command": "sequenceView.insertOrphan",
+                    "command": "sequenceView.insertSister",
                     "when": "view == sequenceView",
                     "group": "atop@4"
+                },
+                {
+                    "command": "sequenceView.insertOrphan",
+                    "when": "view == sequenceView",
+                    "group": "atop@5"
                 },
                 {
                     "command": "sequenceView.newFolder",
@@ -2715,11 +2720,6 @@
                     "command": "sequenceView.insertPythonBeforeTokenize",
                     "when": "view == sequenceView && viewItem =~ /.*tokenize.*/",
                     "group": "tokenize@0"
-                },
-                {
-                    "command": "sequenceView.insertPythonLibraryBeforeTokenize",
-                    "when": "view == sequenceView && viewItem =~ /.*tokenize.*/",
-                    "group": "tokenize@1"
                 },
                 {
                     "command": "sequenceView.tokenize",


### PR DESCRIPTION
The command sat down in the tokenize group of the sequence-view context menu. Move it up to atop@2 -- immediately after the Library Pass submenu -- and renumber the following items. It keeps its tokenize-pass when-clause, so it still only appears when right-clicking a tokenizer pass.