### PR TITLE
fix: strip glued/duplicated node numbers when reformatting comments (#1077, 3.2.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.2.32
+Fix rule reformatting leaving a doubled node number in the comment.
+
+- Reformatting a comment where a node number was glued to the annotation — e.g. `_word ### (2) (2)moose and stuff` (or `### (2)moose and stuff`) — now strips the whole leading run of `(N)` (spaced or glued to the following word) and produces `### (2) moose and stuff`, instead of keeping the extra number. A parenthesized number in the *middle* of an annotation (e.g. `### see rule (3) here`) is still preserved. ([#1077](https://github.com/VisualText/vscode-nlp/issues/1077))
+
 ### 3.2.31
 Fix rule reformatting of numbered comments that carry annotations.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.2.31",
+    "version": "3.2.32",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -852,11 +852,12 @@ export class NLPFile extends TextFile {
 	constructLine(rules, words: string[], type: reformatType) {
 		// Pull the user's annotation out of the trailing comment (the tokens
 		// after the first '#'-prefixed token), dropping the auto-generated node
-		// number '(N)' whether it was written right after '###'
-		// (e.g. "### (2) beginning of year") or at the end (e.g. "### note (2)").
-		// Previously only a trailing '(N)' was stripped, so a leading one stayed
-		// in the comment and a second number got appended on reformat. (#1065)
-		const isNodeNum = (w: string) => /^\(\d+\)$/.test(w);
+		// number. The reformatter emits it number-first ("### (N) note"), so we
+		// strip a leading run of "(N)" -- whether spaced OR glued to the next
+		// word, e.g. "(2) (2)moose and stuff" -> "moose and stuff" -- plus a
+		// single trailing "(N)" left over from the old number-last style. A "(N)"
+		// in the middle of the annotation is the user's text and is kept.
+		// (#1065, #1077)
 		let commentStart = words.length;   // index of the '#'-token, or words.length if none
 		for (let i = words.length - 1; i >= 0; i--) {
 			if (words[i].startsWith('#')) {
@@ -866,12 +867,10 @@ export class NLPFile extends TextFile {
 		}
 		let userComment = '';
 		if (commentStart < words.length) {
-			const commentWords = words.slice(commentStart + 1);
-			if (commentWords.length && isNodeNum(commentWords[0]))
-				commentWords.shift();
-			else if (commentWords.length && isNodeNum(commentWords[commentWords.length - 1]))
-				commentWords.pop();
-			userComment = commentWords.join(' ');
+			userComment = words.slice(commentStart + 1).join(' ')
+				.replace(/^(?:\(\d+\)\s*)+/, '')
+				.replace(/\s*\(\d+\)\s*$/, '')
+				.trim();
 		}
 		let word = '';  // Declare word here
 


### PR DESCRIPTION
## Summary

Fixes [#1077](https://github.com/VisualText/vscode-nlp/issues/1077): reformatting a rule comment that has a node number **glued to the annotation** left a doubled number. Follow-up to #1065. Ships as **3.2.32**.

## The bug

`### (2) (2)moose and stuff` — the second `(2)` is glued to `moose` (`(2)moose`), so it isn't a clean `(N)` token. The #1065 fix only stripped one clean leading token, so `(2)moose and stuff` survived as the comment and reformatting re-emitted `### (2) (2)moose and stuff`. Same for input `### (2)moose and stuff`.

## The fix

`constructLine` now cleans the comment string instead of matching single tokens:
- strip a **leading run** of `(N)` — spaced **or** glued to the following word (`^(?:\(\d+\)\s*)+`),
- strip a single **trailing** `(N)` (old number-last style),
- keep a `(N)` in the **middle** of the annotation (it's the user's text).

## Verified

Ran the full `formatRule` against the issue example and edge cases:
- `### (2) (2)moose and stuff` → `### (2) moose and stuff`; idempotent; no doubled number.
- `### (2)moose and stuff` (glued, single) → `### (N) moose and stuff`.
- `### see rule (3) here` → `(3)` preserved.
- All #1065 cases still pass (`### (2) beginning of year`, number-last, plain `### (N)`).

## Note on the `@RULES` leading space

The issue's "after" shows a space before `@RULES`. `reformatRule` replaces only the range from the `<-` line to `@@` ([findRuleText](src/nlp.ts#L602)), so it never touches the `@RULES` line — that space appears to be a copy/paste artifact, not something the reformat produces. If it's reproducible, let me know and I'll dig in separately.

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
