### PR TITLE
feat: deploy a stand-alone compiled analyzer to a separate folder (3.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.4.3
+Deploy a stand-alone compiled analyzer to a separate folder.
+
+- New "Deploy Compiled Analyzer to Folder" command exports a runnable, stripped compiled analyzer: `bin/{run,runu,kb,kbu}` (the compiled library) plus only the lazy `*full.dict`/`*full.kbb` files, with `spec/`, `input/`, and the non-full `.kb`/`.dict` sources omitted. Requires a prior "Compile Analyzer and KB" and an engine that opens the lazy full files when the KB is compiled.
+
 ### 3.4.2
 Show each lazy-loaded KB and dictionary file in the analyzer log.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.4.2",
+    "version": "3.4.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.4.2",
+            "version": "3.4.3",
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.4.2",
+    "version": "3.4.3",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {

--- a/package.json
+++ b/package.json
@@ -1788,6 +1788,14 @@
                 }
             },
             {
+                "command": "analyzerView.deployCompiledAnalyzer",
+                "title": "Deploy Compiled Analyzer to Folder",
+                "icon": {
+                    "light": "resources/light/run.svg",
+                    "dark": "resources/dark/run.svg"
+                }
+            },
+            {
                 "command": "analyzerView.runRegressionTest",
                 "title": "Run Regression Test (All Files)",
                 "icon": "$(beaker)"
@@ -2435,6 +2443,11 @@
                 },
                 {
                     "command": "analyzerView.compileAnalyzerOnly",
+                    "when": "view == analyzerView",
+                    "group": "secondary"
+                },
+                {
+                    "command": "analyzerView.deployCompiledAnalyzer",
                     "when": "view == analyzerView",
                     "group": "secondary"
                 },
@@ -3239,6 +3252,11 @@
                 },
                 {
                     "command": "analyzerView.compileAnalyzerOnly",
+                    "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
+                    "group": "compile"
+                },
+                {
+                    "command": "analyzerView.deployCompiledAnalyzer",
                     "when": "view == analyzerView && viewItem =~ /.*isAnalyzer.*/",
                     "group": "compile"
                 },

--- a/src/analyzerView.ts
+++ b/src/analyzerView.ts
@@ -219,6 +219,7 @@ export class AnalyzerView {
 		vscode.commands.registerCommand('analyzerView.copyPath', () => this.copyPath());
 		vscode.commands.registerCommand('analyzerView.compileAnalyzer', resource => this.compileAnalyzer(resource));
 		vscode.commands.registerCommand('analyzerView.compileAnalyzerOnly', resource => this.compileAnalyzerOnly(resource));
+		vscode.commands.registerCommand('analyzerView.deployCompiledAnalyzer', resource => this.deployCompiledAnalyzer(resource));
 		vscode.commands.registerCommand('analyzerView.runRegressionTest', resource => this.runRegressionTest(resource));
 		vscode.commands.registerCommand('analyzerView.blessRegression', resource => this.blessRegression(resource));
 
@@ -788,6 +789,20 @@ export class AnalyzerView {
 		}
 		const compile = NLPCompile.attach();
 		await compile.compileAnalyzerOnly(analyzerDir);
+	}
+
+	async deployCompiledAnalyzer(analyzerItem: AnalyzerItem) {
+		let analyzerDir: vscode.Uri;
+		if (analyzerItem && analyzerItem.uri) {
+			analyzerDir = dirfuncs.isDir(analyzerItem.uri.fsPath) ? analyzerItem.uri : vscode.Uri.file(path.dirname(analyzerItem.uri.fsPath));
+		} else if (visualText.analyzer.isLoaded()) {
+			analyzerDir = visualText.analyzer.getAnalyzerDirectory();
+		} else {
+			vscode.window.showWarningMessage('No analyzer loaded. Open an analyzer first.');
+			return;
+		}
+		const compile = NLPCompile.attach();
+		await compile.deployCompiledAnalyzer(analyzerDir);
 	}
 
 	// Run the cross-platform golden-file regression tester (nlp_regress.py, shipped

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -60,6 +60,121 @@ export class NLPCompile {
         await this.runCompile(analyzerDir, compileTarget.ANALYZER_ONLY);
     }
 
+    // Export a stand-alone, runnable compiled analyzer into a separate folder.
+    // The result contains ONLY the compiled library (staged under bin/ as the
+    // run/kb entry points the engine loads) and the lazy "*full.dict"/"*full.kbb"
+    // files, which cannot be compiled and must remain on disk for stream lookup.
+    // Everything else — spec/*.nlp, input/, and the non-full .kb/.dict sources
+    // (now baked into the library) — is deliberately left out, so the shipped
+    // folder exposes only the full files.
+    async deployCompiledAnalyzer(analyzerDir: vscode.Uri): Promise<void> {
+        const anapath = analyzerDir.fsPath;
+        const analyzerName = path.basename(anapath.replace(/[\\/]+$/, ''));
+        const ext = this.sharedLibraryExt();
+
+        // The "Compile Analyzer and KB" target produces <analyzerName><ext>, a single
+        // library exporting both run_analyzer and kb_setup. That combined lib is what a
+        // fully-compiled (analyzer + KB) deployment needs, so require it here.
+        const compiledLib = path.join(anapath, `${analyzerName}${ext}`);
+        if (!fs.existsSync(compiledLib)) {
+            const choice = await vscode.window.showErrorMessage(
+                `No compiled library found (${analyzerName}${ext}). Run "Compile Analyzer and KB to C++ Library" first, then deploy.`,
+                'Compile Analyzer and KB'
+            );
+            if (choice === 'Compile Analyzer and KB') {
+                await this.compileAnalyzer(analyzerDir);
+            }
+            return;
+        }
+
+        // The lazy files are the only data that must ship alongside the library.
+        const kbUserDir = path.join(anapath, 'kb', 'user');
+        const fullFiles = this.findFullKBFiles(kbUserDir);
+
+        // Ask where to write the deployment. Pick a parent directory; the analyzer
+        // folder is created (or replaced) inside it.
+        const picked = await vscode.window.showOpenDialog({
+            canSelectFolders: true,
+            canSelectFiles: false,
+            canSelectMany: false,
+            openLabel: 'Select deployment location',
+            title: `Deploy compiled analyzer "${analyzerName}" into…`
+        });
+        if (!picked || picked.length === 0) {
+            return;
+        }
+        const destParent = picked[0].fsPath;
+        const destDir = path.join(destParent, analyzerName);
+
+        if (path.resolve(destDir) === path.resolve(anapath)) {
+            vscode.window.showErrorMessage('Deployment target cannot be the analyzer folder itself. Choose a different location.');
+            return;
+        }
+
+        if (fs.existsSync(destDir)) {
+            const overwrite = await vscode.window.showWarningMessage(
+                `"${destDir}" already exists. Replace it?`,
+                { modal: true },
+                'Replace'
+            );
+            if (overwrite !== 'Replace') {
+                return;
+            }
+            try {
+                fs.rmSync(destDir, { recursive: true, force: true });
+            } catch (err: any) {
+                vscode.window.showErrorMessage(`Could not remove existing folder: ${err?.message ?? err}`);
+                return;
+            }
+        }
+
+        try {
+            // bin/ — the engine loads <appdir>/bin/run<ext> (analyzer body, via -COMPILED)
+            // and <appdir>/bin/kb<ext> (compiled KB, auto-detected). The combined library
+            // exports both entry points, so it is copied to every name the engine may look
+            // up. This mirrors nlp.ts stageCompiledAnalyzer() for RunMode.COMPILED.
+            const binDir = path.join(destDir, 'bin');
+            fs.mkdirSync(binDir, { recursive: true });
+            for (const name of ['run', 'runu', 'kb', 'kbu']) {
+                fs.copyFileSync(compiledLib, path.join(binDir, `${name}${ext}`));
+            }
+
+            // kb/user/ — only the lazy full files. openFullFiles() in the engine scans
+            // this directory when the compiled KB is loaded and stream-searches them.
+            const destKbUser = path.join(destDir, 'kb', 'user');
+            fs.mkdirSync(destKbUser, { recursive: true });
+            for (const f of fullFiles) {
+                fs.copyFileSync(f, path.join(destKbUser, path.basename(f)));
+            }
+
+            // Runtime working directories the engine writes into.
+            for (const d of ['input', 'output', 'logs', 'tmp']) {
+                fs.mkdirSync(path.join(destDir, d), { recursive: true });
+            }
+
+            const fullMsg = fullFiles.length
+                ? `${fullFiles.length} lazy file(s): ${fullFiles.map(f => path.basename(f)).join(', ')}`
+                : 'no *full.dict/*full.kbb files found (KB is fully compiled into the library)';
+            logView.addMessage(
+                `Deployed compiled analyzer to ${destDir} (bin/${['run', 'runu', 'kb', 'kbu'].map(n => n + ext).join(', ')}; ${fullMsg}).`,
+                logLineType.ANALYER_OUTPUT,
+                analyzerDir
+            );
+            vscode.window.showInformationMessage(
+                `Deployed compiled analyzer "${analyzerName}". Run it with: nlp.exe -ANA "${destDir}" -WORK "<engine>" -COMPILED "<input>". Requires an installed NLP engine (nlp.exe + its data/rfb).`,
+                'Reveal in Explorer'
+            ).then(choice => {
+                if (choice === 'Reveal in Explorer') {
+                    vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(destDir));
+                }
+            });
+        } catch (err: any) {
+            const detail = err?.message ?? String(err);
+            logView.addMessage(`Deploy failed: ${detail}`, logLineType.ANALYER_OUTPUT, analyzerDir);
+            vscode.window.showErrorMessage(`Deploy compiled analyzer failed: ${detail}`);
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // Core compile flow
     // ---------------------------------------------------------------------------
@@ -1052,14 +1167,39 @@ endif()
     // ---------------------------------------------------------------------------
 
     sharedLibraryName(analyzerName: string): string {
+        return analyzerName + this.sharedLibraryExt();
+    }
+
+    private sharedLibraryExt(): string {
         const platform = os.platform();
-        if (platform === 'win32') {
-            return analyzerName + '.dll';
-        } else if (platform === 'darwin') {
-            return analyzerName + '.dylib';
-        } else {
-            return analyzerName + '.so';
+        if (platform === 'win32') return '.dll';
+        if (platform === 'darwin') return '.dylib';
+        return '.so';
+    }
+
+    // Lazy "*full.dict"/"*full.kbb" files under kb/user — the only KB data that
+    // survives compilation and must ship with a deployed compiled analyzer. Mirrors
+    // the engine's CG::stemEndsWithFull ("-full"/"_full" boundary, case-insensitive).
+    private findFullKBFiles(kbUserDir: string): string[] {
+        if (!fs.existsSync(kbUserDir) || !fs.statSync(kbUserDir).isDirectory()) {
+            return [];
         }
+        return fs.readdirSync(kbUserDir)
+            .filter(file => {
+                const lower = file.toLowerCase();
+                if (!lower.endsWith('.dict') && !lower.endsWith('.kbb')) return false;
+                const stem = file.substring(0, file.lastIndexOf('.'));
+                return this.stemEndsWithFull(stem);
+            })
+            .map(file => path.join(kbUserDir, file));
+    }
+
+    private stemEndsWithFull(stem: string): boolean {
+        const lower = stem.toLowerCase();
+        if (!lower.endsWith('full')) return false;
+        if (lower.length === 4) return true; // exactly "full"
+        const before = lower.charAt(lower.length - 5);
+        return before === '-' || before === '_';
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds **"Deploy Compiled Analyzer to Folder"** (`analyzerView.deployCompiledAnalyzer`) — exports a runnable, stripped compiled analyzer into a chosen folder that exposes only the lazy full files.

```
<dest>/<analyzer>/
  bin/{run,runu,kb,kbu}<ext>   # the combined <analyzer><ext> library, staged under every entry-point name the engine loads
  kb/user/*full.dict,*full.kbb # the only visible data (cannot be compiled; the engine stream-searches them on disk)
  input/ output/ logs/ tmp/    # empty runtime dirs
```

`spec/*.nlp`, `input/`, and the non-full `.kb`/`.dict` sources (now baked into the library) are deliberately omitted, so the shipped folder exposes **only** the full files.

## Details

- The `bin/` staging mirrors `nlp.ts` `stageCompiledAnalyzer()` for `RunMode.COMPILED`, so a deployed folder runs identically to an in-place compiled run: `nlp.exe -ANA <folder> -WORK <engine> -COMPILED <input>`.
- Requires a prior **"Compile Analyzer and KB"** (`<analyzer><ext>`, which exports both `run_analyzer` and `kb_setup`).
- Only `*full.dict`/`*full.kbb` are copied, via a TS mirror of the engine's `stemEndsWithFull` boundary rule.
- Prompts for a destination, refuses to target the analyzer folder itself, and confirms before replacing.

Wired into the analyzer view-title and item-context menus (`compile` group). Bumps the extension to **3.4.3**.

## Depends on

Engine support: VisualText/nlp-engine#693 (engine ≥ 3.7.9) — compiled-KB analyzers must open the lazy `*full.*` files so the deployed folder resolves words. Verified end-to-end in that PR.

## Verification

`tsc --noEmit` passes; `package.json` parses. The command itself has not yet been driven through a live extension host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)