### PR TITLE
release: 3.11.4 — version alignment (no functional change from 3.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.11.4
+Version alignment — no functional changes from 3.11.3.
+
+- Republishes the 3.11.3 parse-tree graphic improvements under a fresh version number so the Marketplace and repository stay in sync after a publishing mix-up. See 3.11.3 below for the feature list.
+
 ### 3.11.3
 Parse-tree graphic: instant opening, global menu, and horizontal spacing control.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.11.3",
+    "version": "3.11.4",
     "publisher": "dehilster",
     "enableApiProposals": false,
     "engines": {


### PR DESCRIPTION
## Version alignment: 3.11.3 → 3.11.4

The Marketplace already had a **3.11.3** build, so republishing requires a fresh version number (Marketplace versions can't be overwritten). This bumps to **3.11.4** with the **same parse-tree graphic code as 3.11.3** (instant open, global right-click menu, spacing control + Shift+scroll, staggered leaves).

No functional changes; `dist` is byte-identical to 3.11.3, so only `package.json` and `CHANGELOG.md` change. After merge/tag, the 3.11.4 vsix will be uploaded to supersede the Marketplace 3.11.3 so repo, tag, and Marketplace all align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
