### PR TITLE
Ship only the webpack bundle, not stale tsc output (3.11.14)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,6 +21,11 @@ telemetry-worker/**
 # Formatter test-harness build output (npm run test:format) - never shipped
 out-format/**
 
+# Webpack output: ship the bundle only. `tsc` (npm run compile) also emits per-module
+# .js/.js.map here, and without this every one of them would be packaged - dead code,
+# since package.json main points at dist/extension.js. Re-included below.
+dist/**
+
 # Build artifacts we don't need
 *.vsix
 .vscode/**
@@ -47,6 +52,7 @@ test/**
 # Keep only what's needed for the extension
 !dist/extension.js
 !dist/extension.js.map
+!dist/extension.js.LICENSE.txt
 !resources/**
 !snippets/**
 !grammars/syntaxes/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.11.14
+Syntax highlighting fixes, and the grammars now live in their own repository.
+
+- **Operators colorize at last.** `>`, `<`, `=`, `<>`, `&&`, `||`, `++`, `--`, `==`, `!=`, `<=` and `>=` were all wrapped in word-boundary anchors that punctuation can never satisfy, so not one of them was ever highlighted. `<>` was also ordered after `<` and could never match as a single token, and `++`, `--`, `&&` and `||` were missing from the rule entirely.
+- **`_xWILD`, `_xNUM`, `_xWHITE` and the rest colorize as constants** inside `@RULES` regions instead of as ordinary tokens. The constant rule existed but was losing a tie to the general token rule and never won.
+- A number at the very first character of a file now colorizes.
+- The TextMate grammars moved to [VisualText/nlpplus-tmbundle](https://github.com/VisualText/nlpplus-tmbundle) and are pulled in here as a submodule, so GitHub, Shiki, `bat` and other tools can colorize NLP++ using exactly the grammars this extension ships. Contributors should clone with `--recurse-submodules`.
+- Smaller download — the package no longer carries per-module `tsc` output and source maps that were never loaded.
+
 ### 3.11.13
 LLM prompts can point at the help files.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.11.13",
+    "version": "3.11.14",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
## The bug

`.vscodeignore` carried these lines under *"Keep only what's needed for the extension"*:

```
!dist/extension.js
!dist/extension.js.map
```

They read as if `dist/` were excluded and these two were being rescued. But there was no
`dist/**` pattern anywhere in the file, so both negations were no-ops and the entire
directory was packaged.

Every published vsix has been shipping **51 files from `dist/`** — per-module `tsc` output
(`analyzer.js`, `fileOps.js`, `command.js`, `findView.js`, …) plus roughly twenty `.js.map`
files. None of it is ever loaded: `main` points at `./dist/extension.js`, the webpack bundle.
It is dead weight going out to 6,314 installs, and it varies with whatever `npm run compile`
last left in the working tree.

## The fix

Add `dist/**`, then re-include the three files that belong — the bundle, its source map, and
the webpack-generated LICENSE banner.

## Verification

`vsce ls`, before and after:

| | before | after |
|---|---|---|
| files under `dist/` | 51 | 3 |
| files in package | 256 | 208 |
| vsix size | 3,101,478 B | 2,982,230 B |

119 KB smaller (3.8%). Unzipped the built vsix to confirm `dist/` contains exactly
`extension.js`, `extension.js.map` and `extension.js.LICENSE.txt`, and that the `main` entry
resolves. All 7 grammars still ship.

## Also in this PR

Cuts **3.11.14**. The changelog entry covers this packaging fix plus the grammar scoping
fixes that landed with the submodule move in #1114 but were never released — operators never
colorized at all, and the `_xWILD` family was losing a tie to the general token rule inside
`@RULES` regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)