### PR TITLE
Style the two scopes the 3.11.14 grammar fixes changed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,22 @@
                     }
                 },
                 {
+                    "scope": "keyword.constants.nlp",
+                    "settings": {
+                        "foreground": "#0a7b83",
+                        "fontStyle": "bold"
+                    }
+                },
+                {
+                    "scope": [
+                        "keyword.operator.nlp",
+                        "keyword.operator.word.nlp"
+                    ],
+                    "settings": {
+                        "foreground": "#1f6feb"
+                    }
+                },
+                {
                     "scope": "constant.numeric.tree",
                     "settings": {
                         "foreground": "#5596f0"
@@ -137,6 +153,22 @@
                     "scope": "keyword.attribute.nlp",
                     "settings": {
                         "foreground": "#f293fb"
+                    }
+                },
+                {
+                    "scope": "keyword.constants.nlp",
+                    "settings": {
+                        "foreground": "#4ec9b0",
+                        "fontStyle": "bold"
+                    }
+                },
+                {
+                    "scope": [
+                        "keyword.operator.nlp",
+                        "keyword.operator.word.nlp"
+                    ],
+                    "settings": {
+                        "foreground": "#8ab4f8"
                     }
                 },
                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Syntax highlighting fixes, and the grammars now live in their own repository.
 - **Operators colorize at last.** `>`, `<`, `=`, `<>`, `&&`, `||`, `++`, `--`, `==`, `!=`, `<=` and `>=` were all wrapped in word-boundary anchors that punctuation can never satisfy, so not one of them was ever highlighted. `<>` was also ordered after `<` and could never match as a single token, and `++`, `--`, `&&` and `||` were missing from the rule entirely.
 - **`_xWILD`, `_xNUM`, `_xWHITE` and the rest colorize as constants** inside `@RULES` regions instead of as ordinary tokens. The constant rule existed but was losing a tie to the general token rule and never won.
 - A number at the very first character of a file now colorizes.
+- The **Colorize Analyzer** template gives wildcard nodes and operators explicit colors in both light and dark themes — teal for `_xWILD` and friends, blue for operators — rather than leaving the two newly-fixed scopes to whatever the active theme happens to do with them.
 - The TextMate grammars moved to [VisualText/nlpplus-tmbundle](https://github.com/VisualText/nlpplus-tmbundle) and are pulled in here as a submodule, so GitHub, Shiki, `bat` and other tools can colorize NLP++ using exactly the grammars this extension ships. Contributors should clone with `--recurse-submodules`.
 - Smaller download — the package no longer carries per-module `tsc` output and source maps that were never loaded.
 


### PR DESCRIPTION
## Why

`.vscode/settings.json` — the template `colorizeAnalyzer()` copies into every workspace —
hardcodes explicit NLP++ scopes, and covered only four:

```
entity.name.function.letter.nlp
entity.name.function.nlp
keyword.attribute.nlp
variable.parameter.nlp
```

Neither scope changed by the 3.11.14 grammar fixes was in that list.

This mattered most for the wildcard nodes. `_xWILD`, `_xNUM` and `_xWHITE` used to be
`variable.parameter.nlp` — styled, grey/yellow bold — and are now correctly
`keyword.constants.nlp`, which the template did not mention. In template-using workspaces
they would fall back to whatever the active theme does with a bare `keyword` selector, which
in some themes is nothing at all. A fix that makes them *more* semantically correct would
have made them *less* visible.

## What changed

Adds to both the light and dark sections:

| scope | light | dark |
|---|---|---|
| `keyword.constants.nlp` | `#0a7b83` bold | `#4ec9b0` bold |
| `keyword.operator.nlp`, `keyword.operator.word.nlp` | `#1f6feb` | `#8ab4f8` |

The operator rule names both scopes explicitly. Scope selectors match on whole
dot-separated components, so a `keyword.operator.nlp` selector does **not** match
`keyword.operator.word.nlp` — listing only the first would leave `and`/`or`/`not`/`in`
unstyled.

## Verification

Tokenized `parse-en-us/spec` (141 files) with the shipped grammar via `vscode-textmate`,
collected every scope it emits, and applied VS Code's selector-matching rule against the
template:

```
STYLED   keyword.constants.nlp     32,080 chars  <- "keyword.constants.nlp"
STYLED   keyword.operator.nlp      16,319 chars  <- "keyword.operator.nlp"
```

Both now covered in light and dark. No version bump — 3.11.14 has not been published yet, so
this folds into that release, and the changelog entry gained a line for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)