### PR TITLE
Pick up grammar operator and bracket fixes (3.11.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.11.15
+More highlighting gaps closed, found by building a second colorizer.
+
+- **`!` now colorizes.** The operator rule had `!=` but not bare `!`, so the logical not in `if (!L("con"))` was uncolored everywhere — 2,620 occurrences in the English parser alone. `<<` and `>>` were missing too, which is what `cout` and file output use constantly.
+- **Array subscripts colorize.** Square brackets are a rule element's modifier block inside `@RULES`, but an array subscript in code, and the two go through different parts of the grammar. Function calls and operators inside a subscript — `L("arr")[L("i") + 1]` — were being left plain.
+- **Rule attributes like `[min=0 max=2]`** now colorize their `=` and their numbers, the way the `match=(...)` form always did.
+
+These surfaced while writing an NLP++ lexer for [Pygments](https://pygments.org), which powers highlighting on Wikipedia, Sphinx, Jupyter and LaTeX. A TextMate grammar never complains about text it can't match, so the gaps had been invisible for years; Pygments flags every unmatched character, which made them impossible to miss.
+
 ### 3.11.14
 Syntax highlighting fixes, and the grammars now live in their own repository.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.11.14",
+    "version": "3.11.15",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
Bumps the `grammars` submodule to [`ab5328e`](https://github.com/VisualText/nlpplus-tmbundle/commit/ab5328e).

## Where these came from

Writing the NLP++ lexer for [Pygments](https://github.com/pygments/pygments/pull/3238)
surfaced constructs this grammar had been silently leaving unstyled for years. A TextMate
grammar never complains about text it cannot match — it just renders it plain. Pygments
emits an `Error` token for every unmatched character, so running it over 7.8M characters of
real NLP++ made the gaps impossible to miss, and the same gaps turned out to exist here.

## What was wrong

| gap | effect |
|---|---|
| operator rule had `!=` but not bare `!` | the logical not in `if (!L("con"))` was uncolored — **2,620 occurrences** in parse-en-us alone |
| `<<` and `>>` missing entirely | `cout << "x"` and `"out.txt" << N("$text")` uncolored |
| `array-literal` state included only `#expression` | function calls and operators inside a subscript — `L("arr")[L("i") + 1]` — left plain |
| rule attribute blocks had no operator or numeric rules | `[min=0 max=2]` colorized less than the `match=(...)` form |

The bracket one is the interesting case: `[` opens a rule element's modifier block inside
`@RULES`, but an array subscript in code, and those are handled by two different states. Only
one of them was equipped for expressions.

The fix extracts `#operators` and `#function-call` into the repository so the same rules
serve the top level, rule attributes and array subscripts, rather than being duplicated in
one place and absent from the others.

## Verification

`vscode-textmate` over 141 parse-en-us spec files, diffing scope-per-character:

```
2,794 chars rescoped (0.25%)
  2620  unscoped               -> keyword.operator.nlp          "!"
   102  meta.array.literal     -> entity.name.function.letter   "L" "G" "X"
    56  meta.rules.attribute   -> keyword.operator.nlp          "="
    11  meta.rules.attribute   -> constant.numeric.nlp          digits
     5  meta.array.literal     -> keyword.operator.nlp          "+"
```

All five transitions intended, no scope lost. `npm run check-grammars` passes against the
new pointer.

Cuts **3.11.15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)