### PR TITLE
docs: open the README screenshot full size on click (3.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.2
+The screenshot at the top of the README opens full size.
+
+- The new hero screenshot shows six panels at once, which makes it small enough that the parse tree and the knowledge-base output can't be read at the width a README renders at. **Clicking it now opens the full-size image**, on both GitHub and the Marketplace, rather than doing nothing.
+
 ### 3.12.1
 The README describes the extension as it exists today.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Build, debug, and ship **glass-box** text analyzers in Visual Studio Code.
 
-![The NLP++ extension in VS Code: analyzer sequence, source text, parse tree graphic, dictionaries, knowledge-base output, and the run log](resources/VSCodeNLP.png)
+[![The NLP++ extension in VS Code: analyzer sequence, source text, parse tree graphic, dictionaries, knowledge-base output, and the run log](resources/VSCodeNLP.png)](https://raw.githubusercontent.com/VisualText/vscode-nlp/master/resources/VSCodeNLP.png)
+
+<sub>*Click the screenshot for a full-size view.*</sub>
 
 [NLP++](https://visualtext.org/nlp/) is the only programming language built exclusively for text and natural language processing. This extension brings the full [VisualText](http://visualtext.org) development environment — which ran on Windows for two decades — into VS Code on **Windows, Linux, and macOS**, and bundles the NLP-ENGINE that runs it. Build up a parse tree, consult your dictionaries and knowledge bases, watch every rule fire, then compile the whole analyzer to a native library you can ship.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.1",
+    "version": "3.12.2",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
The hero screenshot shows six panels at once, so at the width a README renders at, the parse tree and the knowledge-base output are too small to read. The image wasn't wrapped in a link, so clicking it did nothing.

It now links to the full-size PNG on `raw.githubusercontent`, which works on both GitHub and the Marketplace — the same absolute-URL pattern the textbook banner already uses, rather than a relative path that `vsce` would rewrite to a blob page.

Follow-up to #1121. Docs and version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)