### PR TITLE
feat: standard language configuration for NLP++ files (3.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.3
+Standard editor behaviors for NLP++ files (language configuration).
+
+- **Word selection** (`wordPattern`) — `_noun`, `_ROOT`, and `$var` now select, rename, and find-references as a single word instead of splitting on `_`/`$`.
+- **Auto-indent** (`indentationRules`) — code indents inside `{ }` / `( )` and after `@CODE`/`@DECL`/`@PRE`/`@POST`/`@CHECK`, and outdents on `}` / `)` / `@@`.
+- **On-Enter rules** — `#` line comments continue on Enter; braces open with smart indentation; and C-style `/* */` block comments continue with ` * `.
+- **Block-comment toggling** (`Shift+Alt+A`) — enabled via `blockComment`. Note: this depends on `/* */` support landing in the NLP++ engine; hold the Marketplace publish until the engine ships it.
+
 ### 3.12.2
 The screenshot at the top of the README opens full size.
 

--- a/nlp-configuration.json
+++ b/nlp-configuration.json
@@ -1,6 +1,7 @@
 {
     "comments": {
-		"lineComment": "#"
+		"lineComment": "#",
+		"blockComment": ["/*", "*/"]
 	},
     "brackets": [
         ["{", "}"],
@@ -23,5 +24,42 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"]
+    ],
+    "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
+    "indentationRules": {
+        "increaseIndentPattern": "(^\\s*(@CODE|@DECL|@PRE|@POST|@CHECK)\\b.*)|(\\{[^}\"']*$)|(\\([^)\"']*$)",
+        "decreaseIndentPattern": "^\\s*(\\}|\\)|@@)"
+    },
+    "onEnterRules": [
+        {
+            "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+            "afterText": "^\\s*\\*\\/$",
+            "action": { "indent": "indentOutdent", "appendText": " * " }
+        },
+        {
+            "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+            "action": { "indent": "none", "appendText": " * " }
+        },
+        {
+            "beforeText": "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!\\/))*)?$",
+            "action": { "indent": "none", "appendText": "* " }
+        },
+        {
+            "beforeText": "^\\s*\\*\\/$",
+            "action": { "indent": "none", "removeText": 1 }
+        },
+        {
+            "beforeText": "^\\s*#.*$",
+            "action": { "indent": "none", "appendText": "# " }
+        },
+        {
+            "beforeText": "\\{[^}\"']*$",
+            "afterText": "^\\s*\\}",
+            "action": { "indent": "indentOutdent" }
+        },
+        {
+            "beforeText": "\\{[^}\"']*$",
+            "action": { "indent": "indent" }
+        }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.2",
+    "version": "3.12.3",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
## What

Adds the standard VS Code **language-configuration** keys that NLP++ was missing, so `.nlp`/`.pat` editing behaves like other languages:

- **`wordPattern`** — `_noun`, `_ROOT`, `$var` select / rename / find-references as a single word (no more splitting on `_`/`$`).
- **`indentationRules`** — auto-indent inside `{ }`/`( )` and after `@CODE`/`@DECL`/`@PRE`/`@POST`/`@CHECK`; outdent on `}`/`)`/`@@`.
- **`onEnterRules`** — continue `#` line comments, smart brace indent, and continue `/* */` block comments with ` * `.
- **`comments.blockComment`** — enables Toggle Block Comment (Shift+Alt+A).

## ⚠️ Sequencing

Block-comment toggling assumes `/* */` support in the **NLP++ engine**, which does **not exist yet** (verified — engine handles `#` only). That work is handed off in `nlp-engine/NLPPP-BLOCK-COMMENTS-HANDOFF.md`. **Hold the Marketplace publish of this version until the engine ships block comments**, or drop the `blockComment` line if you want to publish the other improvements sooner.

Config-only change (`nlp-configuration.json` is a referenced file), so `dist/` is unaffected. Based on 3.12.2 → 3.12.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
