### PR TITLE
chore: release 3.12.4 now that the engine parses /* */

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.4
+Block comments are live: the NLP++ engine now parses `/* */`.
+
+- 3.12.3 added `blockComment` and the on-Enter rule that continues a block comment, but held the release because the engine still knew only `#` line comments -- writing `/* */` in a pass file died with `[Syntax error.]`. **Engine 3.7.14 ships that support**, so **Toggle Block Comment** (`Shift+Alt+A`) now produces something the analyzer will actually build.
+- Block comments work in pass files (`.nlp`/`.pat`) and in the line-oriented data files (`.seq`, `.kb`, `.dict`, `.kbb`). They follow C: they do not nest (the first `*/` closes), a delimiter inside a string or after a `#` is ordinary text, and an unterminated `/*` is reported as an error.
+- **Requires nlp-engine 3.7.14 or later.** On an older engine the syntax colouring still treats `/* */` as a comment, but the analyzer will not build.
+
 ### 3.12.3
 Standard editor behaviors for NLP++ files (language configuration).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.3",
+    "version": "3.12.4",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
Version bump and changelog only — no code change.

3.12.3 added `blockComment` and the on-Enter rule that continues a block comment, but deliberately **held the release**: the engine still knew only `#` line comments, so writing `/* */` in a pass file died with `[Syntax error.]` and **Toggle Block Comment** (`Shift+Alt+A`) would have produced something the analyzer could not build. That hold is recorded in the 3.12.3 changelog entry.

[nlp-engine 3.7.14](https://github.com/VisualText/nlp-engine/pull/700) ships that support and is now tagged, so the hold can be lifted.

**What the engine now accepts** — block comments in pass files (`.nlp`/`.pat`) and in the line-oriented data files (`.seq`, `.kb`, `.dict`, `.kbb`), following C: they do not nest (the first `*/` closes), a delimiter inside a string or after a `#` is ordinary text, and an unterminated `/*` is reported as an error.

**Requires nlp-engine 3.7.14 or later.** On an older engine the syntax colouring still treats `/* */` as a comment, but the analyzer will not build — which is exactly why 3.12.3 was held.

The language configuration itself needed no further change; `nlp-configuration.json` has carried `"blockComment": ["/*", "*/"]` since #1123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
