### PR TITLE
fix(telemetry-worker): force undici 7.29.0 so the security update can land

### DIFF
--- a/telemetry-worker/README.md
+++ b/telemetry-worker/README.md
@@ -24,6 +24,24 @@ npx wrangler d1 execute nlp-telemetry --remote \
   --command "CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)"
 ```
 
+## Requirements
+
+**Node 22 or newer.** `wrangler` 4.114+ declares `node >= 22`, and on Node 20 it
+refuses to run. Nothing else in this repository needs Node 22 — the extension
+itself runs on the Node bundled inside VS Code, and CI pins its own version.
+
+### Why `overrides` is in package.json
+
+`miniflare` depends on **exactly** `undici@7.28.0`, which is the top of the
+vulnerable range in a batch of undici advisories (`7.0.0 - 7.28.0`); the fix is
+`7.29.0`. Because the pin is exact and transitive, npm cannot resolve past it and
+Dependabot cannot propose an update — its security PRs for this directory failed
+repeatedly for exactly this reason. The `overrides` block forces `7.29.0`.
+
+Remove it once Cloudflare ships a miniflare that depends on undici 7.29.0 or
+later; until then, deleting it silently reintroduces twelve advisories. Check
+with `npm audit` after any wrangler bump.
+
 ## One-time deploy
 
 `wrangler` is installed locally here as a devDependency, so run it with `npx`

--- a/telemetry-worker/package-lock.json
+++ b/telemetry-worker/package-lock.json
@@ -7,6 +7,9 @@
 			"name": "nlp-telemetry-worker",
 			"devDependencies": {
 				"wrangler": "^4.114.0"
+			},
+			"engines": {
+				"node": ">=22"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -704,9 +707,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -724,9 +724,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -744,9 +741,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -764,9 +758,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -784,9 +775,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -804,9 +792,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -824,9 +809,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -844,9 +826,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -864,9 +843,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -890,9 +866,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -916,9 +889,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -942,9 +912,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -968,9 +935,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -994,9 +958,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1020,9 +981,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1046,9 +1004,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1461,9 +1416,9 @@
 			"optional": true
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/telemetry-worker/package.json
+++ b/telemetry-worker/package.json
@@ -2,6 +2,9 @@
 	"name": "nlp-telemetry-worker",
 	"private": true,
 	"description": "Cloudflare Worker that records anonymous NLP++ extension usage into D1",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy",
@@ -9,5 +12,8 @@
 	},
 	"devDependencies": {
 		"wrangler": "^4.114.0"
+	},
+	"overrides": {
+		"undici": "^7.29.0"
 	}
 }


### PR DESCRIPTION
Dependabot has failed to update `undici` in `telemetry-worker/` **six times running**. The config is not at fault, and no retry would have helped.

## Why it kept failing

`miniflare` depends on **exactly** `undici@7.28.0` — the top of the vulnerable range shared by twelve advisories (`7.0.0 - 7.28.0`). The fix is `7.29.0`. Because that pin is both exact and transitive, npm cannot resolve past it and Dependabot cannot rewrite it, so there was no update available for it to propose at all. It will keep failing until Cloudflare ships a miniflare built on undici 7.29.0.

An `overrides` block is the only lever available from this side. With it, the directory audits clean:

| package | before | after |
|---|---|---|
| undici | 7.28.0 (12 advisories) | **7.29.0** |
| wrangler | 4.114.0 | 4.114.0 (unchanged) |
| miniflare | 4.20260722.0 | 4.20260722.0 (unchanged, stable — not the 5.x alpha) |

`npm audit` → **0 vulnerabilities**, down from 12.

## Also restores wrangler to the committed ^4.114.0

The working tree had wrangler pinned back to `^4.86.0`. That was a correct call at the time — wrangler 4.114 declares `node >= 22` and simply will not run on Node 20 — but that older chain carries its own advisories, in `miniflare → sharp` and in `wrangler → esbuild`.

I measured both paths before choosing:

| | this PR | staying on the 4.86 chain |
|---|---|---|
| Node required | 22 | 20 (current) |
| overrides needed | **1** | **4** (undici, ws, sharp, esbuild) |
| `npm audit` | **0** | 2 low, and climbing |

Each override substitutes a version Cloudflare never tested wrangler against, so the smaller stack is the one worth maintaining.

Node 22 is the right side of that trade regardless of wrangler: **Node 20 reached end of life in April 2026** and has not received security patches since.

## What this does not affect

Nothing that ships. The extension runs on the Node bundled inside VS Code, and CI pins its own version — `telemetry-worker/` is excluded from the vsix and from CI entirely. This affects only whoever runs `wrangler deploy`, who now needs Node 22.

`worker.js` itself has zero npm dependencies and runs on Cloudflare's runtime, so none of these advisories were ever exposed in production. This is toolchain hygiene, not a live hole.

## Guardrails added

- `engines.node: ">=22"` — npm now says so plainly instead of failing mysteriously.
- A README section explaining why the override exists and when to remove it. Deleting it before Cloudflare moves off undici 7.28.0 silently reintroduces all twelve advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
