### PR TITLE
ci: check out corpus submodules, and fail if the corpus shrinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
     name: Typecheck, lint and unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # grammars/ is the VisualText/nlpplus-tmbundle submodule; check-grammars
           # fails loudly without it, which is the whole point of that script.
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           # VSCode 1.95 (our engines floor) runs on Electron's Node 20.
           node-version: '20'
@@ -65,9 +65,9 @@ jobs:
     name: Formatter corpus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm
@@ -76,40 +76,51 @@ jobs:
       # thousand .nlp/.pat files of real, hand-written code, which is the only
       # thing that meaningfully exercises a lossless formatter. Add repos here to
       # widen coverage; the harness takes any number of directories.
-      - uses: actions/checkout@v4
+      #
+      # submodules: recursive is load-bearing. Three of these four repos embed
+      # their analyzers as submodules, and without it the corpus checks out at
+      # 376 files instead of 934 -- a job that passes while silently verifying
+      # 40% of what it claims to.
+      - uses: actions/checkout@v7
         with:
           repository: VisualText/analyzers
           path: corpus/analyzers
-      - uses: actions/checkout@v4
+          submodules: recursive
+      - uses: actions/checkout@v7
         with:
           repository: VisualText/parse-en-us
           path: corpus/parse-en-us
-      - uses: actions/checkout@v4
+          submodules: recursive
+      - uses: actions/checkout@v7
         with:
           repository: VisualText/package-analyzers
           path: corpus/package-analyzers
-      - uses: actions/checkout@v4
+          submodules: recursive
+      - uses: actions/checkout@v7
         with:
           repository: VisualText/analyzer-templates
           path: corpus/analyzer-templates
+          submodules: recursive
 
       - run: npm ci
 
       # Checks tokenizer/region round-trips, idempotency, and range-vs-full
-      # equivalence on every file. The harness fails on an empty corpus, so a
-      # checkout that silently produced nothing cannot pass this job.
+      # equivalence on every file. --min is the guard against a corpus that
+      # quietly shrinks: the four repos currently supply 934 files, so anything
+      # under 900 means a clone or a submodule did not arrive and the job fails
+      # rather than reporting success over a fraction of the corpus.
       - name: Formatter invariants over the public analyzer corpus
-        run: npm run test:format -- corpus/analyzers corpus/parse-en-us corpus/package-analyzers corpus/analyzer-templates
+        run: npm run test:format -- --min 900 corpus/analyzers corpus/parse-en-us corpus/package-analyzers corpus/analyzer-templates
 
   package:
     name: Build vsix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: npm
@@ -121,7 +132,7 @@ jobs:
 
       # Downloadable from the run summary, so a reviewer can install the exact
       # build a PR produces instead of building it themselves.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: vscode-nlp-vsix
           path: vscode.nlp.vsix

--- a/src/format/corpusTest.ts
+++ b/src/format/corpusTest.ts
@@ -47,7 +47,20 @@ function firstDiff(a: string, b: string): string {
 }
 
 function main(): void {
-	const dirs = process.argv.slice(2);
+	// --min N fails the run if fewer than N files were found. The empty-corpus
+	// check below catches a corpus that vanished entirely; this catches one that
+	// merely shrank -- which is what happened when CI cloned the analyzer repos
+	// without their submodules and verified 376 files while reporting success.
+	const argv = process.argv.slice(2);
+	const dirs: string[] = [];
+	let min = 0;
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--min") {
+			min = parseInt(argv[++i], 10) || 0;
+			continue;
+		}
+		dirs.push(argv[i]);
+	}
 	if (dirs.length === 0) dirs.push("c:\\git");
 
 	const files: string[] = [];
@@ -133,6 +146,15 @@ function main(): void {
 	// checkout fails or a path argument is wrong.
 	if (files.length === 0) {
 		console.log(`\nNo .nlp or .pat files found. Nothing was verified.`);
+		process.exitCode = 1;
+		return;
+	}
+
+	if (min && files.length < min) {
+		console.log(
+			`\nExpected at least ${min} files but found ${files.length}. ` +
+			`The corpus is incomplete -- check that every repo cloned, including its submodules.`
+		);
 		process.exitCode = 1;
 		return;
 	}


### PR DESCRIPTION
The first green run of the formatter job verified **376 files, not the 934** the job was introduced to cover.

Three of the four public analyzer repos — `analyzers`, `package-analyzers` and `analyzer-templates` — embed their analyzers as submodules, and `actions/checkout` does not fetch those unless asked. So the job passed while silently exercising 40% of the corpus.

That is close to the exact failure mode the empty-corpus guard was added to prevent, and it slipped straight past it: that guard only catches a corpus of *exactly nothing*.

## Two changes — one for the cause, one for the class

**`submodules: recursive`** on all four corpus checkouts.

**`--min N`** in the corpus harness, wired up as `--min 900` in the workflow. A corpus that quietly shrinks now fails the job rather than reporting success over whatever fraction survived.

Verified both directions locally:

```
934 files, --min 900  ->  exit 0, "All invariants hold"
372 files, --min 900  ->  exit 1, "Expected at least 900 files but found 372.
                                   The corpus is incomplete -- check that every
                                   repo cloned, including its submodules."
```

## Action versions

Bumps `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` from v4 to **v7**. Every job on the first run carried a deprecation annotation — the v4 actions target Node 20, and the runners are force-upgrading them to Node 24.

## Context

For the record, the rest of the first run was genuinely green: typecheck, lint and both unit suites (21s), the vsix build with its artifact (33s), and the corpus job itself (30s) — which did pass all 376 files it saw. The invariants hold; the coverage was the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
