### PR TITLE
chore: drop four dependencies nothing imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,11 @@
             "dependencies": {
                 "copy-dir": "^1.3.0",
                 "del": "^8.0.1",
-                "download-file": "^0.1.5",
                 "extract-zip": "^2.0.1",
-                "latest-version": "^9.0.0",
-                "line-reader": "^0.4.0",
                 "moment": "^2.30.1",
                 "moment-duration-format": "^2.3.2",
                 "n-readlines": "^3.4.1",
                 "nodejs-file-downloader": "^4.13.0",
-                "readline": "^1.3.0",
                 "tslib": "^2.8.1"
             },
             "devDependencies": {
@@ -595,38 +591,6 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/@pnpm/config.env-replace": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
-            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
-            "engines": {
-                "node": ">=12.22.0"
-            }
-        },
-        "node_modules/@pnpm/network.ca-file": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
-            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
-            "dependencies": {
-                "graceful-fs": "4.2.10"
-            },
-            "engines": {
-                "node": ">=12.22.0"
-            }
-        },
-        "node_modules/@pnpm/npm-conf": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-            "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
-            "dependencies": {
-                "@pnpm/config.env-replace": "^1.1.0",
-                "@pnpm/network.ca-file": "^1.0.1",
-                "config-chain": "^1.1.11"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@secretlint/config-creator": {
@@ -2457,15 +2421,6 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
-        "node_modules/config-chain": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-            "dependencies": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-            }
-        },
         "node_modules/copy-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
@@ -2581,6 +2536,8 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "optional": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -2734,14 +2691,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/download-file": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/download-file/-/download-file-0.1.5.tgz",
-            "integrity": "sha512-cTeC3HGeUdoxKmlWhcNwrCI19kb+WVcJBif1quxIeGmC91FkJzBQuHiQm25uOawV3t33JPthA6yl+f84ofn8UQ==",
-            "dependencies": {
-                "mkdirp": "^0.5.0"
             }
         },
         "node_modules/dunder-proto": {
@@ -3638,7 +3587,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -3843,7 +3793,9 @@
         "node_modules/ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "optional": true
         },
         "node_modules/interpret": {
             "version": "3.1.1",
@@ -4305,31 +4257,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/ky": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/ky/-/ky-1.8.2.tgz",
-            "integrity": "sha512-XybQJ3d4Ea1kI27DoelE5ZCT3bSJlibYTtQuMsyzKox3TMyayw1asgQdl54WroAm+fIA3ZCr8zXW2RpR7qWVpA==",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/ky?sponsor=1"
-            }
-        },
-        "node_modules/latest-version": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
-            "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
-            "dependencies": {
-                "package-json": "^10.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4361,11 +4288,6 @@
             "dependencies": {
                 "immediate": "~3.0.5"
             }
-        },
-        "node_modules/line-reader": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/line-reader/-/line-reader-0.4.0.tgz",
-            "integrity": "sha512-AYJ8g+eE7v+Ba4s/cuYqzuNulH/WbjdKQ55fvx8fNVn8WQzTpioY6vI1MoxTuMgcHYX3VlmZWbVvnkIqkyJbCA=="
         },
         "node_modules/linkify-it": {
             "version": "5.0.2",
@@ -4632,6 +4554,8 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "optional": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4644,17 +4568,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
             }
         },
         "node_modules/mkdirp-classic": {
@@ -5162,23 +5075,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/package-json": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
-            "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
-            "dependencies": {
-                "ky": "^1.2.0",
-                "registry-auth-token": "^5.0.2",
-                "registry-url": "^6.0.1",
-                "semver": "^7.6.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5483,11 +5379,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
-        "node_modules/proto-list": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -5564,6 +5455,8 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -5590,6 +5483,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5653,11 +5548,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/readline": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-            "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
-        },
         "node_modules/rechoir": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -5669,31 +5559,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/registry-auth-token": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
-            "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
-            "dependencies": {
-                "@pnpm/npm-conf": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/registry-url": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
-            "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
-            "dependencies": {
-                "rc": "1.2.8"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/require-directory": {
@@ -5906,6 +5771,7 @@
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -7698,29 +7564,6 @@
             "dev": true,
             "optional": true
         },
-        "@pnpm/config.env-replace": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
-            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="
-        },
-        "@pnpm/network.ca-file": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
-            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
-            "requires": {
-                "graceful-fs": "4.2.10"
-            }
-        },
-        "@pnpm/npm-conf": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-            "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
-            "requires": {
-                "@pnpm/config.env-replace": "^1.1.0",
-                "@pnpm/network.ca-file": "^1.0.1",
-                "config-chain": "^1.1.11"
-            }
-        },
         "@secretlint/config-creator": {
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
@@ -9023,15 +8866,6 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
-        "config-chain": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-            "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-            }
-        },
         "copy-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
@@ -9109,7 +8943,9 @@
         "deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "optional": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -9207,14 +9043,6 @@
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3"
-            }
-        },
-        "download-file": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/download-file/-/download-file-0.1.5.tgz",
-            "integrity": "sha512-cTeC3HGeUdoxKmlWhcNwrCI19kb+WVcJBif1quxIeGmC91FkJzBQuHiQm25uOawV3t33JPthA6yl+f84ofn8UQ==",
-            "requires": {
-                "mkdirp": "^0.5.0"
             }
         },
         "dunder-proto": {
@@ -9825,7 +9653,8 @@
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "has-flag": {
             "version": "4.0.0",
@@ -9952,7 +9781,9 @@
         "ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "optional": true
         },
         "interpret": {
             "version": "3.1.1",
@@ -10281,19 +10112,6 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
-        "ky": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/ky/-/ky-1.8.2.tgz",
-            "integrity": "sha512-XybQJ3d4Ea1kI27DoelE5ZCT3bSJlibYTtQuMsyzKox3TMyayw1asgQdl54WroAm+fIA3ZCr8zXW2RpR7qWVpA=="
-        },
-        "latest-version": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
-            "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
-            "requires": {
-                "package-json": "^10.0.0"
-            }
-        },
         "leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10318,11 +10136,6 @@
             "requires": {
                 "immediate": "~3.0.5"
             }
-        },
-        "line-reader": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/line-reader/-/line-reader-0.4.0.tgz",
-            "integrity": "sha512-AYJ8g+eE7v+Ba4s/cuYqzuNulH/WbjdKQ55fvx8fNVn8WQzTpioY6vI1MoxTuMgcHYX3VlmZWbVvnkIqkyJbCA=="
         },
         "linkify-it": {
             "version": "5.0.2",
@@ -10510,21 +10323,15 @@
         "minimist": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "optional": true
         },
         "minipass": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "requires": {
-                "minimist": "^1.2.6"
-            }
         },
         "mkdirp-classic": {
             "version": "0.5.3",
@@ -10898,17 +10705,6 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
-        "package-json": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
-            "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
-            "requires": {
-                "ky": "^1.2.0",
-                "registry-auth-token": "^5.0.2",
-                "registry-url": "^6.0.1",
-                "semver": "^7.6.0"
-            }
-        },
         "package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -11126,11 +10922,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
-        "proto-list": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
-        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -11179,6 +10970,8 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "optional": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -11189,7 +10982,9 @@
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+                    "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -11245,11 +11040,6 @@
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true
         },
-        "readline": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-            "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
-        },
         "rechoir": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -11257,22 +11047,6 @@
             "dev": true,
             "requires": {
                 "resolve": "^1.20.0"
-            }
-        },
-        "registry-auth-token": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
-            "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
-            "requires": {
-                "@pnpm/npm-conf": "^2.1.0"
-            }
-        },
-        "registry-url": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
-            "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
-            "requires": {
-                "rc": "1.2.8"
             }
         },
         "require-directory": {
@@ -11400,7 +11174,8 @@
         "semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true
         },
         "serialize-javascript": {
             "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -3496,15 +3496,11 @@
     "dependencies": {
         "copy-dir": "^1.3.0",
         "del": "^8.0.1",
-        "download-file": "^0.1.5",
         "extract-zip": "^2.0.1",
-        "latest-version": "^9.0.0",
-        "line-reader": "^0.4.0",
         "moment": "^2.30.1",
         "moment-duration-format": "^2.3.2",
         "n-readlines": "^3.4.1",
         "nodejs-file-downloader": "^4.13.0",
-        "readline": "^1.3.0",
         "tslib": "^2.8.1"
     },
     "scripts": {


### PR DESCRIPTION
`download-file`, `latest-version`, `line-reader` and `readline` are declared as **runtime** dependencies and referenced nowhere — not by an import, not by a dynamic `require()`, not by a script. Searching the whole tree for each name finds only `package.json` itself.

(`visualText.ts` has a local variable named `latestVersion`, which is what makes a careless grep look like a hit.)

## Two are worth naming individually

**`readline`** is a deprecated npm stub of the Node builtin of the same name. Having it installed means any future `require("readline")` resolves to the stub instead of Node's module — silently, with no error. That's a trap sitting in the dependency list waiting for someone to write the obvious line of code.

**`download-file`** (v0.1.5, unmaintained) duplicates `nodejs-file-downloader`, which is the one actually used, in `visualText.ts`.

## Nothing that ships changes

The build confirms it exactly:

```
dist/extension.js   996,098 bytes   (byte-identical)
vsix                184 files, 3.08 MB   (unchanged)
node_modules tree   592 -> 578 packages
```

Webpack only bundles what is imported, so these were dead weight in `node_modules` and in every `npm install` — never in the extension.

Typecheck, lint, and both unit suites pass (79 + 63).

## Deliberately left in place

**`tslib`** — no source file mentions it, but `tsc` emits `require("tslib")` because tsconfig sets `importHelpers`. Removing it would break the build. It's the one entry where "zero references" is the wrong conclusion.

**`mocha`, `@types/mocha`, `@vscode/test-electron`, `glob`** — all four equally unreferenced, leftovers from the `dist/test/runTest.js` runner that never existed in this tree. But removing them signals "no integration tests planned," which is your call rather than a cleanup. Say the word and they go in a follow-up.

## Unrelated, for the record

`npm audit` reports the same **6 dev-side advisories before and after** this commit — `@vscode/vsce → typed-rest-client → underscore` and similar toolchain chains. I verified that against master's lockfile in a scratch copy so the number isn't mistaken for something this PR caused. Production dependencies audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
