### PR TITLE
fix: declare analyzer.directory so the setting can actually be written

### DIFF
--- a/package.json
+++ b/package.json
@@ -3416,6 +3416,12 @@
                     "default": "",
                     "description": "User name for top pass file comments"
                 },
+                "analyzer.directory": {
+                    "type": "string",
+                    "scope": "application",
+                    "default": "",
+                    "description": "Folder holding your analyzers, used when the open workspace folder does not contain any. Written automatically; normally there is no need to set this by hand."
+                },
                 "analyzer.current": {
                     "type": "string",
                     "scope": "resource",

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -93,6 +93,30 @@ export async function languageTests(): Promise<void> {
 	}
 }
 
+// ---- configuration ---------------------------------------------------------
+// A setting the extension writes has to be declared in contributes.configuration
+// or VS Code rejects the write outright, leaving one line in the log and a value
+// that never persists. analyzer.directory sat broken that way: written on every
+// activation, declared nowhere, so the analyzer folder was re-derived from
+// scratch each time. A declared property always reports a defaultValue.
+
+const WRITTEN_SETTINGS: Array<[string, string]> = [
+	["analyzer", "directory"],
+	["analyzer", "current"],
+	["textView", "fast"],
+];
+
+export async function configurationTests(): Promise<void> {
+	for (const [section, key] of WRITTEN_SETTINGS) {
+		const inspected = vscode.workspace.getConfiguration(section).inspect(key);
+		check(
+			`${section}.${key} is a registered configuration`,
+			inspected !== undefined && inspected.defaultValue !== undefined,
+			"declared in contributes.configuration? VS Code rejects writes to settings that are not"
+		);
+	}
+}
+
 // ---- provider wiring -------------------------------------------------------
 // test:format proves the formatting engine is lossless over ~1000 real files.
 // It cannot prove the DocumentFormattingEditProvider is bound to .nlp documents

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -9,6 +9,7 @@ import {
 	activationTests,
 	commandTests,
 	languageTests,
+	configurationTests,
 	providerTests,
 } from "./extension.test";
 
@@ -17,6 +18,7 @@ export async function run(): Promise<void> {
 		["activation", activationTests],
 		["commands", commandTests],
 		["languages", languageTests],
+		["configuration", configurationTests],
 		["providers", providerTests],
 	];
 


### PR DESCRIPTION
`configAnalzyerDirectory()` writes `analyzer.directory` to global settings on **every activation**, but `contributes.configuration` declared only `analyzer.regressionTerminal` and `analyzer.current`. VS Code rejects writes to settings it doesn't know about, so the write failed every single time:

```
Unable to write to User Settings because analyzer.directory is not a registered configuration.
```

## The consequence is quiet rather than loud

[visualText.ts:1085](src/visualText.ts#L1085) reads the setting back, gets nothing, and falls through to `<engineDir>/analyzers`:

```ts
directory = config.get<string>('directory') || '';
if (!directory) {
    directory = path.join(this.engineDir.fsPath, 'analyzers');
}
...
if (directory.length > 1)
    config.update('directory', directory, vscode.ConfigurationTarget.Global);   // always rejected
```

So an analyzer directory outside the workspace **could never persist across sessions**, and the fallback path was silently doing all the work. Nothing surfaced to the user except a line in a log almost nobody reads.

## The fix

Declared with `scope: "application"`, matching the `ConfigurationTarget.Global` the code writes with, and shaped like its neighbours.

## Plus the regression guard that was missing

The integration suite now asserts, for each setting the extension writes, that VS Code reports a `defaultValue` for it — which only a registered property has.

I verified it can actually fail, rather than assuming: deleting the declaration again turns the check red and brings the runtime warning back.

```
with declaration:     integration tests: 18 passed, 0 failed
declaration removed:  Unable to write to User Settings because analyzer.directory is not a registered configuration.
                      FAIL: analyzer.directory is a registered configuration
                      integration tests: 17 passed, 1 failed
```

An assertion that cannot fail isn't worth writing. The suite goes 15 → 18 checks.

## Verified

Grammar guard, typecheck, lint, language (79) and treeview (63) suites all pass; package unchanged at 184 files / 3.08 MB.

Found by the integration harness from #1136, which surfaced this warning on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
