### PR TITLE
chore: release 3.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.7
+Two failures that only ever showed up away from a developer's machine.
+
+- **The extension could fail to activate at all.** `getExtensionPath()` looked for an installed copy of the extension under the extensions directory, and read `extensionItems[-1].uri` when it found none -- throwing `Cannot read properties of undefined (reading 'uri')` straight out of `activate()`. Nothing registered after that: no command, no view, no provider, and one line in a log to explain it. Having no installed copy is the *normal* state whenever the extension runs from source rather than the marketplace -- F5 development on a clean machine -- so it stayed invisible on any machine that already had it installed. It now falls back to where the running code actually lives.
+- **The analyzer directory was never remembered.** `analyzer.directory` is written to your settings on every activation, but it was never declared in the extension's configuration, and VS Code rejects writes to settings it does not know about. The write failed every single time, silently, so an analyzer folder outside the workspace was re-derived from the engine directory on each start instead of persisting.
+- **Six commands are gone from the Command Palette.** `nlp.opendisplayMatchedRules`, `sequenceView.reveal`, `sequenceView.changeTitle`, `analyzerView.deleteFileLogs`, `logView.matches` and `logView.setClearFlag` were declared but never registered, so choosing any of them produced "command not found". Four were leftovers from renames; their working replacements -- `nlp.displayMatchedRules`, `textView.deleteFileLogs`, `outputView.matches` and `logView.clear` -- are unaffected.
+- Under the hood, every pull request now runs the test suites on GitHub Actions, including a new one that launches a real VS Code and checks that the extension activates and that all 218 declared commands are registered. That suite is what found the first two items above.
+
 ### 3.12.6
 Corrected label in the README screenshot.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.12.6",
+    "version": "3.12.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.12.6",
+            "version": "3.12.7",
             "license": "MIT",
             "dependencies": {
                 "copy-dir": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.6",
+    "version": "3.12.7",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
> ⚠️ **Merging this publishes 3.12.7 to the VS Code Marketplace.** The version bump on master triggers `release.yml`, which tags `v3.12.7`, creates the GitHub release, and pushes the vsix to real users. A Marketplace version cannot be replaced once published. Merge when you're ready for that, not before.

## What ships

Twenty-nine commits have landed since `v3.12.3` was tagged, most of them build and test infrastructure with no user-visible effect. The changelog entry covers only what a user would actually notice:

**Activation could fail entirely.** `getExtensionPath()` looked for an installed copy of the extension and read `extensionItems[-1].uri` when it found none, throwing out of `activate()`. Nothing registered after that — no command, no view, no provider. It stayed invisible on any machine that already had the extension installed, which is every maintainer's machine.

**The analyzer directory was never remembered.** `analyzer.directory` was written on every activation but never declared, and VS Code rejects writes to settings it doesn't know. It failed silently every time.

**Six dead Command Palette entries removed** — they produced "command not found" when chosen.

Both of the first two were found by the integration suite added earlier today.

## This is also the first automated release

It exercises `release.yml` end to end for the first time. Expected sequence on merge:

1. `decide` sees the version change 3.12.6 → 3.12.7
2. builds `nlp-3.12.7.vsix`
3. creates and pushes tag `v3.12.7`
4. creates the GitHub release, notes pulled from CHANGELOG.md
5. publishes that same vsix to the Marketplace using `VSCE_PAT`

Step 5 is the one that has never run. If the token's scope is wrong it fails there — after the GitHub release has already succeeded, so the release still exists and the step is re-runnable once the token is fixed.

The generated release title previews as:

```
3.12.7 — Two failures that only ever showed up away from a developer's machine
```

## Verified locally

```
grammar guard    7 grammars
typecheck        clean
lint             clean
language          79 passed
treeview          63 passed
integration       18 passed
package          nlp-3.12.7.vsix — 184 files, 3.08 MB
```

Version bumped in both `package.json` and `package-lock.json`; nothing else in the repo references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
