### PR TITLE
test: cover the language-feature providers in the integration suite

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -153,3 +153,110 @@ export async function providerTests(): Promise<void> {
 	);
 	check("a document symbol provider answers for .nlp documents", Array.isArray(symbols));
 }
+
+// ---- language features -----------------------------------------------------
+// registerLanguageFeatures() binds eleven providers to { language: "nlp" }, and
+// langTest.ts already covers the engines behind them. What it cannot cover is
+// whether each one is reachable through VS Code for an .nlp document -- a
+// provider registered against the wrong selector, or not registered at all,
+// looks identical to a provider that simply had nothing to say.
+//
+// So each check below uses input the engine is known to answer on, and requires
+// a non-empty result. Asserting merely "an array came back" would pass just as
+// happily with no provider registered, since VS Code returns an empty array in
+// both cases.
+//
+// Definition, references and rename are deliberately absent: they resolve across
+// passes via the workspace index, which needs a real analyzer on disk rather than
+// an untitled buffer. langTest.ts exercises that logic directly.
+
+async function openNlp(content: string): Promise<vscode.TextDocument> {
+	return vscode.workspace.openTextDocument({ language: "nlp", content });
+}
+
+export async function languageFeatureTests(): Promise<void> {
+	// Hover: over the @NODES region marker, which the provider documents.
+	{
+		const doc = await openNlp(SAMPLE_PASS);
+		const pos = doc.positionAt(SAMPLE_PASS.indexOf("@NODES") + 3);
+		const hovers = await vscode.commands.executeCommand<vscode.Hover[]>(
+			"vscode.executeHoverProvider",
+			doc.uri,
+			pos
+		);
+		check(
+			"hover answers on a region marker",
+			Array.isArray(hovers) && hovers.length > 0,
+			`got ${Array.isArray(hovers) ? `${hovers.length} hovers` : typeof hovers}`
+		);
+	}
+
+	// Completion: after an "@", where the provider offers the region markers.
+	{
+		const content = `${SAMPLE_PASS}\n@`;
+		const doc = await openNlp(content);
+		const list = await vscode.commands.executeCommand<vscode.CompletionList>(
+			"vscode.executeCompletionItemProvider",
+			doc.uri,
+			doc.positionAt(content.length),
+			"@"
+		);
+		check(
+			"completion offers region markers after @",
+			(list?.items?.length ?? 0) > 0,
+			`got ${list?.items?.length ?? 0} items`
+		);
+	}
+
+	// Signature help: cursor inside a call in a @CODE region.
+	{
+		const content = '@CODE\n  strval( pnvar("x") )\n@@CODE\n';
+		const doc = await openNlp(content);
+		const help = await vscode.commands.executeCommand<vscode.SignatureHelp | undefined>(
+			"vscode.executeSignatureHelpProvider",
+			doc.uri,
+			doc.positionAt(content.indexOf('"x"') + 1),
+			"("
+		);
+		check(
+			"signature help answers inside a call",
+			(help?.signatures?.length ?? 0) > 0,
+			`got ${help ? `${help.signatures.length} signatures` : "undefined"}`
+		);
+	}
+
+	// Folding: the region structure of a pass file.
+	{
+		const doc = await openNlp(SAMPLE_PASS);
+		const ranges = await vscode.commands.executeCommand<vscode.FoldingRange[]>(
+			"vscode.executeFoldingRangeProvider",
+			doc.uri
+		);
+		check(
+			"folding ranges cover the pass regions",
+			Array.isArray(ranges) && ranges.length > 0,
+			`got ${Array.isArray(ranges) ? ranges.length : typeof ranges} ranges`
+		);
+	}
+
+	// Semantic tokens: the colouring layered over the TextMate grammar.
+	//
+	// Needs a @CODE region containing something classifiable from the *static*
+	// tables -- a builtin (strlength) and a node accessor (L). Concepts, rules
+	// and user functions are classified from the workspace index, which an
+	// untitled buffer has nothing to contribute to, so a rules-only sample
+	// produces zero tokens and says nothing about whether the provider is wired.
+	{
+		const content = '@CODE\n  x = strlength("a");\n  L("y");\n@@CODE\n';
+		const doc = await openNlp(content);
+		const tokens = await vscode.commands.executeCommand<vscode.SemanticTokens | undefined>(
+			"vscode.provideDocumentSemanticTokens",
+			doc.uri
+		);
+		check(
+			"semantic tokens are produced",
+			(tokens?.data?.length ?? 0) > 0,
+			`got ${tokens ? `${tokens.data.length} ints` : "undefined"}`
+		);
+	}
+}

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -11,6 +11,7 @@ import {
 	languageTests,
 	configurationTests,
 	providerTests,
+	languageFeatureTests,
 } from "./extension.test";
 
 export async function run(): Promise<void> {
@@ -20,6 +21,7 @@ export async function run(): Promise<void> {
 		["languages", languageTests],
 		["configuration", configurationTests],
 		["providers", providerTests],
+		["language features", languageFeatureTests],
 	];
 
 	for (const [name, fn] of groups) {


### PR DESCRIPTION
`registerLanguageFeatures()` binds **eleven providers** to `{ language: "nlp" }`. [langTest.ts](src/language/langTest.ts) covers the engines behind them, but nothing checked that any of them is actually reachable through VS Code for an `.nlp` document.

That gap matters because a provider bound to the wrong selector — or never registered at all — is **indistinguishable from one that simply had nothing to say**. Both produce an empty array.

## Five new checks

| feature | input it answers on |
|---|---|
| hover | the `@NODES` region marker |
| completion | after an `@`, offering region markers |
| signature help | cursor inside `strval( pnvar("x") )` in a `@CODE` region |
| folding | the region structure of a pass file |
| semantic tokens | a `@CODE` region using `strlength` and `L` |

Each requires a **non-empty** result. Asserting "an array came back" would pass just as happily with no provider registered.

## The semantic-token check earned its place

It first ran against a rules-only sample and correctly returned nothing — because concepts, rules and user functions are classified from the **workspace index**, and an untitled buffer contributes nothing to it. Only builtins and node accessors come from the static tables, so the sample is now a `@CODE` region using `strlength` and `L`.

```
rules-only sample:   FAIL: semantic tokens are produced — got 0 ints
@CODE sample:        23 passed, 0 failed
```

A check that fails against the wrong input and passes against the right one is the evidence it isn't vacuous. The other four were written the same way.

## Deliberately not covered

**Definition, references and rename.** They resolve across passes through the workspace index, which needs a real analyzer on disk rather than an untitled document. Covering them properly means fabricating an analyzer layout — which would test my guess at that layout as much as it tests the providers. langTest.ts exercises that logic directly instead.

Saying so here rather than quietly omitting them, since "the integration suite covers the language features" would otherwise read as more complete than it is.

## Cost

Suite goes **18 → 23 checks**, still ~40 seconds. No production code changes, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
