### PR TITLE
chore: dependabot config, a security policy, and a survivable publish step

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+# Dependabot configuration.
+#
+# Security updates were already running without this file -- that is a repository
+# setting, not a config one. What this adds is *version* updates: routine bumps
+# for dependencies that have no advisory against them, which is how you avoid the
+# situation where a security fix is three majors away because nothing moved for a
+# year.
+#
+# Safe to have now that CI runs on every pull request. Before that, each of these
+# would have been a manual verification.
+
+version: 2
+
+updates:
+  # The extension itself.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for the routine dev-tooling churn instead of six. Majors stay
+      # separate, since those are the ones that actually need reading.
+      dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+    commit-message:
+      prefix: chore
+
+  # The Cloudflare worker, which has its own lockfile and its own toolchain.
+  #
+  # Note the overrides block in telemetry-worker/package.json pinning undici to
+  # ^7.29.0: miniflare depends on exactly 7.28.0, which carries twelve
+  # advisories. If Dependabot proposes a wrangler bump here, check `npm audit`
+  # afterwards and remove the override only once miniflare has moved off 7.28.0.
+  - package-ecosystem: npm
+    directory: "/telemetry-worker"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore
+
+  # The actions used by ci.yml and release.yml. These go stale silently -- the v4
+  # actions were being force-migrated to Node 24 by the runners before anyone
+  # noticed the deprecation annotations.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,14 +151,20 @@ jobs:
           VERSION="${{ steps.decide.outputs.version }}"
           VSIX="${{ steps.build.outputs.vsix }}"
 
+          # A missing token is a warning, not a failure. Global PATs stop being
+          # supported on 1 December 2026 and this one is the scope vsce needs, so
+          # an expired or revoked token is an expected end state rather than a
+          # bug. The tag, the release and the downloadable vsix are all done by
+          # this point; only the Marketplace push is outstanding, and
+          # `npm run publish` from a laptop still covers it. Turning a complete
+          # release red would misreport what happened.
           if [[ -z "${VSCE_PAT:-}" ]]; then
-            echo "::error::VSCE_PAT is not set. Create an Azure DevOps personal access token with Marketplace > Manage scope and add it as a repository secret named VSCE_PAT. The GitHub release above already succeeded; re-run this workflow once the secret exists."
-            exit 1
+            echo "::warning::VSCE_PAT is not set, so ${VERSION} was not published to the Marketplace. The GitHub release is complete. To automate this step, create an Azure DevOps token with the Marketplace > Manage scope and add it as a repository secret named VSCE_PAT, then re-run this workflow."
+            exit 0
           fi
 
           # A Marketplace version cannot be replaced once published, so check
-          # before trying. vsce would fail anyway; this makes a re-run of an
-          # already-published version a no-op instead of a red build.
+          # before trying, and make a re-run a no-op instead of a red build.
           ALREADY=$(npx vsce show dehilster.nlp --json 2>/dev/null \
             | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).versions.some(v=>v.version==='${VERSION}')?'yes':'no')}catch{console.log('unknown')}})")
 
@@ -169,5 +175,21 @@ jobs:
 
           # Publish the exact artifact attached to the release, rather than
           # letting vsce build a second one that could differ.
-          npx vsce publish --packagePath "${VSIX}"
-          echo "Published ${VERSION} to the Marketplace."
+          #
+          # The check above cannot be trusted on its own: a freshly published
+          # version sits in "verifying" for a few minutes and does not appear in
+          # `vsce show` while it does, so a re-run inside that window would try to
+          # publish again. Treat a duplicate-version rejection as success -- the
+          # version is there either way -- and fail only on something else.
+          if npx vsce publish --packagePath "${VSIX}" > /tmp/publish.log 2>&1; then
+            cat /tmp/publish.log
+            echo "Published ${VERSION} to the Marketplace."
+          else
+            cat /tmp/publish.log
+            if grep -qiE "already exists|already published" /tmp/publish.log; then
+              echo "::warning::${VERSION} was already published (likely still verifying from an earlier run). Nothing to do."
+              exit 0
+            fi
+            echo "::error::Publishing ${VERSION} to the Marketplace failed for a reason other than the version already existing. The GitHub release is complete; fix the cause and re-run this workflow."
+            exit 1
+          fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security issues privately rather than opening a public issue.
+
+- **Preferred:** [open a private security advisory](https://github.com/VisualText/vscode-nlp/security/advisories/new) on this repository.
+- **Or email:** contact@visualtext.org
+
+Please include what you did, what happened, and the extension version from the
+Extensions view. A proof of concept helps but is not required to report
+something.
+
+Expect an acknowledgement within a week. If a report is confirmed, the fix ships
+in the next release and the advisory is published once it is available on the
+Marketplace.
+
+## Supported versions
+
+Only the latest version published to the VS Code Marketplace is supported. There
+are no long-term support branches; fixes go out as a new patch release.
+
+## What this extension does that is worth knowing
+
+Reported honestly rather than left for you to discover, since some of it looks
+alarming without context:
+
+- **It downloads and runs a native binary.** The NLP++ engine (`nlp.exe` and its
+  libraries) is fetched from GitHub releases in the
+  [VisualText](https://github.com/VisualText) organisation and executed locally
+  to analyse text. Analyzers are code, and running one runs it on your machine
+  with your permissions.
+- **It sends anonymous usage telemetry**, opt-out via `nlp.telemetry.enable` and
+  also honoured through VS Code's own `telemetry.telemetryLevel`. Counts and
+  version metadata only -- never file contents, file names, paths, analyzer
+  names, or error message text. The full schema and the worker that receives it
+  are in [`telemetry-worker/`](telemetry-worker/), and the categories are listed
+  in the README.
+- **It writes inside your workspace**, including a `.vscode/settings.json` for
+  colourisation and analyzer output under the analyzer folder.
+
+## Scope
+
+Reports about the extension, the telemetry worker in this repository, and the
+release pipeline are in scope.
+
+The NLP++ engine itself lives in
+[VisualText/nlp-engine](https://github.com/VisualText/nlp-engine); please report
+engine issues there, or here if you are unsure which side a problem falls on.


### PR DESCRIPTION
Three small things, all consequences of what landed earlier today.

## 1. `dependabot.yml`

Security updates were already running — that's a repository setting, not a config file. What was missing is **routine version updates**, which is how a security fix ends up three majors away because nothing moved for a year.

Covers the extension, the telemetry worker, and **the actions used by the two workflows** — that last one goes stale silently, which is exactly how the v4 actions ended up being force-migrated to Node 24 by the runners before anyone read the deprecation annotations.

Dev-tooling minors and patches are grouped into one PR so the weekly noise is bearable; majors stay separate, since those are the ones worth reading.

This is only safe *now that CI runs on every pull request*. Before today, each of these bumps would have been a manual verification.

The worker entry carries a warning in a comment: a wrangler bump there could silently reintroduce twelve advisories if the `undici` override is dropped before miniflare moves off 7.28.0.

## 2. `SECURITY.md`

A public extension with **6,333 installs** that publishes a contact address had no private way to report a vulnerability. Points at GitHub private advisories first, email second.

It also states plainly what a security-minded reader deserves to know up front rather than discover: the extension **downloads and executes a native engine binary**, sends **anonymous opt-out telemetry**, and **writes inside the workspace**. All three are legitimate and documented elsewhere; none of them should be a surprise found by reading source.

## 3. The Marketplace step no longer fails a complete release

Global PATs stop being supported **1 December 2026**, and that's the scope `vsce` needs — so an expired token is an *expected end state*, not a bug.

By the time that step runs, the tag, the release and the vsix are all done. Turning a complete release red because the last of five steps couldn't run misreports what happened, and `npm run publish` from your laptop still covers it.

It also closes a hole I found watching 3.12.7 go out: a freshly published version sits in **"verifying"** for some minutes and doesn't appear in `vsce show` during that window — so re-running the workflow inside it would have tried to publish again and failed. A duplicate-version rejection now counts as success, since the version is there either way.

**Genuine failures still fail.** I exercised all five outcomes before committing:

```
1. no token                    -> warn, release stands      exit 0
2. already listed              -> skip                      exit 0
3. clean publish               -> success                   exit 0
4. re-run during verification  -> warn, not red             exit 0
5. bad credentials             -> FAIL loudly               exit 1
```

Case 5 is the one that matters — it's what keeps this from being a blanket error-swallow.

## Verified

Both YAML files parse; `ci.yml` and `release.yml` still resolve to the expected jobs and steps; lint clean. No production code touched, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
