### PR TITLE
chore: unblock the dependency updates CI just rejected

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,22 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    ignore:
+      # @types/vscode declares which VS Code API surface we compile against, and
+      # vsce refuses to package when it exceeds engines.vscode -- "@types/vscode
+      # ^1.125.0 greater than engines.vscode ^1.95.0". So this is not a routine
+      # bump: raising it means raising the minimum VS Code version users need,
+      # which is a decision about who gets dropped, not a dependency update.
+      # Bump it by hand, together with engines.vscode.
+      - dependency-name: "@types/vscode"
+
+      # @types/node must describe the Node that VS Code actually runs on -- the
+      # one inside its Electron build, currently Node 20 for VS Code 1.95. Types
+      # ahead of that compile happily and then fail at runtime for users, which
+      # nothing in CI would catch. Minor and patch bumps are fine; a major is a
+      # deliberate choice to follow VS Code's own runtime.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       # One PR for the routine dev-tooling churn instead of six. Majors stay
       # separate, since those are the ones that actually need reading.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,13 @@
         "importHelpers": true,
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
+        // Do not type-check .d.ts files from dependencies. The four harness
+        // tsconfigs already set this; leaving it off here meant a type conflict
+        // between two packages we do not control could fail our build. It did:
+        // bumping eslint to 10 broke `npm run typecheck` with five errors inside
+        // @types/eslint-scope, a transitive dependency of webpack that no source
+        // file here imports.
+        "skipLibCheck": true,
         "lib": [
             "es2019",
             "es6",


### PR DESCRIPTION
Dependabot opened **five PRs within minutes** of yesterday's config landing, and CI failed three of them. Two of those failures were *our configuration*, not a bad update.

## `skipLibCheck` in tsconfig.json

The four harness tsconfigs already set it. The main one didn't — which meant a type conflict between two packages we don't control could fail our build.

It did. Bumping eslint to 10 (#1145) broke `npm run typecheck` with five errors inside `@types/eslint-scope`, a transitive dependency of webpack that **no source file here imports**. eslint 10 ships its own `Scope` types now, and the two disagree about whether `"TDZ"` is a scope kind.

I verified this rather than assuming it — installed eslint 10 locally and ran both ways:

```
eslint 10, skipLibCheck ON   -> typecheck passes            exit 0
eslint 10, skipLibCheck OFF  -> the exact CI error, 5 of them
```

Lint itself was never the problem: **eslint 10 runs the existing flat config clean**, so #1145 needs only a rebase after this lands.

## Two Dependabot ignores

Both are cases where a routine bump is really a decision about users.

**`@types/vscode`** declares which API surface we compile against, and vsce refuses to package when it exceeds `engines.vscode`. That's what failed #1143:

```
@types/vscode ^1.125.0 greater than engines.vscode ^1.95.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

Raising it means raising the **minimum VS Code version people need to install the extension**. That belongs in a deliberate commit alongside `engines.vscode`, not in a weekly group PR.

**`@types/node`** must describe the Node inside VS Code's Electron build — Node 20 for VS Code 1.95. Types ahead of the runtime compile happily and then fail for users, and **nothing in CI would catch it**, because CI runs the tests on a Node we choose rather than the one the extension ships inside. Majors are now ignored; minors and patches still flow.

## Where that leaves the five PRs

| PR | status | action |
|---|---|---|
| #1142 wrangler → 4.118 | ✅ passes | **merge** — I audited `/telemetry-worker` separately, since no CI job covers it: undici still resolves to 7.29.0 via the override, 0 vulnerabilities |
| #1143 dev-dependencies group | ❌ vsce | rebase after this; @types/vscode drops out of the group |
| #1144 @types/node → 26 | ⚠️ passes CI | **close** — passing is exactly the problem, see above |
| #1145 eslint → 10 | ❌ typecheck | rebase after this; verified to pass with `skipLibCheck` |
| #1146 typescript → 6 | ❌ all four | separate piece of work, see below |

## TypeScript 6 is a real task, not a config gap

```
tsconfig.json(5,29): error TS5107: Option 'moduleResolution=node10' is deprecated
and will stop functioning in TypeScript 7.0.
```

Moving to `node16` changes how imports resolve — package `exports` maps start being honoured — so it can alter which files are loaded at build time. That deserves its own change with the test suites run against it, not a rubber-stamp of a Dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
