### PR TITLE
chore: TypeScript 6, and drop the ESM-only dependency blocking it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "copy-dir": "^1.3.0",
-                "del": "^8.0.1",
                 "extract-zip": "^2.0.1",
                 "moment": "^2.30.1",
                 "moment-duration-format": "^2.3.2",
@@ -28,7 +27,7 @@
                 "@vscode/vsce": "^3.9.2",
                 "eslint": "^10.8.0",
                 "ts-loader": "^9.6.2",
-                "typescript": "^5.8.3",
+                "typescript": "^6.0.3",
                 "webpack": "^5.109.2",
                 "webpack-cli": "^7.2.2"
             },
@@ -430,6 +429,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -442,6 +442,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -450,6 +451,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -623,6 +625,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
             "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+            "dev": true,
             "engines": {
                 "node": ">=18"
             },
@@ -1704,6 +1707,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -2179,27 +2183,6 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/del": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-8.0.1.tgz",
-            "integrity": "sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==",
-            "license": "MIT",
-            "dependencies": {
-                "globby": "^14.0.2",
-                "is-glob": "^4.0.3",
-                "is-path-cwd": "^3.0.0",
-                "is-path-inside": "^4.0.0",
-                "p-map": "^7.0.2",
-                "presentable-error": "^0.0.1",
-                "slash": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2716,6 +2699,7 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -2731,6 +2715,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -2772,6 +2757,7 @@
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
             "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -2801,6 +2787,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -3024,6 +3011,7 @@
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
             "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^2.1.0",
@@ -3044,6 +3032,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
             "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -3210,6 +3199,7 @@
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -3321,6 +3311,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3338,6 +3329,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -3380,30 +3372,9 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-path-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
-            "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-plain-object": {
@@ -3928,6 +3899,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -3936,6 +3908,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -4407,6 +4380,7 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
             "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+            "dev": true,
             "engines": {
                 "node": ">=18"
             },
@@ -4545,6 +4519,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
             "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -4568,6 +4543,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -4690,18 +4666,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/presentable-error": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/presentable-error/-/presentable-error-0.0.1.tgz",
-            "integrity": "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4756,6 +4720,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -4942,6 +4907,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -4963,6 +4929,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5244,6 +5211,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
             "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14.16"
@@ -5661,6 +5629,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -5789,10 +5758,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6503,6 +6473,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -6511,12 +6482,14 @@
         "@nodelib/fs.stat": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true
         },
         "@nodelib/fs.walk": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -6655,7 +6628,8 @@
         "@sindresorhus/merge-streams": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="
+            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+            "dev": true
         },
         "@textlint/ast-node-types": {
             "version": "15.7.1",
@@ -7442,6 +7416,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "requires": {
                 "fill-range": "^7.1.1"
             }
@@ -7749,20 +7724,6 @@
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true
-        },
-        "del": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-8.0.1.tgz",
-            "integrity": "sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==",
-            "requires": {
-                "globby": "^14.0.2",
-                "is-glob": "^4.0.3",
-                "is-path-cwd": "^3.0.0",
-                "is-path-inside": "^4.0.0",
-                "p-map": "^7.0.2",
-                "presentable-error": "^0.0.1",
-                "slash": "^5.1.0"
-            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -8113,6 +8074,7 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -8125,6 +8087,7 @@
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "dev": true,
                     "requires": {
                         "is-glob": "^4.0.1"
                     }
@@ -8153,6 +8116,7 @@
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
             "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
             }
@@ -8178,6 +8142,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -8329,6 +8294,7 @@
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
             "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+            "dev": true,
             "requires": {
                 "@sindresorhus/merge-streams": "^2.1.0",
                 "fast-glob": "^3.3.3",
@@ -8341,7 +8307,8 @@
                 "unicorn-magic": {
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-                    "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+                    "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+                    "dev": true
                 }
             }
         },
@@ -8445,7 +8412,8 @@
         "ignore": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true
         },
         "immediate": {
             "version": "3.0.6",
@@ -8512,7 +8480,8 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -8524,6 +8493,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -8546,17 +8516,8 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
-        "is-path-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
-            "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA=="
-        },
-        "is-path-inside": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -8951,12 +8912,14 @@
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
         },
         "micromatch": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
             "requires": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -9266,7 +9229,8 @@
         "p-map": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA=="
+            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+            "dev": true
         },
         "p-try": {
             "version": "2.2.0",
@@ -9366,7 +9330,8 @@
         "path-type": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="
+            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+            "dev": true
         },
         "pend": {
             "version": "1.2.0",
@@ -9382,7 +9347,8 @@
         "picomatch": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -9465,11 +9431,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
         },
-        "presentable-error": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/presentable-error/-/presentable-error-0.0.1.tgz",
-            "integrity": "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg=="
-        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9509,7 +9470,8 @@
         "queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true
         },
         "rc": {
             "version": "1.2.8",
@@ -9635,7 +9597,8 @@
         "reusify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true
         },
         "run-applescript": {
             "version": "7.0.0",
@@ -9647,6 +9610,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
             }
@@ -9810,7 +9774,8 @@
         "slash": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true
         },
         "slice-ansi": {
             "version": "4.0.0",
@@ -10112,6 +10077,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -10198,9 +10164,9 @@
             }
         },
         "typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -3467,7 +3467,6 @@
     },
     "dependencies": {
         "copy-dir": "^1.3.0",
-        "del": "^8.0.1",
         "extract-zip": "^2.0.1",
         "moment": "^2.30.1",
         "moment-duration-format": "^2.3.2",
@@ -3506,7 +3505,7 @@
         "@vscode/vsce": "^3.9.2",
         "eslint": "^10.8.0",
         "ts-loader": "^9.6.2",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "webpack": "^5.109.2",
         "webpack-cli": "^7.2.2"
     }

--- a/src/dirfuncs.ts
+++ b/src/dirfuncs.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { deleteSync } from 'del';
 import { visualText } from './visualText';
 import { anaSubDir } from './analyzer';
 
@@ -249,7 +248,7 @@ export namespace dirfuncs {
         if (!fs.existsSync(dirPath) || dirPath.length <= 2)
             return false;
         try {
-            deleteSync(dirPath, { force: true });
+            fs.rmSync(dirPath, { recursive: true, force: true });
             return true;
         } catch (err: any) {
             vscode.window.showInformationMessage('Error deleting folder ' + dirPath + ': ' + err.message);
@@ -276,7 +275,7 @@ export namespace dirfuncs {
         if (!fs.existsSync(dirPath) || dirPath.length <= 2)
             return false;
         try {
-            deleteSync(dirPath, { force: true });
+            fs.rmSync(dirPath, { recursive: true, force: true });
             fs.mkdirSync(dirPath);
             return true;
         } catch (err: any) {

--- a/tsconfig.format.json
+++ b/tsconfig.format.json
@@ -5,14 +5,15 @@
 	"compilerOptions": {
 		"rootDir": "src/format",
 		"outDir": "out-format",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": ["es2019"],
 		"strict": true,
 		"noImplicitAny": false,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"types": ["node"],
 		"sourceMap": false
 	},
 	"include": ["src/format/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "rootDir": "src",
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "node16",
+        "moduleResolution": "node16",
         "target": "es6",
         "outDir": "out",
         "sourceMap": true,
@@ -18,6 +18,13 @@
         // @types/eslint-scope, a transitive dependency of webpack that no source
         // file here imports.
         "skipLibCheck": true,
+        // Declared explicitly rather than left to the automatic @types scan.
+        // Under module/moduleResolution node16 the scan stopped contributing
+        // @types/node's globals, so `require`, `process` and `__dirname` went
+        // unresolved across visualText.ts. Naming them also makes the set
+        // deterministic: it no longer depends on which @types packages happen to
+        // be installed alongside.
+        "types": ["node", "vscode"],
         "lib": [
             "es2019",
             "es6",

--- a/tsconfig.language.json
+++ b/tsconfig.language.json
@@ -7,14 +7,15 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "out-language",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": ["es2019"],
 		"strict": true,
 		"noImplicitAny": false,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"types": ["node"],
 		"sourceMap": false
 	},
 	"include": ["src/language/**/*.ts", "src/format/**/*.ts"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,14 +7,15 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "out-test",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": ["es2019"],
 		"strict": true,
 		"noImplicitAny": false,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"types": ["node", "vscode"],
 		"sourceMap": false
 	},
 	"include": ["src/test/**/*.ts"]

--- a/tsconfig.treeview.json
+++ b/tsconfig.treeview.json
@@ -6,14 +6,15 @@
 	"compilerOptions": {
 		"rootDir": "src/treeview",
 		"outDir": "out-treeview",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": ["es2019"],
 		"strict": true,
 		"noImplicitAny": false,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
+		"types": ["node"],
 		"sourceMap": false
 	},
 	"include": ["src/treeview/**/*.ts"],


### PR DESCRIPTION
> Supersedes #1146, which bumped typescript alone and failed all four jobs.

TypeScript 6 deprecates `moduleResolution=node10`, which every tsconfig here used:

```
tsconfig.json(5,29): error TS5107: Option 'moduleResolution=node10' is deprecated
and will stop functioning in TypeScript 7.0.
```

Silencing it with `ignoreDeprecations` buys one major version and leaves the same work for whoever hits TypeScript 7. All five configs move to `module` and `moduleResolution: node16` instead. package.json declares no `"type"`, so node16 **still emits CommonJS** — what VS Code loads and what webpack bundles.

Two things had to change to make that compile. Neither is cosmetic.

## `del` is ESM-only — and always was

Under node16 the compiler finally says so:

```
src/dirfuncs.ts(4,28): error TS1479: The current file is a CommonJS module whose
imports will produce 'require' calls; however, the referenced file is an
ECMAScript module and cannot be imported with 'require'.
```

This was already true. node10 resolution just never mentioned it, and it worked at runtime only because **webpack inlines the package** rather than emitting the `require`.

Both call sites pass a plain directory path with no globs — `deleteSync(dirPath, { force: true })` — which is exactly `fs.rmSync(dirPath, { recursive: true, force: true })`, built into Node since 14.14. So `del` is **removed** rather than worked around.

One subtlety worth flagging: `force` means different things either side of that swap. For `del` it waives the refusal to delete outside the working directory; for `fs.rm` it means ignore a missing path. Both call sites already guard with `existsSync` and a `dirPath.length <= 2` check, and `fs.rm` has no cwd restriction to waive — so the behaviour that matters, deleting an analyzer directory outside the workspace, is preserved.

## Ambient types now have to be named

Under node16 the automatic `@types` scan stopped contributing `@types/node`'s globals, so `require`, `process` and `__dirname` went unresolved across visualText.ts and all three harness entry points. Each config now declares its types explicitly.

That's better regardless: the set no longer depends on which `@types` packages happen to be installed alongside.

## Verified on the real compiler, not by argument

I installed TypeScript 6.0.3 locally and worked against it throughout:

```
all five tsconfigs      typecheck clean
lint                    clean
language                79 passed
tree view               63 passed
integration             23 passed
```

The integration suite launches a real VS Code against the rebuilt bundle, so **the changed module emit is exercised rather than assumed** — that's the check that would catch a CommonJS/ESM mistake at runtime.

## The vsix loses `del` and nothing else

```
before:  185 files, 3.05 MB
after:   185 files, 2.93 MB
```

Same file list — I built both sides and diffed them, rather than trusting the counts. (An earlier "184 files" figure of mine was stale; this morning's dependency bumps had already moved it to 185.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
