### PR TITLE
chore: stop shipping two repository documents to users

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -81,8 +81,25 @@ test/**
 !snippets/**
 !grammars/syntaxes/**
 !themes/**
-!*.md
+# Named individually rather than as !*.md. vsce applies every negation after the
+# ignore patterns, so a later plain pattern cannot subtract from an earlier
+# re-include -- a blanket !*.md cannot be narrowed afterwards, it can only be
+# replaced. It was shipping vsc-extension-quickstart.md, the extension
+# generator's scaffold notes, and SECURITY.md, which is for contributors here
+# rather than for users of the extension.
+#
+# README.md is the Marketplace page; CHANGELOG.md is rendered on the Changelog
+# tab. Both are shown to users, so both ship.
+!README.md
+!CHANGELOG.md
 !*.html
+
+# Repository documents, not extension documents. Nothing above excludes markdown
+# at the root, so each needs naming: vsc-extension-quickstart.md is the extension
+# generator's scaffold notes, and SECURITY.md is for people working on this
+# repository rather than for people installing the extension.
+vsc-extension-quickstart.md
+SECURITY.md
 !*-configuration.json
 !.vscodeignore
 !package.json


### PR DESCRIPTION
The vsix contained `vsc-extension-quickstart.md` — the extension generator's scaffold notes, *"Welcome to your VS Code Extension"* — packaged into every release since the project was created. It also contained `SECURITY.md`, which I added yesterday and which is addressed to contributors, not to people installing the extension.

## Why they were there

Nothing in `.vscodeignore` excluded markdown at the root, so both needed naming explicitly. The blanket `!*.md` was re-including files that were **never excluded in the first place** — which made it read as a deliberate choice rather than an oversight.

It's now `!README.md` and `!CHANGELOG.md`: the two actually shown to users — README as the Marketplace page, CHANGELOG on the Changelog tab.

## Worth recording for whoever edits that file next

**vsce applies every negation after the ignore patterns**, so a later plain pattern cannot subtract from an earlier re-include. A blanket negation can't be narrowed — only replaced.

I tried narrowing it first, and the package came out byte-identical. That's how I found out.

## Result

```
before:  185 files, 2.93 MB
after:   183 files, 2.93 MB
```

Verified that only the two intended files left: `dist`, `package.json`, `LICENSE`, the seven grammars, 153 resources, snippets, themes and the colourisation settings template are all still packaged.

Shipped documents are now exactly README.md, CHANGELOG.md, DOWNLOADHELP.html and UPDATERHELP.html — the last two loaded at runtime by the help view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
