### PR TITLE
refactor: clear the unused imports and parameters

### DIFF
--- a/src/analyzerView.ts
+++ b/src/analyzerView.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { visualText } from './visualText';
 import { dirfuncs } from './dirfuncs';
-import { textView, TextItem } from './textView';
+import { textView } from './textView';
 import { fileOpRefresh, fileOperation } from './fileOps';
 import { SequenceFile } from './sequence';
 import { TextFile } from './textFile';
@@ -189,7 +189,7 @@ export class AnalyzerView {
 	public converting: boolean;
 	private sequenceFile = new SequenceFile;
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const analyzerViewProvider = new AnalyzerTreeDataProvider();
 		this.analyzerView = vscode.window.createTreeView('analyzerView', { treeDataProvider: analyzerViewProvider });
 		vscode.commands.registerCommand('analyzerView.refreshAll', () => analyzerViewProvider.refresh());
@@ -197,7 +197,7 @@ export class AnalyzerView {
 		vscode.commands.registerCommand('analyzerView.deleteAnalyzer', resource => this.deleteAnalyzer(resource));
 		vscode.commands.registerCommand('analyzerView.deleteFile', resource => this.deleteFile(resource));
 		vscode.commands.registerCommand('analyzerView.deleteFolder', resource => this.deleteFolder(resource));
-		vscode.commands.registerCommand('analyzerView.loadExampleAnalyzers', resource => this.loadExampleAnalyzers());
+		vscode.commands.registerCommand('analyzerView.loadExampleAnalyzers', _resource => this.loadExampleAnalyzers());
 		vscode.commands.registerCommand('analyzerView.openAnalyzer', resource => this.openAnalyzer(resource));
 		vscode.commands.registerCommand('analyzerView.deleteAnalyzerLogs', resource => this.deleteAnalyzerLogs(resource));
 		vscode.commands.registerCommand('analyzerView.deleteAllAnalyzerLogs', () => this.deleteAllAnalyzerLogs());
@@ -258,7 +258,7 @@ export class AnalyzerView {
 		return items;
 	}
 
-	newECLFile(analyzerItem: AnalyzerItem) {
+	newECLFile(_analyzerItem: AnalyzerItem) {
 		if (visualText.hasWorkspaceFolder() && this.checkForECLAnalyzersDir().length > 0) {
 			vscode.window.showInputBox({ value: 'filename', prompt: 'Enter ECL file name' }).then(newname => {
 				if (newname) {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -257,7 +257,7 @@ export class NLPCompile {
         // 1. Check NLP engine executable
         const exe = visualText.exePath().fsPath;
         if (!exe.length || !fs.existsSync(exe)) {
-            vscode.window.showErrorMessage('NLP Engine missing', 'Download Now').then(response => {
+            vscode.window.showErrorMessage('NLP Engine missing', 'Download Now').then(_response => {
                 visualText.startUpdater();
             });
             return;

--- a/src/dirfuncs.ts
+++ b/src/dirfuncs.ts
@@ -303,7 +303,7 @@ export namespace dirfuncs {
         return filenames.length ? true : false;
     }
 
-    export function hasLogDirs(dir: vscode.Uri, first: boolean): boolean {
+    export function hasLogDirs(dir: vscode.Uri, _first: boolean): boolean {
         if (dirfuncs.isDir(dir.fsPath)) {
             const entries = dirfuncs.getDirectoryTypes(dir);
 

--- a/src/findView.ts
+++ b/src/findView.ts
@@ -37,7 +37,7 @@ export class FindTreeDataProvider implements vscode.TreeDataProvider<FindItem> {
 		};
 	}
 
-	public getChildren(element?: FindItem): FindItem[] {
+	public getChildren(_element?: FindItem): FindItem[] {
 		return findView.getFinds();
 	}
 }
@@ -53,7 +53,7 @@ export class FindView {
 	public findItems: FindItem[] = [];
 	private searchWord: string = '';
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const findViewProvider = new FindTreeDataProvider();
 		this.findView = vscode.window.createTreeView('findView', { treeDataProvider: findViewProvider });
 		vscode.commands.registerCommand('findView.refreshAll', () => findViewProvider.refresh());

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { visualText } from './visualText';
-import { ETIME } from 'constants';
 
 // One entry in the Help tree view. `page` is a path under Help/markdown/ (no .md).
 export interface HelpItem {
@@ -146,7 +145,7 @@ export class HelpView {
         return helpView;
     }
 
-    lookup(resource: vscode.Uri) {
+    lookup(_resource: vscode.Uri) {
         const editor = vscode.window.activeTextEditor;
         if (editor) {
             const cursorPosition = editor.selection.start;
@@ -182,7 +181,7 @@ export class HelpView {
         return 'Not found: ' + term;
     }
 
-    windowCHMHelp(resource: vscode.Uri) {
+    windowCHMHelp(_resource: vscode.Uri) {
         if (os.platform() == 'win32') {
             const helpPath = path.join(visualText.getVisualTextDirectory('Help'), 'Help.chm');
             if (fs.existsSync(helpPath)) {

--- a/src/kbView.ts
+++ b/src/kbView.ts
@@ -257,7 +257,7 @@ export class KBView {
 	private findFile = new FindFile();
 	private textFile = new TextFile();
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const treeDataProvider = new FileSystemProvider();
 		this.kbView = vscode.window.createTreeView('kbView', { treeDataProvider });
 		vscode.commands.registerCommand('kbView.refreshAll', () => treeDataProvider.refresh());
@@ -286,7 +286,7 @@ export class KBView {
 		vscode.commands.registerCommand('kbView.modAdd', (KBItem) => this.modAdd(KBItem));
 		vscode.commands.registerCommand('kbView.modCreate', () => this.modCreate());
 		vscode.commands.registerCommand('kbView.modLoad', (KBItem) => this.modLoad(KBItem));
-		vscode.commands.registerCommand('kbView.langLibs', (KBItem) => this.langLibs());
+		vscode.commands.registerCommand('kbView.langLibs', (_KBItem) => this.langLibs());
 		vscode.commands.registerCommand('kbView.miscLibs', () => this.miscLibs());
 		vscode.commands.registerCommand('kbView.compileKB', (item?: any) => this.compileKB(item));
 	}

--- a/src/logView.ts
+++ b/src/logView.ts
@@ -44,7 +44,7 @@ export class OutputTreeDataProvider implements vscode.TreeDataProvider<LogItem> 
 		};
 	}
 
-	public getChildren(element?: LogItem): LogItem[] {
+	public getChildren(_element?: LogItem): LogItem[] {
 		if (visualText.hasWorkspaceFolder()) {
 			return logView.getLogs();
 		}
@@ -53,7 +53,7 @@ export class OutputTreeDataProvider implements vscode.TreeDataProvider<LogItem> 
 
 	// Required for TreeView.reveal() (used to auto-scroll to the newest line).
 	// The log is a flat list, so every item is a root node with no parent.
-	public getParent(element: LogItem): LogItem | undefined {
+	public getParent(_element: LogItem): LogItem | undefined {
 		return undefined;
 	}
 }
@@ -405,7 +405,7 @@ export class LogView {
 				const pos = line.indexOf('.json');
 				const filepath = line.substring(18, pos + 5);
 				const msg = 'Json error(s) in file: ' + filepath;
-				vscode.window.showErrorMessage(msg, "Click to fix file").then(response => {
+				vscode.window.showErrorMessage(msg, "Click to fix file").then(_response => {
 					vscode.window.showTextDocument(vscode.Uri.file(filepath));
 				});
 				break;

--- a/src/modFile.ts
+++ b/src/modFile.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { visualText } from './visualText';
-import { TextFile, nlpFileType } from './textFile';
+import { TextFile } from './textFile';
 import { SequenceFile, PassItem } from './sequence';
 import { logView, logLineType } from './logView';
 import { anaSubDir } from './analyzer';

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -28,12 +28,6 @@ interface analyzerRun {
 	type: analyzerType;
 }
 
-interface ruleParse {
-	suggested: string,
-	rule: string,
-	comment: string
-}
-
 export let nlpFile: NLPFile;
 export class NLPFile extends TextFile {
 
@@ -72,7 +66,7 @@ export class NLPFile extends TextFile {
 			// Check to see if the engine executable is there
 			const exe = visualText.exePath().fsPath;
 			if (!exe.length || !fs.existsSync(exe)) {
-				vscode.window.showErrorMessage("NLP Engine missing", "Download Now").then(response => {
+				vscode.window.showErrorMessage("NLP Engine missing", "Download Now").then(_response => {
 					visualText.startUpdater();
 				});
 			}
@@ -501,7 +495,7 @@ export class NLPFile extends TextFile {
 		}
 	}
 
-	findLineSelection(line: string): vscode.Selection {
+	findLineSelection(_line: string): vscode.Selection {
 		let contextSel = this.findLineStartsWith('@NODES');
 		if (contextSel.isEmpty)
 			contextSel = this.findLineStartsWith('@PATH');

--- a/src/outputView.ts
+++ b/src/outputView.ts
@@ -48,7 +48,7 @@ export class OutputTreeDataProvider implements vscode.TreeDataProvider<OutputIte
 		};
 	}
 
-	public getChildren(outputItem?: OutputItem): OutputItem[] {
+	public getChildren(_outputItem?: OutputItem): OutputItem[] {
 		if (visualText.hasWorkspaceFolder()) {
 			const children: OutputItem[] = new Array();
 			for (const folder of outputView.getOutputFiles()) {
@@ -70,7 +70,7 @@ export class OutputView {
 	private testDirectory: vscode.Uri;
 	private type: outputFileType;
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const outputViewProvider = new OutputTreeDataProvider();
 		this.outputView = vscode.window.createTreeView('outputView', { treeDataProvider: outputViewProvider });
 		vscode.commands.registerCommand('outputView.refreshAll', () => outputViewProvider.refresh());

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -668,7 +668,7 @@ export class SequenceView {
 		return sequenceView;
 	}
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const treeDataProvider = new PassTree();
 
 		this.sequenceView = vscode.window.createTreeView('sequenceView', { treeDataProvider });

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { visualText,updateOp } from './visualText';
+import { visualText } from './visualText';
 import { TreeFile } from './treeFile';
 import { nlpFileType } from './textFile';
 import * as os from 'os';

--- a/src/textFile.ts
+++ b/src/textFile.ts
@@ -33,7 +33,7 @@ export class TextFile {
             this.setFile(vscode.Uri.file(filepath), separateLines);
     }
 
-    runPython(editor: vscode.TextEditor) {
+    runPython(_editor: vscode.TextEditor) {
         if (vscode.window.activeTextEditor) {
             const editor = vscode.window.activeTextEditor;
             if (editor) {

--- a/src/textView.ts
+++ b/src/textView.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { visualText, closeFileIfOpen } from './visualText';
+import { visualText } from './visualText';
 import { NLPFile, analyzerType } from './nlp';
 import { FindFile } from './findFile';
 import { findView } from './findView';
 import { dirfuncs } from './dirfuncs';
-import { nlpStatusBar, DevMode, FiredMode } from './status';
+import { nlpStatusBar, DevMode } from './status';
 import { fileOperation, fileOpRefresh } from './fileOps';
 import { anaSubDir } from './analyzer';
 import { regressionRunner } from './regression';
@@ -153,7 +153,7 @@ export class FileSystemProvider implements vscode.TreeDataProvider<TextItem> {
 		return keepers;
 	}
 
-	checkFileCount(dir: string) {
+	checkFileCount(_dir: string) {
 		const count = dirfuncs.fileCount(visualText.analyzer.getInputDirectory());
 		if (!visualText.fastAnswered && count > 100 && !visualText.getTextFastLoad()) {
 			const items: vscode.QuickPickItem[] = [];
@@ -294,7 +294,7 @@ export class TextView {
 	private findFile = new FindFile();
 	public folderUri: vscode.Uri | undefined;
 
-	constructor(context: vscode.ExtensionContext) {
+	constructor(_context: vscode.ExtensionContext) {
 		const treeDataProvider = new FileSystemProvider();
 		this.textView = vscode.window.createTreeView('textView', { treeDataProvider, showCollapseAll: true, canSelectMany: true });
 		vscode.commands.registerCommand('textView.refreshAll', () => treeDataProvider.refresh());
@@ -485,7 +485,7 @@ export class TextView {
 		}
 	}
 
-	exploreAll(textItem: TextItem) {
+	exploreAll(_textItem: TextItem) {
 		const inputDir = visualText.analyzer.getInputDirectory().fsPath;
 		if (fs.existsSync(inputDir)) {
 			visualText.openFileManager(inputDir);

--- a/src/treeview/renderSvg.ts
+++ b/src/treeview/renderSvg.ts
@@ -6,7 +6,7 @@
 // click-to-reveal. Colors/fonts are left to the host stylesheet (CSS classes),
 // so the same markup themes correctly in light and dark VS Code.
 
-import { LayoutResult, LayoutNode, flatten } from "./layout";
+import { LayoutResult, flatten } from "./layout";
 
 function esc(s: string): string {
 	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -652,7 +652,7 @@ export class VisualText {
     }
 
     checkExeVersion(op: updateOp) {
-        visualText.fetchExeVersion(op)?.then(version => {
+        visualText.fetchExeVersion(op)?.then(_version => {
             visualText.checkEngineVersionRepo(op)
                 .then(newerVersion => {
                     if (newerVersion) {
@@ -663,7 +663,7 @@ export class VisualText {
                     visualText.updateVersion(op);
                 })
         })
-            .catch(error => {
+            .catch(_error => {
                 op.status = upStat.FAILED;
             });
         op.status = upStat.RUNNING;
@@ -675,7 +675,7 @@ export class VisualText {
             const https = require('follow-redirects').https;
 
             const request = https.get(this.GITHUB_ENGINE_LATEST_VERSION, function (res) {
-                res.on('data', function (chunk) {
+                res.on('data', function (_chunk) {
                     let newer = false;
                     if (op.status != upStat.DONE) {
                         const url = res.responseUrl;
@@ -738,7 +738,7 @@ export class VisualText {
             const https = require('follow-redirects').https;
 
             const request = https.get(this.GITHUB_VISUALTEXT_FILES_LATEST_VERSION, function (res) {
-                res.on('data', function (chunk) {
+                res.on('data', function (_chunk) {
                     let newer = false;
                     if (op.status != upStat.DONE) {
                         const url = res.responseUrl;
@@ -791,7 +791,7 @@ export class VisualText {
             const https = require('follow-redirects').https;
 
             const request = https.get(this.GITHUB_ANALYZERS_LATEST_VERSION, function (res) {
-                res.on('data', function (chunk) {
+                res.on('data', function (_chunk) {
                     let newer = false;
                     if (op.status != upStat.DONE) {
                         const url = res.responseUrl;
@@ -1094,7 +1094,7 @@ export class VisualText {
     }
 
     failedWarning() {
-        vscode.window.showErrorMessage("Update failed", "Click here to see solutions").then(response => {
+        vscode.window.showErrorMessage("Update failed", "Click here to see solutions").then(_response => {
             logView.downloadHelp();
         });
     }
@@ -1317,7 +1317,7 @@ export class VisualText {
         const config = vscode.workspace.getConfiguration('user');
         const username = config.get<string>('name');
         if (!username) {
-            vscode.window.showErrorMessage("No user name for comments.", "Enter user name").then(response => {
+            vscode.window.showErrorMessage("No user name for comments.", "Enter user name").then(_response => {
                 vscode.window.showInputBox({ value: 'Your Name', prompt: 'Enter author name for comments' }).then(username => {
                     if (username) {
                         visualText.username = username;


### PR DESCRIPTION
First half of adopting `@typescript-eslint/no-unused-vars`, which reports **95 findings**.

This takes the **38 mechanical ones** — names declared and never referenced at all — and leaves the 57 *"assigned a value but never used"* for a separate pass, because several of those look like real defects rather than dead weight and each needs reading rather than deleting.

## Seven imports removed

One worth naming: `helpView.ts` imported **`ETIME` from Node's `constants` module** — deprecated since Node 6 — and never used it. Also gone: `TextItem` (analyzerView), `nlpFileType` (modFile), `LayoutNode` (renderSvg), `updateOp` (status), and `closeFileIfOpen` + `FiredMode` (textView).

## One dead type

`interface ruleParse` in nlp.ts — declared, never referenced.

## Thirty parameters prefixed rather than deleted

Deleting them would change signatures that callers and interfaces depend on — `TreeDataProvider.getChildren`/`getParent`, and six view constructors whose callers pass a context regardless. The underscore is what the rule's `argsIgnorePattern` already treats as deliberate, so the intent is now **stated in the code instead of inferred**.

I applied these by line and column from ESLint's own output rather than by regex, so nothing was renamed by coincidence.

## One thing I checked rather than assumed

Three `res.on('data', function (chunk))` handlers in visualText.ts ignore their chunk. That looks like a bug — a data handler that discards its data — so I read all three. Each reads `res.responseUrl` from follow-redirects instead, using the event purely as a signal that the redirect resolved. The parameter is genuinely unwanted there.

## The rule is not switched on yet

It can't be an `error` while 57 findings remain, and a warning nobody sees in CI isn't a control. It goes on in the commit that clears the rest.

## Verification

Behaviour is unchanged by construction — nothing here was referenced. Verified anyway:

```
typecheck     clean
lint          clean
language      79 passed
tree view     63 passed
integration   23 passed
```

The integration suite launches a real VS Code against the rebuilt bundle.

## What's coming next

The 57 remaining include some genuinely suspicious ones I'll be reading individually:

- `textView.ts:566` — `msg = msg.concat(...)` building a message that's then never used
- `textFile.ts:64-65` and `visualText.ts:1772-1773` — light/dark icon paths computed for QuickPick items and dropped
- `treeFile.ts:131` — `tokens[0].split('\s')`, where `'\s'` in a string literal is just the letter *s*
- `status.ts:221` — a `changed` flag computed and never consulted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
