### PR TITLE
test: cover cross-pass definition, references and rename

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,10 @@ module.exports = [
                 caughtErrors: 'none',
             }],
 
+            // A `let` that is never reassigned misreports the author's intent, and
+            // reading one costs a moment working out whether it changes later.
+            'prefer-const': 'error',
+
             // --- rules the compiler already covers, or that fight the code style ------
             'no-undef': 'off',                   // tsc does this properly for TS
             'no-unused-vars': 'off',             // superseded by the typed rule above

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -149,8 +149,7 @@ export class Analyzer {
                     const basename = path.basename(file.fsPath);
                     if (dirfuncs.isDir(file.fsPath)) {
                         const readme = path.join(file.fsPath, "README.md");
-                        let descr: string, tit: string;
-                        ({ title: tit, description: descr } = this.readDescription(readme));
+                        const { title: tit, description: descr } = this.readDescription(readme);
                         const item: vscode.QuickPickItem = { label: tit, description: descr };
                         if (basename === "Knowledge Base") {
                             // Default choice: pre-check the Knowledge Base template and float it to the top.
@@ -169,7 +168,7 @@ export class Analyzer {
                         return false;
                     }
                     if (selections.length == 1) {
-                        let dirName = dirMap[selections[0].label];
+                        const dirName = dirMap[selections[0].label];
                         this.makeNewAnalyzer(fromDir, dirName);
                         visualText.fileOps.startFileOps();
                         this.loaded = true;

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -631,7 +631,7 @@ export class NLPFile extends TextFile {
 		if (this.getFileType() == nlpFileType.NLP || this.getFileType() == nlpFileType.DICT || this.getFileType() == nlpFileType.KBB) {
 			const position = editor.selection.active;
 			const lines = this.getLines(true);
-			let line = lines[position.line];
+			const line = lines[position.line];
 			const posEnd = new vscode.Position(position.line + 1, 0);
 			const rang = new vscode.Selection(posEnd, posEnd);
 			// appendText escapes snippet metacharacters (\, $, }) so a literal "\\" is

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -28,6 +28,34 @@ function unsetHostEnvironment(): void {
 	}
 }
 
+// Two pass files in the workspace, so the cross-pass features have something
+// real to resolve against.
+//
+// Definition, references and rename all go through nlpWorkspaceIndex, which
+// scans the workspace for **/*.{nlp,pat,kbb} -- it does not require an analyzer
+// directory layout, so two files on disk are the whole fixture. They must exist
+// before VS Code starts, since the index builds from what findFiles sees.
+//
+// FIXTURE_RULE is declared in the first and used in the second: a rule head is
+// `_name <- ... @@` inside an @RULES region, so the occurrence in pass two is a
+// reference rather than a second declaration.
+export const FIXTURE_RULE = "_fixtureSharedRule";
+export const FIXTURE_DECL_FILE = "pass1_declares.nlp";
+export const FIXTURE_REF_FILE = "pass2_references.nlp";
+
+function writeCrossPassFixture(dir: string): void {
+	fs.writeFileSync(
+		path.join(dir, FIXTURE_DECL_FILE),
+		`@NODES _ROOT\n\n@RULES\n${FIXTURE_RULE} <- _xALPHA @@\n`,
+		"utf8"
+	);
+	fs.writeFileSync(
+		path.join(dir, FIXTURE_REF_FILE),
+		`@NODES _ROOT\n\n@RULES\n_fixtureCaller <- ${FIXTURE_RULE} @@\n`,
+		"utf8"
+	);
+}
+
 async function main(): Promise<void> {
 	unsetHostEnvironment();
 
@@ -35,6 +63,7 @@ async function main(): Promise<void> {
 	// per-workspace state, so handing it a throwaway directory keeps a test run
 	// from touching whatever the developer happens to have open.
 	const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "nlp-itest-"));
+	writeCrossPassFixture(workspace);
 
 	try {
 		await runTests({

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -166,9 +166,8 @@ export async function providerTests(): Promise<void> {
 // happily with no provider registered, since VS Code returns an empty array in
 // both cases.
 //
-// Definition, references and rename are deliberately absent: they resolve across
-// passes via the workspace index, which needs a real analyzer on disk rather than
-// an untitled buffer. langTest.ts exercises that logic directly.
+// Definition, references and rename are not here because they need files on disk
+// rather than an untitled buffer; they are covered in crossPassTests below.
 
 async function openNlp(content: string): Promise<vscode.TextDocument> {
 	return vscode.workspace.openTextDocument({ language: "nlp", content });
@@ -239,6 +238,8 @@ export async function languageFeatureTests(): Promise<void> {
 		);
 	}
 
+	// Cross-pass resolution is covered separately, in crossPassTests.
+
 	// Semantic tokens: the colouring layered over the TextMate grammar.
 	//
 	// Needs a @CODE region containing something classifiable from the *static*
@@ -259,4 +260,96 @@ export async function languageFeatureTests(): Promise<void> {
 			`got ${tokens ? `${tokens.data.length} ints` : "undefined"}`
 		);
 	}
+}
+
+// ---- cross-pass resolution -------------------------------------------------
+// Definition, references and rename resolve a name declared in ONE pass file
+// from a use in ANOTHER, through nlpWorkspaceIndex. langTest.ts covers the
+// symbol parsing in isolation; only a real workspace exercises the index that
+// joins the files together, which is where the cross-pass logic actually lives.
+//
+// The fixture is two .nlp files written into the temp workspace by runTest.ts
+// before VS Code starts: pass1_declares.nlp has `_fixtureSharedRule <- ... @@`
+// and pass2_references.nlp uses that name on a rule's right-hand side.
+
+const FIXTURE_RULE = "_fixtureSharedRule";
+const FIXTURE_DECL_FILE = "pass1_declares.nlp";
+const FIXTURE_REF_FILE = "pass2_references.nlp";
+
+function fixtureUri(name: string): vscode.Uri | undefined {
+	const folder = vscode.workspace.workspaceFolders?.[0];
+	return folder ? vscode.Uri.joinPath(folder.uri, name) : undefined;
+}
+
+export async function crossPassTests(): Promise<void> {
+	const refUri = fixtureUri(FIXTURE_REF_FILE);
+	const declUri = fixtureUri(FIXTURE_DECL_FILE);
+	if (!refUri || !declUri) {
+		unreachable("cross-pass definition resolves to the declaring file", "no workspace folder");
+		return;
+	}
+
+	let refDoc: vscode.TextDocument;
+	try {
+		refDoc = await vscode.workspace.openTextDocument(refUri);
+	} catch (err) {
+		unreachable("cross-pass definition resolves to the declaring file", String(err));
+		return;
+	}
+
+	// Position on the *use* of the shared rule in pass two.
+	const useOffset = refDoc.getText().indexOf(FIXTURE_RULE);
+	check(`${FIXTURE_REF_FILE} contains a use of ${FIXTURE_RULE}`, useOffset >= 0);
+	if (useOffset < 0) return;
+	const usePos = refDoc.positionAt(useOffset + 2);
+
+	// Definition: must land in the other file, not merely return something.
+	const defs = await vscode.commands.executeCommand<vscode.Location[]>(
+		"vscode.executeDefinitionProvider",
+		refUri,
+		usePos
+	);
+	const landedInDecl = (defs ?? []).some((d) => d.uri.fsPath === declUri.fsPath);
+	check(
+		"cross-pass definition resolves to the declaring file",
+		landedInDecl,
+		`got ${(defs ?? []).length} location(s): ${(defs ?? []).map((d) => d.uri.path.split("/").pop()).join(", ") || "none"}`
+	);
+
+	// References: both the declaration and the use, in two different files.
+	const refs = await vscode.commands.executeCommand<vscode.Location[]>(
+		"vscode.executeReferenceProvider",
+		refUri,
+		usePos
+	);
+	const files = new Set((refs ?? []).map((r) => r.uri.fsPath));
+	check(
+		"references span both pass files",
+		files.has(declUri.fsPath) && files.has(refUri.fsPath),
+		`got ${(refs ?? []).length} reference(s) across ${files.size} file(s)`
+	);
+
+	// Rename: the edit has to reach the declaring file too, or renaming from a
+	// use would leave the declaration behind and silently break the analyzer.
+	// The provider rejects a name it cannot resolve -- "not a declared rule,
+	// function, or concept" -- by throwing rather than returning nothing, so a
+	// bare await would abort the group and lose the checks above it.
+	let edit: vscode.WorkspaceEdit | undefined;
+	try {
+		edit = await vscode.commands.executeCommand<vscode.WorkspaceEdit>(
+			"vscode.executeDocumentRenameProvider",
+			refUri,
+			usePos,
+			"_fixtureRenamed"
+		);
+	} catch (err) {
+		check("rename edits both pass files", false, `rename provider threw: ${String(err)}`);
+		return;
+	}
+	const touched = edit ? edit.entries().map(([uri]) => uri.fsPath) : [];
+	check(
+		"rename edits both pass files",
+		touched.includes(declUri.fsPath) && touched.includes(refUri.fsPath),
+		`edits ${touched.length} file(s): ${touched.map((p) => p.split(/[\\/]/).pop()).join(", ") || "none"}`
+	);
 }

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -12,6 +12,7 @@ import {
 	configurationTests,
 	providerTests,
 	languageFeatureTests,
+	crossPassTests,
 } from "./extension.test";
 
 export async function run(): Promise<void> {
@@ -22,6 +23,7 @@ export async function run(): Promise<void> {
 		["configuration", configurationTests],
 		["providers", providerTests],
 		["language features", languageFeatureTests],
+		["cross-pass resolution", crossPassTests],
 	];
 
 	for (const [name, fn] of groups) {

--- a/src/textView.ts
+++ b/src/textView.ts
@@ -117,7 +117,7 @@ export class FileSystemProvider implements vscode.TreeDataProvider<TextItem> {
 
 	getKeepers(dir: vscode.Uri): TextItem[] {
 		// this.checkFileCount(dir.fsPath);
-		let keepers = Array();
+		const keepers = Array();
 		const entries = dirfuncs.getDirectoryTypes(dir);
 
 		const startTime = moment();


### PR DESCRIPTION
The integration suite skipped definition, references and rename when it was written. My stated reason was that they resolve through `nlpWorkspaceIndex` and so need files on disk, and that fabricating an analyzer layout "would test my guess at that layout as much as the providers."

**That reasoning was wrong about the requirement.** The index scans the workspace for `**/*.{nlp,pat,kbb}` — it doesn't care about analyzer directory structure at all. Two pass files written into the temp workspace before VS Code starts are the whole fixture:

```
pass1_declares.nlp     _fixtureSharedRule <- _xALPHA @@
pass2_references.nlp   _fixtureCaller <- _fixtureSharedRule @@
```

## What the three checks assert

All three are about **crossing the file boundary** — the part [langTest.ts](src/language/langTest.ts) cannot reach, since it exercises symbol parsing within a single text.

- **definition** from the use lands in the *declaring file*, asserted on the resolved path rather than on "something came back"
- **references** span both files, not just the one under the cursor
- **rename** edits both files — renaming from a use while leaving the declaration behind would quietly break an analyzer

## Each was verified to fail

With the declaration removed from the first file and the use left in place:

```
FAIL: cross-pass definition resolves to the declaring file — got 0 location(s): none
FAIL: references span both pass files — got 1 reference(s) across 1 file(s)
FAIL: rename edits both pass files — rename provider threw: "_fixtureSharedRule" is not a
      declared rule, function, or concept.
```

**That last one changed the code.** The rename provider rejects an unresolvable name by *throwing*, not by returning nothing — so a bare `await` aborted the entire group and took the two checks above it down with it. It's now caught and reported as a failed check, which is both more useful and honest about what happened.

I also confirmed the fixture's own sanity check fires: pointing pass two at a name that appears nowhere fails at "contains a use of" before the real assertions run.

## Also: `prefer-const` switched on

Five fixes. Four mechanical; the fifth ESLint can't auto-fix, because it would have to merge a declaration into an assignment:

```ts
let descr: string, tit: string;
({ title: tit, description: descr } = this.readDescription(readme));
```

As a destructuring declaration that's one line instead of two, and `const`.

## Verification

```
typecheck     clean
lint          clean (prefer-const now on)
grammars      7
worker guard  undici 7.29.0
language      79 passed
tree view     63 passed
integration   27 passed  (was 23)
package       183 files, 2.93 MB
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
