### PR TITLE
chore: release 3.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.8
+Telemetry can now say which of the shipped examples people actually use.
+
+- **Running or creating one of the analyzers this extension ships now records its name.** Until now the question "which examples are worth maintaining?" was unanswerable: analyzer runs deliberately left the name out, and creating an analyzer was not recorded at all. The templates and the analyzers from the [analyzers](https://github.com/VisualText/analyzers) repository are a fixed, public set, so naming one says nothing about you -- the same way a command id does not.
+- **Your own analyzers are still never named.** The name is checked against the folders the extension downloads from those public repositories, and anything else is left out of the record entirely rather than replaced with a placeholder. Because the list comes from those folders rather than being written into the extension, a template added to either repository is covered without waiting for a release.
+- **The Telemetry section of the README says all of this**, as does `SECURITY.md`. The old wording promised that analyzer names were never sent, which this would have made untrue; it now promises that the names *you* create are never sent, and states the exception plainly.
+- Creating an analyzer also records which template you started from and how many blocks you combined -- template names only, never the name you gave the analyzer.
+- **Smaller download.** The bundle drops about 120 KB: `del` is gone, replaced by Node's own `fs.rmSync`, which does the same job for the two places that used it.
+
+Nothing here is retroactive. It answers the question from this release onward.
+
 ### 3.12.7
 Two failures that only ever showed up away from a developer's machine.
 

--- a/README.md
+++ b/README.md
@@ -157,14 +157,17 @@ NLP++ is 100% open source and coordinated by two organizations:
 
 ## Telemetry
 
-This extension can send **anonymous usage data** to help prioritize features and catch errors in the field. It records only counts and metadata. It **never** sends file contents, analyzer/KB/dictionary source, file names, paths, analyzer names, or any text being analyzed — and never the text of an error message, since those routinely quote paths and rule source.
+This extension can send **anonymous usage data** to help prioritize features and catch errors in the field. It records only counts and metadata. It **never** sends file contents, analyzer/KB/dictionary source, file names, paths, the names of analyzers you create, or any text being analyzed — and never the text of an error message, since those routinely quote paths and rule source.
+
+The one exception is deliberate and narrow: when you run or create an analyzer **that this extension shipped** — one of the templates, or an analyzer from the public [analyzers](https://github.com/VisualText/analyzers) repository — its name is recorded, so we can see which examples are worth maintaining. Those names are already public, and they are matched against the folders the extension downloads: a name that is not one of them is left out entirely rather than replaced with a placeholder.
 
 What is recorded:
 
 - **Environment**, attached to every record: extension version, VS Code version, OS platform and CPU architecture, the NLP++ engine version once detected, and whether the window is local, remote (WSL/SSH), or web.
 - **Sessions**: an activation record noting whether this was a fresh install, an upgrade (and from which version), or an ordinary relaunch.
 - **Feature usage**: which extension commands and language features (hover, go-to-definition, find references, rename, completion, signature help) were used, as periodic counts. Command identifiers are fixed strings from this extension — never anything you typed.
-- **Analyzer runs**: run mode, dev mode, whether the target was a file or a folder, and the timing breakdown already shown in the log view (setup, engine startup, KB load, analyzer load, exec, post-processing). On failure, only whether it was a syntax or execution error.
+- **Analyzer runs**: run mode, dev mode, whether the target was a file or a folder, and the timing breakdown already shown in the log view (setup, engine startup, KB load, analyzer load, exec, post-processing). On failure, only whether it was a syntax or execution error. If the analyzer is one this extension shipped, its name — see the exception above.
+- **New analyzers**: which shipped template you started from, and how many blocks you combined. Template names only; the name you give the analyzer is not recorded.
 - **Compiles**: target and route (local or cloud), success or failure, elapsed time, and for failures a fixed stage name such as `no-cmake`, `codegen`, or `release-not-found`. For cloud compiles: the platform key, whether the build was a cache hit, runner wait time, and the payload size in KB. Deploying a compiled analyzer records how many lazy KB files and python scripts were copied — never the destination or any file name.
 - **Engine updates**: which component was downloaded or unzipped, its public release tag, elapsed time, and whether it succeeded.
 - **Regression runs**: number of files, and how many passed, failed, were missing, or were blessed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,10 +32,15 @@ alarming without context:
   with your permissions.
 - **It sends anonymous usage telemetry**, opt-out via `nlp.telemetry.enable` and
   also honoured through VS Code's own `telemetry.telemetryLevel`. Counts and
-  version metadata only -- never file contents, file names, paths, analyzer
-  names, or error message text. The full schema and the worker that receives it
-  are in [`telemetry-worker/`](telemetry-worker/), and the categories are listed
-  in the README.
+  version metadata only -- never file contents, file names, paths, the names of
+  analyzers you create, or error message text. One deliberate exception: the
+  names of analyzers and templates the extension itself ships are recorded when
+  you run or create one, since those names are already public and knowing which
+  examples get used decides which are worth maintaining. They are matched
+  against the folders the extension downloads, so anything else is omitted
+  rather than redacted. The full schema and the worker that receives it are in
+  [`telemetry-worker/`](telemetry-worker/), and the categories are listed in the
+  README.
 - **It writes inside your workspace**, including a `.vscode/settings.json` for
   colourisation and analyzer output under the analyzer folder.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.12.7",
+    "version": "3.12.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.12.7",
+            "version": "3.12.8",
             "license": "MIT",
             "dependencies": {
                 "copy-dir": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.7",
+    "version": "3.12.8",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -10,6 +10,7 @@ import { nlpFileType } from "./textFile";
 import { logLineType } from "./logView";
 import { fileOpRefresh, fileOperation } from "./fileOps";
 import { sequenceView } from "./sequenceView";
+import * as telemetry from "./telemetry/telemetry";
 
 export enum anaSubDir { UNKNOWN, INPUT, KB, LOGS, OUTPUT, SPEC };
 
@@ -167,6 +168,16 @@ export class Analyzer {
                     if (!selections) {
                         return false;
                     }
+                    // Which templates people actually start from. The names come
+                    // from the analyzer-templates directory the updater downloads,
+                    // so they are public strings -- nothing here is user-authored.
+                    // Picking several blocks builds on Bare Minimum, so the count
+                    // distinguishes "chose this one" from "assembled from parts".
+                    telemetry.sendEvent("analyzer.created", {
+                        template: selections.map((s) => dirMap[s.label] ?? s.label).sort().join("+").slice(0, 120),
+                        blocks: String(selections.length),
+                    });
+
                     if (selections.length == 1) {
                         const dirName = dirMap[selections[0].label];
                         this.makeNewAnalyzer(fromDir, dirName);

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -105,12 +105,18 @@ export class NLPFile extends TextFile {
 			// Anonymous: how the run was configured. No file names, paths, or content.
 			// Sent up front so a run that hangs or crashes the host still shows up;
 			// the outcome and timings follow in analyzer.done / analyzer.failed.
-			const runProps = {
+			// `example` is present only when the analyzer is one the extension itself
+			// ships -- a template, or an analyzer from the public analyzers repo.
+			// publicAnalyzerName() returns undefined for anything else, so a user's
+			// own analyzer name is absent rather than redacted.
+			const exampleName = visualText.publicAnalyzerName(visualText.getCurrentAnalyzerName());
+			const runProps: Record<string, string> = {
 				mode: usingCompiled ? 'compiled' : 'interpreted',
 				runMode: RunMode[runMode],
 				devMode: DevMode[mode],
 				target: typeStr, // "file" or "directory" -- not the name
 			};
+			if (exampleName) runProps.example = exampleName;
 			telemetry.sendEvent('analyzer.run', runProps);
 			if (usingCompiled) {
 				const staged = visualText.nlp.stageCompiledAnalyzer(anapath, engineDir, filepath, runMode);

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1363,6 +1363,52 @@ export class VisualText {
         return this.analyzer.getName();
     }
 
+    // ---- public analyzer names -------------------------------------------------
+    // Telemetry may name an analyzer only when the extension shipped it. The two
+    // directories below are the ones the updater downloads from public GitHub
+    // repositories -- analyzer-templates from visualtext-files, and the analyzers
+    // repo -- so every folder name in them is already public. A name that is not
+    // in this set belongs to the user and never leaves the machine.
+    //
+    // Derived from disk rather than hard-coded, so a template added to either
+    // repository is covered without an extension release.
+    private publicAnalyzerNamesCache: Set<string> | undefined;
+
+    publicAnalyzerNames(): Set<string> {
+        if (this.publicAnalyzerNamesCache) return this.publicAnalyzerNamesCache;
+
+        const names = new Set<string>();
+        const roots: string[] = [];
+        try {
+            roots.push(this.getVisualTextDirectory('analyzer-templates'));
+            roots.push(this.getBlockAnalyzersPath().fsPath);
+        } catch {
+            // Engine directory not resolved yet; fall through with what we have.
+        }
+
+        for (const root of roots) {
+            if (!root || !dirfuncs.isDir(root)) continue;
+            for (const dir of dirfuncs.getDirectories(vscode.Uri.file(root))) {
+                const name = path.basename(dir.fsPath);
+                if (name && !name.startsWith('.')) names.add(name);
+            }
+        }
+
+        // Only cache once something was found: the directories arrive with the
+        // updater's first download, so an empty result early in a fresh install
+        // would otherwise be remembered for the rest of the session.
+        if (names.size) this.publicAnalyzerNamesCache = names;
+        return names;
+    }
+
+    // The analyzer's own name when the extension ships it, otherwise undefined --
+    // which is what callers send, so an unrecognised name is simply absent rather
+    // than replaced by a placeholder.
+    publicAnalyzerName(name: string): string | undefined {
+        if (!name) return undefined;
+        return this.publicAnalyzerNames().has(name) ? name : undefined;
+    }
+
     hasAnalyzers(): boolean {
         return this.analyzers.length ? true : false;
     }

--- a/telemetry-worker/HANDOVER-stats-read-path.md
+++ b/telemetry-worker/HANDOVER-stats-read-path.md
@@ -1,0 +1,178 @@
+# Hand-over: how visualtext.org/vscode-activity-stats gets its numbers
+
+**Written** 2026-08-07, from the `vscode-nlp` repository side.
+**For** the session with access to the visualtext.org WordPress install.
+**Supersedes the premise of** `HANDOVER-wordpress-shortcodes.md`, which assumed the stats page did not exist yet. It does, it works, and it is rendering live data. The open question is no longer *what to build* — it is *how the data is currently getting out of the database*, because the documented path does not exist.
+
+---
+
+## 0. The one thing to find out
+
+**How does the WordPress page read the D1 database?**
+
+Everything else in this document depends on that answer, and I could not determine it from outside.
+
+What I verified from this side, today:
+
+| Check | Result |
+|---|---|
+| `GET https://nlp-telemetry.dehilster.workers.dev/` | `nlp telemetry ok` |
+| `GET https://nlp-telemetry.dehilster.workers.dev/stats` | `nlp telemetry ok` — the same catch-all. **No read route exists.** |
+| `npx wrangler deployments list` | Latest deployment **2026-07-30T15:53Z**, matching the write-only `worker.js` in this repo |
+| Page source | Rendered **server-side**. No `fetch()`, no XHR, no endpoint or token visible in the HTML |
+
+The worker is write-only by construction. Its entire `fetch` handler is: `GET` → health check string, `POST` → insert a row, anything else → 405. There is no code path that returns data.
+
+So the numbers are reaching WordPress another way. The two plausible candidates:
+
+1. **A Cloudflare API token on the WordPress server**, with PHP calling D1's REST API directly.
+2. **A second worker** on a different hostname, whose source is not in this repository.
+
+### Why this matters if it is (1)
+
+A Cloudflare D1 REST token is **not scoped to one database**. It can read *and write* every database on the account. WordPress — with a theme, plugins, and a public login — is a far larger attack surface than a worker that does one thing.
+
+That is not hindsight; it is what the earlier hand-over said before any of this was built:
+
+> Do not put a Cloudflare account API token on the WordPress server. A D1 REST token is broad — it can read and write every database on the account, and WordPress is a much larger attack surface than a worker.
+
+### How to find out
+
+On the WordPress host, search for any of these:
+
+```bash
+grep -ril "api.cloudflare.com" .
+grep -ril "cloudflare" wp-config.php wp-content/themes wp-content/plugins wp-content/mu-plugins
+grep -ri  "18a15af7-27c3-44b6-941e-b914fc60e1be" .     # the D1 database id
+grep -ril "nlp-telemetry" .
+grep -ril "workers.dev" .
+```
+
+Also check the database, since tokens are often stored as options rather than in files:
+
+```sql
+SELECT option_name, LEFT(option_value, 80) FROM wp_options
+WHERE option_value LIKE '%cloudflare%'
+   OR option_value LIKE '%api.cloudflare%'
+   OR option_name  LIKE '%cloudflare%';
+```
+
+Then find the shortcode itself. The page renders tables titled *Daily Active Machines*, *Extension Versions in Use*, *Operating Systems*, *Platform and Architecture*, *NLP++ Engine Versions*, *Most Used Commands*, *Analyzer Metrics*, *Component Downloads* and *Events Recorded* — so grep the theme's `functions.php`, any custom or mu-plugin, and `wp_posts` for `add_shortcode`.
+
+**Report back what you find before changing anything.** The page works today; the goal is to make the read path safe and reviewable, not to rebuild it.
+
+---
+
+## 1. Do not break what is already right
+
+Whoever built this page did it carefully. Preserve these properties through any change:
+
+- **Aggregates only.** Nothing per-`machine_id` or per-`session_id`, and no raw row dump.
+- **Small buckets are suppressed** — the page says *"18 smaller groups hidden"*. With 165 machines, a bucket of one is effectively a name. Keep the floor.
+- **The disclaimers stay.** *"These are machines, not people"*, and the note that telemetry is opt-out via two independent settings. Both are accurate and both matter.
+
+---
+
+## 2. The fix, if a token is on the WordPress server
+
+The destination is the design the earlier document specified, and the work splits across two repositories.
+
+### 2a. In `vscode-nlp` (not on the website)
+
+`telemetry-worker/worker.js` gains a `GET /stats` route returning one pre-aggregated JSON blob. Rules for it:
+
+- **Fixed queries only.** Never accept SQL, a table name, a column name or a LIMIT from the query string. The aggregates are the whole menu.
+- **Read-only by construction** — the route only ever issues `SELECT`.
+- **Cache hard.** The endpoint is public: the worker URL ships inside the extension bundle, so anyone can hit it. Use the Cloudflare Cache API in the worker (or `s-maxage`), plus a WordPress transient of 1–6 hours.
+- **Apply the small-bucket floor in the worker**, so it holds for every consumer rather than depending on each caller.
+
+The SQL is already written — see §4 of `HANDOVER-wordpress-shortcodes.md` in this same directory, plus the query set in `telemetry-worker/README.md`.
+
+**Ask the vscode-nlp side to do this part.** The worker's source is version-controlled there and deployed with `npx wrangler deploy` from `telemetry-worker/`. Changing it from the website side would put production out of sync with the repository, which is how this situation arose.
+
+### 2b. On the website
+
+Replace the direct D1 call with a cached `wp_remote_get` against `https://nlp-telemetry.dehilster.workers.dev/stats`, then `json_decode`. No credentials on the WordPress side at all.
+
+Afterwards: **revoke the Cloudflare token** in the Cloudflare dashboard. Removing it from the code is not the same as revoking it — assume anything that sat in a web root is compromised.
+
+---
+
+## 3. The fix, if it is a second worker
+
+Smaller, but still worth closing: that worker's source is not in version control, so nobody can review the SQL it runs or redeploy it if it breaks.
+
+Get the source into `vscode-nlp` alongside `telemetry-worker/worker.js` — either as a second worker directory or, preferably, folded into the existing worker as the `/stats` route so there is one deployable with one config. Note its hostname and its Cloudflare project name in the reply so the vscode-nlp side can wire it up.
+
+---
+
+## 4. Numbers to check your work against
+
+I read these from D1 directly on 2026-08-07 at about 13:15 UTC. The page agreed with them exactly, which is how I know it is live rather than cached from a snapshot:
+
+| | |
+|---|---|
+| Total events | **2,620** |
+| Distinct machines | **165** |
+| Database size | ~1.02 MB |
+| Rows read by a `count(*)` | 2,620 (a full scan) |
+| Earliest data | 2026-07-11 |
+
+At this size, live aggregation is comfortably viable — D1's free tier allows 5M row reads per day, so a full scan costs about 0.05% of the daily budget. **Caching is needed to survive traffic, not to survive the query.** Do not build a pre-aggregated summary table; it is not warranted yet.
+
+If the page still shows the same totals after a change, the read path is intact.
+
+---
+
+## 5. Four ways to get the numbers silently wrong
+
+These apply to any query you write or move. Each produces a plausible-looking chart that is simply false.
+
+**5.1 — `command` and `language` events are batched.** The extension buffers them and flushes one row per distinct id per minute, carrying an `n`. One row can mean 300 uses. Counting rows undercounts by an arbitrary, varying factor.
+
+```sql
+-- WRONG
+SELECT json_extract(props,'$.id') AS cmd, count(*) FROM events WHERE event='command' GROUP BY cmd;
+
+-- RIGHT
+SELECT json_extract(props,'$.id') AS cmd,
+       sum(json_extract(metrics,'$.n')) AS uses,
+       count(DISTINCT machine_id)       AS machines
+FROM events WHERE event='command' GROUP BY cmd ORDER BY uses DESC;
+```
+
+The page's "Most Used Commands" currently shows `logView.refreshAll` at 2,512 uses across 52 machines — a uses-to-machines ratio that only makes sense if it is summing `n` correctly. Preserve that.
+
+**5.2 — `ts` is in milliseconds.** Day bucketing needs `date(ts/1000,'unixepoch')`. Without the divide you get dates in the year 56000 and an empty chart.
+
+**5.3 — Failure rate is not `analyzer.failed / analyzer.run`.** `run` fires *before* the engine starts; `done` and `failed` fire after. A run whose host was killed emits `run` and nothing else, so `run >= done + failed` always and the gap is not failures. Compare outcomes only against outcomes. The page currently shows 132 started, 15 completed, 10 failed — that gap is expected and is not a 90% failure rate.
+
+**5.4 — Two names are overloaded across events.** `kb` means KB-load *seconds* in `analyzer.done` but payload *kilobytes* in `compile.cloud.done`; `engine` is a version string as a column but startup *seconds* as an `analyzer.done` metric. Always filter by `event` before touching `metrics`.
+
+---
+
+## 6. Two caveats about the data itself
+
+- **It starts 2026-07-11.** There is no history before that.
+- **`command` and `language` events only exist for extension 3.12.0+.** Any chart spanning that boundary shows rollout, not growth. Label the period rather than implying history that is not there.
+
+---
+
+## 7. Reference
+
+- **Worker source, schema, deploy steps, example queries:** `telemetry-worker/` in `github.com/VisualText/vscode-nlp`
+- **Endpoint:** `https://nlp-telemetry.dehilster.workers.dev` — write-only as deployed
+- **Cloudflare account:** dehilster@gmail.com. D1 database `nlp-telemetry`, id `18a15af7-27c3-44b6-941e-b914fc60e1be`
+- **Event inventory and full schema:** `HANDOVER-wordpress-shortcodes.md`, §1 and §2, in this directory
+- **Privacy contract the extension makes to users:** the `# Telemetry` section of the extension `README.md`, and `SECURITY.md` in the repository root
+
+---
+
+## 8. What to reply with
+
+1. **How the page reads D1** — token in PHP, second worker, or something else.
+2. **If a token:** where it was stored, and what scopes it has in the Cloudflare dashboard.
+3. **If a second worker:** its hostname and Cloudflare project name.
+4. **Where the shortcode lives** — file path and shortcode tag.
+
+That is enough for the vscode-nlp side to build the `/stats` route to match, so the swap is a one-line change on the website.

--- a/telemetry-worker/HANDOVER-wordpress-shortcodes.md
+++ b/telemetry-worker/HANDOVER-wordpress-shortcodes.md
@@ -76,7 +76,8 @@ Everything the extension can send. Events marked **batched** are the ones most l
 | `command` **batched** | `id` — the command id, e.g. `analyzerView.refreshAll` | `n` — occurrences since last flush |
 | `command.error` | `reason` — `"<commandId>:<ErrorClass>"` | — |
 | `language` **batched** | `id` — `hover`/`definition`/`references`/`rename`/`completion`/`signature` | `n` |
-| `analyzer.run` | `mode` (`compiled`/`interpreted`), `runMode`, `devMode`, `target` (`file`/`directory`) | — |
+| `analyzer.run` | `mode` (`compiled`/`interpreted`), `runMode`, `devMode`, `target` (`file`/`directory`), `example` — **present only when the analyzer is one the extension ships**; absent for a user's own | — |
+| `analyzer.created` | `template` (shipped template name, or several joined with `+`), `blocks` (how many were combined) | — |
 | `analyzer.done` | same four as `analyzer.run` | `secs`, `setup`, `engine`, `kb`, `load`, `exec`, `post` (all **seconds**), `lazy` (file count) |
 | `analyzer.failed` | `reason` — `syntax` / `exec` | `secs` |
 | `compile.start` | `target` (`ANALYZER`/`KB_ONLY`/`ANALYZER_ONLY`), `mode` (`local`/`cloud`) | — |


### PR DESCRIPTION
> ⚠️ **Merging this publishes 3.12.8 to the VS Code Marketplace.** Merge #1156 first — this is stacked on it.

## Why this one genuinely needs a release

Unlike everything else merged today, which was invisible to users, this has two reasons that both point the same way:

**Nothing is retroactive.** The `example` field doesn't exist in the field until a version carrying it is installed. Without a release, #1156 answers nothing.

**`README.md` is the Marketplace page.** The disclosure only reaches users when the extension is republished. Landing the collection without the release would leave a *published* promise that analyzer names are never sent, while the extension had already started recording the shipped ones — collection live, promise stale. That's the wrong way round, and it's the reason not to sit on this.

## What ships

- Running or creating one of the **shipped** analyzers now records its name — the templates and the [analyzers](https://github.com/VisualText/analyzers) repo collections, which are a fixed public set
- **Your own analyzers are still never named** — checked against the folders the extension downloads, and anything else is omitted entirely rather than replaced with a placeholder
- Creating an analyzer records which template you started from and how many blocks you combined
- README and SECURITY.md now say all of this, replacing wording this change would have made untrue
- **~120 KB smaller download** — `del` replaced by Node's `fs.rmSync`

## Verified

```
grammars      7
worker guard  undici 7.29.0
typecheck     clean
lint          clean
language      79 passed
tree view     63 passed
integration   27 passed
package       nlp-3.12.8.vsix — 183 files, 2.93 MB
```

Version bumped in both `package.json` and `package-lock.json`; nothing else in the repo references it.

The generated release title previews as:

```
3.12.8 — Telemetry can now say which of the shipped examples people actually use
```

## What happens on merge

`release.yml` fires: builds the vsix, tags `v3.12.8`, creates the GitHub release with notes from CHANGELOG.md, and publishes that same artifact to the Marketplace. Same path 3.12.7 took, which completed in 46 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
