### PR TITLE
fix(telemetry): recognise nested shipped example analyzers (3.12.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.9
+Telemetry: recognise shipped example analyzers that live in nested folders.
+
+- The `example` tag on `analyzer.run` was only set when a run's folder name matched a **top-level** shipped folder, so examples nested inside grouping folders (e.g. `nlp-tutorials/`, `nlpfix-analyzers/`) were never recognised and counted as a user's own analyzer. Detection is now **path-based**: an analyzer run from anywhere under the shipped `analyzer-templates` or `analyzers` directories is named, at any depth. A user's own analyzer still never qualifies.
+
 ### 3.12.8
 Telemetry can now say which of the shipped examples people actually use.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.8",
+    "version": "3.12.9",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/nlp.ts
+++ b/src/nlp.ts
@@ -105,11 +105,12 @@ export class NLPFile extends TextFile {
 			// Anonymous: how the run was configured. No file names, paths, or content.
 			// Sent up front so a run that hangs or crashes the host still shows up;
 			// the outcome and timings follow in analyzer.done / analyzer.failed.
-			// `example` is present only when the analyzer is one the extension itself
-			// ships -- a template, or an analyzer from the public analyzers repo.
+			// `example` is present only when the analyzer being run lives under a
+			// directory the extension itself ships -- a template, or an analyzer from
+			// the public analyzers repo (including ones nested in grouping folders).
 			// publicAnalyzerName() returns undefined for anything else, so a user's
 			// own analyzer name is absent rather than redacted.
-			const exampleName = visualText.publicAnalyzerName(visualText.getCurrentAnalyzerName());
+			const exampleName = visualText.publicAnalyzerName(visualText.analyzer.getAnalyzerDirectory());
 			const runProps: Record<string, string> = {
 				mode: usingCompiled ? 'compiled' : 'interpreted',
 				runMode: RunMode[runMode],

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1363,21 +1363,13 @@ export class VisualText {
         return this.analyzer.getName();
     }
 
-    // ---- public analyzer names -------------------------------------------------
-    // Telemetry may name an analyzer only when the extension shipped it. The two
-    // directories below are the ones the updater downloads from public GitHub
-    // repositories -- analyzer-templates from visualtext-files, and the analyzers
-    // repo -- so every folder name in them is already public. A name that is not
-    // in this set belongs to the user and never leaves the machine.
-    //
-    // Derived from disk rather than hard-coded, so a template added to either
-    // repository is covered without an extension release.
-    private publicAnalyzerNamesCache: Set<string> | undefined;
-
-    publicAnalyzerNames(): Set<string> {
-        if (this.publicAnalyzerNamesCache) return this.publicAnalyzerNamesCache;
-
-        const names = new Set<string>();
+    // ---- public (shipped) analyzers --------------------------------------------
+    // Telemetry may name an analyzer only when the extension itself shipped it: a
+    // template from analyzer-templates, or an analyzer from the public `analyzers`
+    // repo (both downloaded by the updater from public GitHub repositories). These
+    // are the roots that hold them; anything OUTSIDE them is the user's own work
+    // and its name never leaves the machine.
+    publicAnalyzerRoots(): string[] {
         const roots: string[] = [];
         try {
             roots.push(this.getVisualTextDirectory('analyzer-templates'));
@@ -1385,28 +1377,25 @@ export class VisualText {
         } catch {
             // Engine directory not resolved yet; fall through with what we have.
         }
-
-        for (const root of roots) {
-            if (!root || !dirfuncs.isDir(root)) continue;
-            for (const dir of dirfuncs.getDirectories(vscode.Uri.file(root))) {
-                const name = path.basename(dir.fsPath);
-                if (name && !name.startsWith('.')) names.add(name);
-            }
-        }
-
-        // Only cache once something was found: the directories arrive with the
-        // updater's first download, so an empty result early in a fresh install
-        // would otherwise be remembered for the rest of the session.
-        if (names.size) this.publicAnalyzerNamesCache = names;
-        return names;
+        return roots.filter(r => !!r);
     }
 
-    // The analyzer's own name when the extension ships it, otherwise undefined --
-    // which is what callers send, so an unrecognised name is simply absent rather
-    // than replaced by a placeholder.
-    publicAnalyzerName(name: string): string | undefined {
-        if (!name) return undefined;
-        return this.publicAnalyzerNames().has(name) ? name : undefined;
+    // The analyzer's folder name IFF it lives under a shipped root (at ANY depth --
+    // the example analyzers nest inside grouping folders like nlp-tutorials/ and
+    // nlpfix-analyzers/), otherwise undefined. PATH-based on purpose: a user's own
+    // analyzer never qualifies even if it shares a name with a shipped one, and it
+    // needs no directory scan. Callers send whatever this returns, so an
+    // unrecognised analyzer is simply absent rather than replaced by a placeholder.
+    publicAnalyzerName(dir: vscode.Uri | undefined): string | undefined {
+        if (!dir || !dir.fsPath) return undefined;
+        const target = path.resolve(dir.fsPath);
+        for (const root of this.publicAnalyzerRoots()) {
+            const rel = path.relative(path.resolve(root), target);
+            if (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+                return path.basename(target);
+            }
+        }
+        return undefined;
     }
 
     hasAnalyzers(): boolean {


### PR DESCRIPTION
Fixes the `example` tag on analyzer.run.

It was only set when a run's folder name matched a top-level shipped folder, so example analyzers nested inside grouping folders (nlp-tutorials/, nlpfix-analyzers/) were never recognised and counted as a user's own analyzer — in production only 1 of 139 runs was tagged.

Detection is now path-based: an analyzer run from anywhere under the shipped analyzer-templates or analyzers roots is named, at any depth. A user's own analyzer never qualifies. Bumps to 3.12.9.

Generated with Claude Code.