### PR TITLE
feat: the copy icon on an LLM prompt copies the prompt (3.12.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.10
+The copy icon on an LLM prompt now copies the prompt.
+
+- **Copying a prompt from the Help view gives you the finished text, not a file path.** The inline copy icon on the LLM Prompts was the same "Copy File Path" action every other help item gets, so it handed back a location on disk -- something an LLM cannot read and you would have to open yourself. It now copies the prompt exactly as it would be handed to an LLM, with the `{{...}}` placeholders already replaced by this machine's paths: the engine executable, the analyzers and templates directories, the currently loaded analyzer, and the rest. Paste it and it works.
+- The title line and the internal tooltip marker are dropped, the same way they already were when you clicked a prompt to preview it -- so the icon and the click now produce identical text.
+- Markdown help pages are unchanged: their copy icon still copies the path.
+
 ### 3.12.9
 Telemetry: recognise shipped example analyzers that live in nested folders.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.12.8",
+    "version": "3.12.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.12.8",
+            "version": "3.12.10",
             "license": "MIT",
             "dependencies": {
                 "copy-dir": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.9",
+    "version": "3.12.10",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,
@@ -642,6 +642,12 @@
                 "command": "helpView.copyPath",
                 "category": "NLP",
                 "title": "Copy File Path",
+                "icon": "$(copy)"
+            },
+            {
+                "command": "helpView.copyPrompt",
+                "category": "NLP",
+                "title": "Copy LLM Prompt",
                 "icon": "$(copy)"
             },
             {
@@ -2564,6 +2570,11 @@
                 {
                     "command": "helpView.copyPath",
                     "when": "view == helpView && viewItem == helpFile",
+                    "group": "inline"
+                },
+                {
+                    "command": "helpView.copyPrompt",
+                    "when": "view == helpView && viewItem == helpPrompt",
                     "group": "inline"
                 },
                 {

--- a/src/helpView.ts
+++ b/src/helpView.ts
@@ -46,11 +46,12 @@ export class HelpTreeDataProvider implements vscode.TreeDataProvider<HelpItem> {
             ti.command = { command: 'helpView.openVscodeHelp', title: 'Open Help', arguments: [item] };
         }
         // File-backed items (a markdown page or a prompt file that exists on the
-        // local drive) get the inline "copy path" action; categories and
-        // external Helpful Links do not.
+        // local drive) get an inline copy action; categories and external
+        // Helpful Links do not. Prompts copy the filled-out prompt text, other
+        // help files copy their path.
         const filePath = helpView.helpFilePath(item);
         if (filePath && fs.existsSync(filePath))
-            ti.contextValue = 'helpFile';
+            ti.contextValue = item.promptFile ? 'helpPrompt' : 'helpFile';
         return ti;
     }
 
@@ -131,6 +132,7 @@ export class HelpView {
         vscode.commands.registerCommand('helpView.openLink', (item) => this.openLink(item));
         vscode.commands.registerCommand('helpView.showLatestAnnouncement', () => this.showLatestAnnouncement());
         vscode.commands.registerCommand('helpView.copyPath', (item) => this.copyHelpPath(item));
+        vscode.commands.registerCommand('helpView.copyPrompt', (item) => this.copyPrompt(item));
         this.exists = false;
         this.ctx = context;
         this.panel = undefined;
@@ -362,20 +364,26 @@ export class HelpView {
         vscode.window.showInformationMessage('LLM prompt copied to clipboard — paste it into your LLM.');
     }
 
+    // The ready-to-paste text of a prompt file: the tooltip marker and title line
+    // dropped, {{...}} variables filled with this machine's paths. Returns
+    // undefined if the file isn't there.
+    promptText(file: string): string | undefined {
+        const full = path.join(this.promptsDir(), file);
+        if (!fs.existsSync(full)) return undefined;
+        const raw = fs.readFileSync(full, 'utf8').replace(/<!--\s*desc:[\s\S]*?-->\s*/i, '');
+        const nl = raw.indexOf('\n');
+        return this.fillPromptVariables(nl >= 0 ? raw.slice(nl + 1) : raw).replace(/^\s+/, '');
+    }
+
     // Read a prompt file, drop its title line, fill ${...} variables, and open the
     // result in a new editor ready to paste into an LLM. The prompt is also copied
     // to the clipboard.
     async openPromptByFile(file: string) {
-        const full = path.join(this.promptsDir(), file);
-        if (!fs.existsSync(full)) {
-            vscode.window.showErrorMessage(`Prompt file not found: ${full}`);
+        const content = this.promptText(file);
+        if (content === undefined) {
+            vscode.window.showErrorMessage(`Prompt file not found: ${path.join(this.promptsDir(), file)}`);
             return;
         }
-        const raw = fs.readFileSync(full, 'utf8');
-        const nl = raw.indexOf('\n');
-        let body = nl >= 0 ? raw.slice(nl + 1) : '';
-        body = body.replace(/<!--\s*desc:[\s\S]*?-->\s*/i, ''); // drop the tooltip marker
-        const content = this.fillPromptVariables(body).replace(/^\s+/, '');
         const doc = await vscode.workspace.openTextDocument({ content, language: 'markdown' });
         await vscode.window.showTextDocument(doc);
         await this.copyPromptToClipboard(content);
@@ -384,6 +392,18 @@ export class HelpView {
     openPrompt(item: HelpItem) {
         if (item && item.promptFile)
             this.previewPromptByFile(item.promptFile);
+    }
+
+    // Inline action on LLM prompt items: copy the generated prompt -- variables
+    // filled out -- rather than the prompt file's path, so it pastes straight
+    // into an LLM without opening it first.
+    async copyPrompt(item: HelpItem) {
+        const content = item && item.promptFile ? this.promptText(item.promptFile) : undefined;
+        if (content === undefined) {
+            vscode.window.showErrorMessage('This help item has no LLM prompt to copy.');
+            return;
+        }
+        await this.copyPromptToClipboard(content);
     }
 
     // Render a prompt as a markdown preview (consistent with the other help
@@ -406,9 +426,7 @@ export class HelpView {
 
         // Copy the ready-to-paste prompt (body without the title heading) to the
         // clipboard so clicking a prompt makes it immediately usable in an LLM (#1104).
-        const nl = raw.indexOf('\n');
-        const body = this.fillPromptVariables(nl >= 0 ? raw.slice(nl + 1) : raw).replace(/^\s+/, '');
-        await this.copyPromptToClipboard(body);
+        await this.copyPromptToClipboard(this.promptText(file) ?? content);
     }
 
     // The toolbar button / quickstart link: open the first prompt in the library,


### PR DESCRIPTION
The inline copy icon on the Help view's **LLM Prompts** was the generic "Copy File Path" action that every file-backed help item gets, so it returned a location on disk — something an LLM cannot read, and something you would have to go open yourself before you could use it.

It now copies the prompt itself, with the variables already filled out.

### What changed

- Prompt items get their own `contextValue` (`helpPrompt`) and their own inline action, `helpView.copyPrompt` ("Copy LLM Prompt").
- That action copies the prompt exactly as it would be handed to an LLM: the title line and the `<!-- desc: -->` marker dropped, and the `{{...}}` placeholders replaced with this machine's paths — engine executable, analyzers and templates directories, the currently loaded analyzer, and the rest.
- This is the same text that clicking a prompt already placed on the clipboard, so the icon and the click now produce identical output.
- The strip/fill logic moves into a `promptText()` helper shared by `copyPrompt`, `openPromptByFile` and `previewPromptByFile`, rather than being spelled out three times.
- Markdown help pages are untouched — their copy icon still copies the path.

### Version

Bumped to **3.12.10**, which publishes to the marketplace on merge. CHANGELOG entry included.

Note: this branch originally carried 3.12.9, which #1160 took first. Rebased onto the new master and moved to 3.12.10; the CHANGELOG now lists 3.12.10 above the 3.12.9 telemetry entry.

### Testing

- `npm run lint`, `npm run compile` — clean
- `npm run test:format` — 11,408 files, 0 failures
- `npm run test:language` — 79 passed
- `npm run test:treeview` — 63 passed
- `npm run test:integration` could not run locally (the VS Code 1.133.0 download aborted repeatedly); CI runs it on this PR. The check it exists for — every declared command actually registered — was verified directly: 219 declared commands, `helpView.copyPrompt` among them, none missing from `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
