### PR TITLE
3.12.13: sequence tooltips show the pass comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.13
+The Sequence view shows the pass's comment on mouse-over.
+
+- **Hovering a pass in the Sequence view shows what the comment on that line of `analyzer.seq` says**, instead of the pass file's path on disk. The path told you where the file lives -- something the tree already makes obvious -- while the comment is where the author wrote down what the pass is for, and it was visible nowhere but the sequence file itself.
+- A pass with no comment, or one still carrying the placeholder `# comment` the extension writes on a new pass, falls back to the file path exactly as before. Tokenizers keep their built-in description unless the line has a comment of its own, and a pass whose file is missing still says `MISSING`.
+- Folders, Python passes, and rule passes all read their comment the same way, and both `#` line comments and `/* */` block comments are understood.
+
 ### 3.12.12
 Comments and blank lines in `analyzer.seq` survive the Sequence view.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.12",
+    "version": "3.12.13",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -51,6 +51,20 @@ export class PassItem {
 		return tooltip;
 	}
 
+	// The trailing comment from the analyzer.seq line, stripped of its comment
+	// markers, when it says something. Placeholder comments -- the '# comment' the
+	// extension itself writes on a new pass -- carry no information, so they are
+	// treated as absent and the caller falls back to the file path.
+	public commentTooltip(): string {
+		let text = this.comment.trim();
+		if (text.startsWith('/*') && text.endsWith('*/'))
+			text = text.substring(2, text.length - 2);
+		text = text.replace(/^[#/*\s]+/, '').trim();
+		if (text.toLowerCase() == 'comment')
+			return '';
+		return text;
+	}
+
 	public isRuleFile(): boolean {
 		return this.typeStr.localeCompare('nlp') == 0 || this.typeStr.localeCompare('rec') == 0;
 	}

--- a/src/sequenceView.ts
+++ b/src/sequenceView.ts
@@ -27,6 +27,14 @@ export interface SequenceItem extends vscode.TreeItem {
 	inFolder: boolean;
 }
 
+// A pass's mouse-over text: the comment the author wrote on that line of
+// analyzer.seq, when there is one worth showing, otherwise the given default
+// (normally the pass file path).
+function passTooltip(passItem: PassItem, fallback: string): string {
+	const comment = passItem.commentTooltip();
+	return comment.length ? comment : fallback;
+}
+
 export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 
 	private _onDidChangeTreeData: vscode.EventEmitter<SequenceItem | undefined | null | void> = new vscode.EventEmitter<SequenceItem | undefined | null | void>();
@@ -116,8 +124,9 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 				}
 				if (!oneActive)
 					passItem.active = false;
+				tooltip = passTooltip(passItem, passItem.uri.fsPath);
 				seqItems.push({
-					uri: passItem.uri, label: label, name: passItem.name, tooltip: passItem.uri.fsPath, contextValue: conVal, inFolder: passItem.inFolder,
+					uri: passItem.uri, label: label, name: passItem.name, tooltip: tooltip, contextValue: conVal, inFolder: passItem.inFolder,
 					type: passItem.typeStr, passNum: passItem.passNum, library: passItem.library, row: row,
 					collapsibleState: vscode.TreeItemCollapsibleState.Collapsed, active: passItem.active
 				});
@@ -129,10 +138,10 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 				if (treeFile.hasFileType(passItem.uri, passItem.passNum, nlpFileType.KBB))
 					conVal = conVal + 'hasKB';
 				if (debugConVal) label = row.toString() + ' ' + conVal;
-				tooltip = row.toString() + ' ' + tooltip;
+				tooltip = passTooltip(passItem, passItem.uri.fsPath);
 				if (passItem.fileExists())
 					seqItems.push({
-						uri: passItem.uri, label: label, name: passItem.name, tooltip: passItem.uri.fsPath, contextValue: conVal,
+						uri: passItem.uri, label: label, name: passItem.name, tooltip: tooltip, contextValue: conVal,
 						inFolder: passItem.inFolder, type: passItem.typeStr, passNum: passItem.passNum, library: passItem.library, row: row,
 						collapsibleState: collapse, active: passItem.active
 					});
@@ -147,7 +156,7 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 				conVal = conVal + 'pythonfile';
 				label = passItem.name;
 				if (debugConVal) label = row.toString() + ' ' + conVal;
-				tooltip = passItem.uri.fsPath;
+				tooltip = passTooltip(passItem, passItem.uri.fsPath);
 				if (passItem.fileExists())
 					seqItems.push({
 						uri: passItem.uri, label: label, name: passItem.name, tooltip: tooltip, contextValue: conVal,
@@ -162,10 +171,12 @@ export class PassTree implements vscode.TreeDataProvider<SequenceItem> {
 					});
 
 			} else {
-				tooltip = passItem.uri.fsPath;
+				tooltip = passTooltip(passItem, passItem.uri.fsPath);
 				if (passItem.tokenizer) {
 					label = '1 ' + passItem.typeStr;
-					tooltip = passItem.fetchTooltip();
+					// The tokenizer's canned description only stands in when the
+					// sequence line carries no comment of its own.
+					tooltip = passTooltip(passItem, passItem.fetchTooltip());
 					conVal = conVal + 'tokenize' + 'hasLog';
 					conVal = conVal.replace('mvdown', '');
 				} else {


### PR DESCRIPTION
Hovering a pass in the Sequence view showed the pass file's path on disk — something the tree already makes obvious. The comment on that line of `analyzer.seq` is where the author writes down what the pass is for, and it was visible nowhere but the sequence file itself. Now it's the tooltip.

### What changed

`PassItem.commentTooltip()` (src/sequence.ts) strips the comment markers — `#` line comments and `/* */` blocks — off the pass's trailing comment and returns `''` for the placeholder `# comment` the extension writes on a new pass, so those are treated as absent.

`passTooltip(passItem, fallback)` (src/sequenceView.ts) applies it in every branch of `getPasses()`:

| Pass kind | Tooltip |
|---|---|
| folder | comment → folder path |
| rule file (.nlp/.rec) | comment → file path (`MISSING` if absent) |
| python | comment → file path (`MISSING` if absent) |
| tokenizer | comment → the tokenizer's canned description |
| stub | comment → path |

`MISSING` still wins over a comment for a pass whose file doesn't exist — that state is worth surfacing.

### Incidental fix

The rule-file branch had a dead line, `tooltip = row.toString() + ' ' + tooltip;`, that accumulated row numbers across the loop into a variable the `push` then ignored in favour of a hardcoded `passItem.uri.fsPath`. It's now the real tooltip assignment.

### Verification

`npx tsc --noEmit -p .` is clean. Not yet exercised in a live EDH window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
