### PR TITLE
3.12.14: KB tooltips show the file's header comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.14
+The KB view shows what a dictionary or knowledge base is for on mouse-over.
+
+- **Hovering a `.dict` or `.kbb` file in the KB view shows the comment written at the top of it**, instead of the file's path on disk. The path tells you where the file lives -- something the tree already makes obvious -- while the header comment is where the author wrote down what the file holds, and it was visible nowhere but inside the file. The same idea the Sequence view picked up for pass comments in 3.12.13.
+- The opening comment paragraph is shown rather than only its first line, so a description that runs across two or three lines arrives whole instead of stopping mid-sentence. A bare `#` closes the paragraph, which keeps a long file header down to its opening statement. Both `#` line comments and `/* */` block comments are understood.
+- A file with no header comment keeps the path tooltip exactly as before -- `en-full.kbb` opens straight onto `dictionary`, so nothing changes for it. Files toggled off (`.dictt`, `.kbbb`) read their comment the same way as the active ones.
+- Only the head of each file is read, and what it yields is held until the file changes on disk. The KB view rebuilds every row on every refresh and `en-full.kbb` is 10MB, so the body of a lexicon is never touched to draw a tooltip.
+
 ### 3.12.13
 The Sequence view shows the pass's comment on mouse-over.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.13",
+    "version": "3.12.14",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/kbView.ts
+++ b/src/kbView.ts
@@ -18,6 +18,89 @@ export interface KBItem {
 	type: vscode.FileType;
 }
 
+// The mouse-over text for a .dict / .kbb file: the comment block its author
+// wrote at the top of it, which is where they say what the file holds. Without
+// it the tooltip is the file's path -- something the tree already makes obvious.
+// Same idea as the pass comment the Sequence view shows.
+//
+// Only the head of the file is read. en-full.kbb is 10 MB and getTreeItem runs
+// once per row on every refresh, so the body is never touched, and the result is
+// cached until the file changes on disk.
+const HEAD_BYTES = 4096;
+const DESCRIPTION_MAX_LINES = 8;
+
+interface CachedDescription {
+	mtimeMs: number;
+	size: number;
+	text: string;
+}
+const descriptionCache = new Map<string, CachedDescription>();
+
+// Strip the comment markers off one comment line: '#', '/*', '*/', and the '*'
+// that the continuation lines of a block comment are often drawn with.
+function stripCommentMarkers(line: string): string {
+	let text = line.trim();
+	if (text.startsWith('/*')) text = text.substring(2);
+	if (text.endsWith('*/')) text = text.substring(0, text.length - 2);
+	return text.replace(/^[#*\s]+/, '').trim();
+}
+
+// The opening comment paragraph of a KB file: comment lines from the top of the
+// file, stopping at the first line that is not one. A bare '#' ends it, so a
+// long file header contributes its first paragraph rather than all of itself,
+// while a '/*' alone on the line that opens a block comment is stepped over.
+function leadingComment(head: string, truncated: boolean): string {
+	const lines = head.split(/\r?\n/);
+	if (truncated) lines.pop();     // the read stopped mid-line: that line is not whole
+
+	// The blanker stops at a '#' and leaves the rest of the line alone, so '#'
+	// comments are matched directly; blanking is what finds the /* */ ones.
+	const blanked = blankBlockCommentLines(lines);
+
+	const out: string[] = [];
+	for (let i = 0; i < lines.length && out.length < DESCRIPTION_MAX_LINES; i++) {
+		const line = lines[i];
+		if (!line.trim().startsWith('#') && !isCommentOnly(line, blanked[i]))
+			break;
+		const text = stripCommentMarkers(line);
+		if (text.length == 0) {
+			if (out.length == 0) continue;  // '/*' on a line of its own opens the block
+			break;                          // a marker-only line closes the paragraph
+		}
+		out.push(text);
+	}
+	return out.join('\n');
+}
+
+// Empty when the file has no opening comment, cannot be read, or has gone away;
+// the caller then leaves VSCode's default tooltip (the path) in place.
+function fileDescription(filePath: string): string {
+	let stat: fs.Stats;
+	try {
+		stat = fs.statSync(filePath);
+	} catch {
+		return '';
+	}
+	const cached = descriptionCache.get(filePath);
+	if (cached && cached.mtimeMs == stat.mtimeMs && cached.size == stat.size)
+		return cached.text;
+
+	let text = '';
+	try {
+		const fd = fs.openSync(filePath, 'r');
+		try {
+			const buffer = Buffer.alloc(HEAD_BYTES);
+			const read = fs.readSync(fd, buffer, 0, HEAD_BYTES, 0);
+			text = leadingComment(buffer.toString('utf8', 0, read), read == HEAD_BYTES);
+		} finally {
+			fs.closeSync(fd);
+		}
+	} catch { /* unreadable: fall back to the path */ }
+
+	descriptionCache.set(filePath, { mtimeMs: stat.mtimeMs, size: stat.size, text: text });
+	return text;
+}
+
 export class FileSystemProvider implements vscode.TreeDataProvider<KBItem> {
 
 	public readonly EMPTY_TEXT = '>> right click for libs <<';
@@ -72,8 +155,14 @@ export class FileSystemProvider implements vscode.TreeDataProvider<KBItem> {
 				return treeItem;
 			}
 
-			if (name.endsWith('.kbb') || name.endsWith('.dict') || name.endsWith('.kbbb') || name.endsWith('.dictt'))
+			if (name.endsWith('.kbb') || name.endsWith('.dict') || name.endsWith('.kbbb') || name.endsWith('.dictt')) {
 				treeItem.contextValue = 'toggle';
+				// What the file is for, taken from the comment at the top of it.
+				// With no such comment the default tooltip (the path) stands.
+				const description = fileDescription(kbItem.uri.fsPath);
+				if (description.length)
+					treeItem.tooltip = description;
+			}
 
 			if (name.endsWith('.kb'))
 				treeItem.contextValue = 'old';


### PR DESCRIPTION
Hovering a `.dict` or `.kbb` file in the KB view showed the file's path on disk -- something the tree already makes obvious. The comment at the top of the file is where the author says what it holds, and it was visible nowhere but inside the file. This does for the KB view what #1167 did for pass comments in the Sequence view.

### What you see

Hovering these files in `StatuteFrames/kb/user`:

| file | tooltip |
| --- | --- |
| `en-full.dict` | Full English Dictionary POS |
| `en-full.kbb` | *(no header comment -- keeps the path)* |
| `legal-units.kbb` | Statutory subdivision names and the depth each one denotes. |
| `quantities.kbb` | Statutory threshold vocabulary: comparison words, and the fraction words the<br>number library does not carry. |
| `roles.kbb` | The parties and time periods a provision quantifies over, and the argument<br>name each one contributes to a frame condition. |

### How it reads the comment

`fileDescription()` returns the file's opening comment **paragraph**, not just its first line -- three of the six files above wrap their opening sentence, and one line alone would have cut `quantities.kbb` off at "the fraction words the".

- Comment lines from the top of the file, stopping at the first line that is not one.
- A bare `#` closes the paragraph, so a long file header contributes its opening statement rather than all of itself. Capped at 8 lines.
- A `/*` alone on the line that opens a block comment is stepped over rather than read as an empty paragraph.
- Markers come off: `#`, `/*`, `*/`, and the `*` that continuation lines are often drawn with.
- `#` comments are matched directly -- the blanker in `blockComment.ts` stops at a `#` and leaves the rest of the line alone -- while blanking is what finds the `/* */` ones. Both kinds go through the existing module.
- No header comment, an unreadable file, or one that has just been deleted all yield nothing, and VSCode's default path tooltip stands.

Applies to `.dict` and `.kbb` and to their toggled-off `.dictt` / `.kbbb` variants.

### Cost

`getTreeItem` runs once per row on every refresh and `en-full.kbb` is 10MB, so only the first 4KB of a file is read, and the result is cached against mtime and size. The body of a lexicon is never touched to draw a tooltip. (Same trap as the `offsetToPosition` rescan in `workspaceIndex`.)

### Checks

- `npm run pretest` (typecheck + eslint) clean.
- Extraction exercised against the eight real `.dict`/`.kbb` files in `StatuteFrames/kb/user`, plus synthetic cases: multi-line and one-line `/* */` headers, CRLF, a leading blank line, a bare `#` first line, a header longer than the cap, a `/*` appearing inside a `#` comment, and a file with no comment at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
