### PR TITLE
3.12.15: index offsets from a line table, not a rescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.15
+Opening an analyzer that uses the full English lexicon no longer hangs the extension.
+
+- **"Extension host unresponsive" on an analyzer whose `kb/user` holds `en-full.kbb` is fixed.** Building the cross-pass index converted a source offset to a line and column by counting newlines from the start of the file, once for the beginning of each symbol and once for its end. That is quadratic in the size of the file, and the English lexicon is 10MB holding 375,449 concepts: indexing that one file took roughly two and a half hours, during which outline, hover, go-to-definition, references and rename were all unavailable and VSCode reported the extension host as wedged. The same file now indexes in a tenth of a second.
+- The line offsets are now worked out in a single pass when a file is read, and each lookup is a binary search over that table. What it returns is unchanged, down to how an offset past the end of the file is handled.
+- **Per-input log directories are no longer indexed.** A `-DEV` analyzer run writes one `.kbb` per pass into `input/<text>_log/`, and the file watcher picked up every one of them. Those are engine output rather than source; the full index build already skipped them, and the watcher now skips them too, along with `node_modules`.
+
 ### 3.12.14
 The KB view shows what a dictionary or knowledge base is for on mouse-over.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.14",
+    "version": "3.12.15",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/language/providers.ts
+++ b/src/language/providers.ts
@@ -546,11 +546,17 @@ export function registerLanguageFeatures(ctx: vscode.ExtensionContext): void {
 	// workspace rebuild (re-reading and re-parsing every .nlp/.pat/.kbb file), so
 	// an analyzer run — which writes KB files — kicked off repeated full rebuilds
 	// that tied up the extension host and made opening files feel slow.
+	// Same shape as the rebuild() glob above, minus the excludes -- which the
+	// watcher API cannot express, so onDidCreate re-checks them. A -DEV run writes
+	// one .kbb per pass into input/<text>_log/; those are engine output, and the
+	// full build already skips them.
 	const watcher = vscode.workspace.createFileSystemWatcher("**/*.{nlp,pat,kbb}");
+	const isIndexable = (uri: vscode.Uri): boolean =>
+		!/(^|\/)(node_modules|[^/]*_log)\//.test(uri.path);
 	ctx.subscriptions.push(
 		watcher,
 		watcher.onDidDelete((uri) => nlpWorkspaceIndex.removeFile(uri)),
-		watcher.onDidCreate((uri) => { void nlpWorkspaceIndex.indexUri(uri); }),
+		watcher.onDidCreate((uri) => { if (isIndexable(uri)) void nlpWorkspaceIndex.indexUri(uri); }),
 		vscode.workspace.onDidSaveTextDocument((d) => {
 			if (d.languageId === "nlp" || d.languageId === "kbb")
 				nlpWorkspaceIndex.indexText(d.uri, d.getText());

--- a/src/language/workspaceIndex.ts
+++ b/src/language/workspaceIndex.ts
@@ -34,17 +34,37 @@ export interface IndexedRef {
 // names (optionally leading underscore), never pure numbers.
 const IDENT = /^_?[A-Za-z][\w]*$/;
 
-// Convert a source offset to a VSCode Position by counting newlines up to it.
-function offsetToPosition(text: string, offset: number): vscode.Position {
-	let line = 0;
-	let last = 0; // offset of the start of the current line
-	for (let i = 0; i < offset && i < text.length; i++) {
-		if (text[i] === "\n") {
-			line++;
-			last = i + 1;
+// Offset -> Position for one file, over a line table built once.
+//
+// This used to be a free function that counted newlines from byte 0 on every
+// call, and indexing a file costs two calls per symbol -- quadratic in the file
+// size. On a real analyzer that is not a slow path, it is a hang: the English
+// lexicon en-full.kbb is 10 MB and parses to 375,449 concepts, so indexing that
+// one file blocked the extension host for roughly two and a half hours, which
+// VSCode reports as "Extension host unresponsive". Building the line table is a
+// single pass; each lookup is then a binary search.
+class LineIndex {
+	// starts[i] = offset of the first character of line i.
+	private readonly starts: number[] = [0];
+
+	constructor(text: string) {
+		for (let i = 0; i < text.length; i++) {
+			if (text[i] === "\n") this.starts.push(i + 1);
 		}
 	}
-	return new vscode.Position(line, offset - last);
+
+	position(offset: number): vscode.Position {
+		// Last line whose start is <= offset. An offset past the end of the text
+		// lands on the final line, matching the old scan-and-clamp behaviour.
+		let lo = 0;
+		let hi = this.starts.length - 1;
+		while (lo < hi) {
+			const mid = (lo + hi + 1) >> 1;
+			if (this.starts[mid] <= offset) lo = mid;
+			else hi = mid - 1;
+		}
+		return new vscode.Position(lo, offset - this.starts[lo]);
+	}
 }
 
 export class NlpWorkspaceIndex {
@@ -107,8 +127,10 @@ export class NlpWorkspaceIndex {
 	// (Re)index a single file from in-memory text (used on save / on change).
 	indexText(uri: vscode.Uri, text: string): void {
 		this.removeFile(uri);
-		if (this.isKb(uri)) this.indexKb(uri, text);
-		else this.indexNlp(uri, text);
+		// One line table per file, shared by every offset conversion below.
+		const lines = new LineIndex(text);
+		if (this.isKb(uri)) this.indexKb(uri, text, lines);
+		else this.indexNlp(uri, text, lines);
 	}
 
 	private addDecl(uri: vscode.Uri, name: string, kind: IndexKind, range: vscode.Range, bucket: IndexedSymbol[], signature?: string): void {
@@ -119,29 +141,23 @@ export class NlpWorkspaceIndex {
 		this.byName.set(name, list);
 	}
 
-	private indexNlp(uri: vscode.Uri, text: string): void {
+	private indexNlp(uri: vscode.Uri, text: string, lines: LineIndex): void {
 		const syms: IndexedSymbol[] = [];
 		try {
 			for (const d of declaredSymbols(text)) {
-				const range = new vscode.Range(
-					offsetToPosition(text, d.selStart),
-					offsetToPosition(text, d.selEnd),
-				);
+				const range = new vscode.Range(lines.position(d.selStart), lines.position(d.selEnd));
 				this.addDecl(uri, d.name, d.kind, range, syms, d.signature);
 			}
 		} catch { /* keep whatever parsed; still index usages below */ }
 		this.byFile.set(uri.toString(), syms);
-		this.indexUsages(uri, text);
+		this.indexUsages(uri, text, lines);
 	}
 
-	private indexKb(uri: vscode.Uri, text: string): void {
+	private indexKb(uri: vscode.Uri, text: string, lines: LineIndex): void {
 		const syms: IndexedSymbol[] = [];
 		try {
 			for (const c of parseKbConcepts(text)) {
-				const range = new vscode.Range(
-					offsetToPosition(text, c.start),
-					offsetToPosition(text, c.end),
-				);
+				const range = new vscode.Range(lines.position(c.start), lines.position(c.end));
 				this.addDecl(uri, c.name, "concept", range, syms);
 			}
 		} catch { /* tolerate */ }
@@ -150,15 +166,12 @@ export class NlpWorkspaceIndex {
 
 	// Record every identifier-like Word token as a reference occurrence. Uses the
 	// tokenizer so matches inside strings and comments are excluded.
-	private indexUsages(uri: vscode.Uri, text: string): void {
+	private indexUsages(uri: vscode.Uri, text: string, lines: LineIndex): void {
 		const refs: IndexedRef[] = [];
 		try {
 			for (const t of tokenize(text)) {
 				if (t.kind !== TokenKind.Word || !IDENT.test(t.text)) continue;
-				const range = new vscode.Range(
-					offsetToPosition(text, t.start),
-					offsetToPosition(text, t.end),
-				);
+				const range = new vscode.Range(lines.position(t.start), lines.position(t.end));
 				const ref: IndexedRef = { name: t.text, uri, range };
 				refs.push(ref);
 				const list = this.refsByName.get(t.text) ?? [];


### PR DESCRIPTION
Opening an analyzer whose `kb/user` holds the full English lexicon wedged the extension host. `offsetToPosition()` counted newlines from byte 0 on every call, and indexing a file costs two calls per symbol -- quadratic in the size of the file. `en-full.kbb` is 10MB and parses to 375,449 concepts.

### Measured on the real file

`C:/git/en/StatuteFrames/kb/user/en-full.kbb`, 10.2 MB, 375,449 lines, 750,898 conversions:

| | |
| --- | --- |
| before | 11.26 ms per call → **2.35 hours** (extrapolated from 300 spread offsets) |
| after | 69 ms to build the line table + 50 ms for all 750,898 lookups = **0.12 s** |

VSCode reports the wait as "Extension host unresponsive". Outline, hover, go-to-definition, references and rename are all unavailable while it runs.

### The fix

`LineIndex` builds the table of line starts in one pass over the text, then binary-searches it per lookup. One table per file, built in `indexText()` and handed down to `indexNlp()`, `indexKb()` and `indexUsages()`.

**Behaviour is unchanged.** The new lookup was checked against the old scan over **22,622 offsets** with no mismatch:

- empty text, `\n` only, `\n\n\n`, no trailing newline, leading and trailing newlines
- CRLF and mixed line endings
- every offset from `-3` to `length + 5` on 14 hand-written cases
- 300 randomised texts (tabs, letters, `\n`, `\r\n`), 60 random offsets each

That includes the two edges worth naming: an offset past the end of the text still lands on the final line with a character index past the end of it, and a negative offset still yields line 0 with a negative character, exactly as the scan-and-clamp did.

### Also: stop indexing per-input log directories

A `-DEV` run writes one `.kbb` per pass into `input/<text>_log/`, and the file watcher picked up every one of them as a file to index. `rebuild()` already excluded them through its `findFiles` exclude (`{**/node_modules/**,**/*_log/**}`), but the watcher API has no exclude, so `onDidCreate` now re-checks the same shape.

### Checks

- `npm test` green: 79 language, 63 treeview, 11,901-file formatter corpus, grammar and worker checks.
- `npm run pretest` (typecheck + eslint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
