### PR TITLE
3.12.16: KB tooltips show the header comment over the file's path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.16
+KB view mouse-overs say what the file is for and where it lives.
+
+- **The tooltip on a `.dict` or `.kbb` file now carries the file's path underneath its header comment.** 3.12.14 put the comment written at the top of the file into the tooltip, which replaced the path VSCode had been showing there. The comment says what the file holds, and the path says which one of several similarly named lexicons you are actually pointing at, so the tooltip now shows the description first and the path below it.
+- A file with no header comment is unchanged: its tooltip is the path on its own, exactly as VSCode shows by default.
+
 ### 3.12.15
 Opening an analyzer that uses the full English lexicon no longer hangs the extension.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.15",
+    "version": "3.12.16",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/kbView.ts
+++ b/src/kbView.ts
@@ -19,9 +19,9 @@ export interface KBItem {
 }
 
 // The mouse-over text for a .dict / .kbb file: the comment block its author
-// wrote at the top of it, which is where they say what the file holds. Without
-// it the tooltip is the file's path -- something the tree already makes obvious.
-// Same idea as the pass comment the Sequence view shows.
+// wrote at the top of it, which is where they say what the file holds, followed
+// by the path the file lives at. Same idea as the pass comment the Sequence view
+// shows, with the path VSCode tooltips carry by default kept underneath it.
 //
 // Only the head of the file is read. en-full.kbb is 10 MB and getTreeItem runs
 // once per row on every refresh, so the body is never touched, and the result is
@@ -157,11 +157,12 @@ export class FileSystemProvider implements vscode.TreeDataProvider<KBItem> {
 
 			if (name.endsWith('.kbb') || name.endsWith('.dict') || name.endsWith('.kbbb') || name.endsWith('.dictt')) {
 				treeItem.contextValue = 'toggle';
-				// What the file is for, taken from the comment at the top of it.
-				// With no such comment the default tooltip (the path) stands.
+				// What the file is for, taken from the comment at the top of it,
+				// over the path it lives at. With no such comment the tooltip is
+				// the path alone, which is what VSCode shows by default anyway.
 				const description = fileDescription(kbItem.uri.fsPath);
 				if (description.length)
-					treeItem.tooltip = description;
+					treeItem.tooltip = description + '\n\n' + kbItem.uri.fsPath;
 			}
 
 			if (name.endsWith('.kb'))


### PR DESCRIPTION
Hovering a `.dict` or `.kbb` file in the KB view showed its header comment as of 3.12.14, which replaced the path VSCode had been putting there. Both are worth having: the comment says what the file holds, and the path says which of several similarly named lexicons the row is actually pointing at.

The tooltip is now the header comment, a blank line, then the file's path:

```
Verb lexicon for the phrasal-verb pass.
Entries are lower-cased and sorted by byte.

c:\git\analyzers\Foo\kb\user\verbs.dict
```

A file with no header comment is unchanged -- its tooltip stays VSCode's default path, so `en-full.kbb` reads exactly as it did. No change to how the comment is read or cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
