### PR TITLE
chore: ignore TypeScript major bumps until typescript-eslint supports TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,16 @@ updates:
       # deliberate choice to follow VS Code's own runtime.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+
+      # TypeScript 7 is the Go rewrite (typescript-go), not a routine major. The
+      # whole lint toolchain peers against the old compiler -- typescript-eslint
+      # 8.68.0, the current latest, still declares typescript ">=4.8.4 <6.1.0" --
+      # so npm ci fails ERESOLVE on every job the moment typescript goes to 7.
+      # PR #1172 was closed for exactly this. Minor and patch bumps inside 6.x
+      # keep flowing; revisit the major once typescript-eslint ships TS 7
+      # support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # One PR for the routine dev-tooling churn instead of six. Majors stay
       # separate, since those are the ones that actually need reading.


### PR DESCRIPTION
Dependabot #1172 proposed `typescript` 6.0.3 → 7.0.2. It merges cleanly, but all four CI jobs fail at `npm ci`:

```
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.68.0
npm error Found: typescript@7.0.2
```

TypeScript 7 is the Go rewrite (typescript-go), and the lint toolchain has not followed it. `@typescript-eslint/eslint-plugin@latest` is 8.68.0 — the version already in `package.json` — and its peer range still caps at `<6.1.0`. Neither `latest` nor `canary` (8.68.1-alpha.8) accepts TS 7, so there is no combination of released versions that installs.

That leaves only `--legacy-peer-deps` or `--force` to get it green, which would install a typescript-eslint that calls a compiler API the Go port does not present the same way — papering over a real incompatibility rather than resolving it.

So this adds a documented `ignore` for typescript majors, in the same style as the `@types/vscode` and `@types/node` entries it sits under: these are the bumps that are a decision, not a version move. Minor and patch bumps inside 6.x keep flowing through the `dev-dependencies` group as before.

Revisit once typescript-eslint ships TS 7 support.

Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
