### PR TITLE
3.12.19: stop the startup analyzer scan from walking output directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.19
+Startup stops walking folders that hold no analyzers.
+
+- **The scan for analyzers no longer walks build and engine output.** Starting up points that scan at your workspace folder and walks the whole thing, synchronously, before the extension host can do anything else -- so the cost is paid on every start and nothing else happens meanwhile. It descended into `.git`, `.vscode-test`, `.nlp-compile` and per-input `_log` folders, none of which can hold an analyzer, and into `node_modules`, which almost never does. Measured on a folder of about 45,000 directories, the scan went from roughly 65 seconds to 36; on an ordinary analyzer folder, from 129ms to 48ms.
+- `node_modules` is skipped only when it does not contain the published `nlpplus` package, which does ship analyzers inside it and is meant to be found. Checked against a tree holding 797 analyzers: the same 797 are found, none lost and none gained -- the scan is only quicker about it.
+- This is a first cut rather than the whole story. The scan is still synchronous and still has no depth limit, so a deep enough tree can still take a while; those are the next things to look at.
+
 ### 3.12.18
 The log view stops logging unhandled promise errors.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.12.18",
+    "version": "3.12.19",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.12.18",
+            "version": "3.12.19",
             "license": "MIT",
             "dependencies": {
                 "copy-dir": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.18",
+    "version": "3.12.19",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1427,6 +1427,21 @@ export class VisualText {
         return this.analyzers;
     }
 
+    // Build and engine output that never holds an analyzer, so the scan below
+    // does not descend into it. The same exclusions src/language/providers.ts
+    // already applies to the cross-pass index.
+    private static readonly SCAN_SKIP = /^(\.git|\.vscode-test|\.nlp-compile)$|_log$/;
+
+    // node_modules is handled separately rather than skipped outright, because
+    // the published nlpplus package ships analyzers inside it and they are meant
+    // to be found. Descend only when this node_modules actually contains it.
+    private static scanSkips(dirPath: string): boolean {
+        const name = path.basename(dirPath);
+        if (name === 'node_modules')
+            return !fs.existsSync(path.join(dirPath, 'nlpplus'));
+        return VisualText.SCAN_SKIP.test(name);
+    }
+
     getAnalyzersRecursive(testForLogs: boolean, dir: vscode.Uri) {
         if (dir.fsPath.length) {
             let anas: vscode.Uri[] = [];
@@ -1435,6 +1450,8 @@ export class VisualText {
             }
             anas = dirfuncs.getDirectories(dir);
             for (const ana of anas) {
+                if (VisualText.scanSkips(ana.fsPath))
+                    continue;
                 if (visualText.isAnalyzerDirectory(ana)) {
                     if (!testForLogs || dirfuncs.analyzerHasLogFiles(ana))
                         this.analyzers.push(ana);


### PR DESCRIPTION
Profiling the activation path, which I flagged in the last round as wanting evidence before anyone touched it. The evidence turned out to be worse than expected.

## What's happening

`getAnalyzersRecursive` runs during activation — `readState()` points it at the workspace folder — and it is **synchronous**. So whatever folder you have open is walked in full before the extension host can do anything else, on every start. It descended into everything it found.

Measured on this machine:

| folder | directories | before |
|---|---|---|
| an ordinary analyzer folder | ~460 | 129 ms |
| a large working tree | ~45,000 | **~65 s** |

The 65s case is a fully blocked extension host. It needs someone to open a big folder as their workspace, which is not exotic.

## The fix here

Skip directories that hold no analyzers: `.git`, `.vscode-test`, `.nlp-compile`, and per-input `_log` folders — the same exclusions [providers.ts](src/language/providers.ts) already applies to the cross-pass index.

**`node_modules` is deliberately not skipped outright.** My first attempt did, and I checked it before believing it: that lost **15 real analyzers**, all from the published `nlpplus` package, which ships analyzers inside `node_modules` and is meant to find them. So it is skipped only when that particular `node_modules` does not contain `nlpplus` — which is both correct and, as it happens, the fastest variant measured.

| | ordinary folder | large tree | analyzers found |
|---|---|---|---|
| today | 129 ms | ~65 s | 797 |
| this PR | **48 ms** | **~36 s** | **797** |

Correctness was verified by collecting the full analyzer set both ways over a tree containing 797 analyzers: **identical — none lost, none gained.**

## What this does not fix

The scan is still synchronous and still has **no depth limit**, which is the real reason a pathological tree is expensive. A depth cap would take the large tree from ~36s to ~1s, but it is a behaviour change — it needs a decision about how deeply nested an analyzer folder is allowed to be — so it is not in this PR.

## Verification

Typecheck, lint, 79 language + 63 treeview + 12,374 corpus files, integration 27/0, webpack clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
