### PR TITLE
3.12.20: only write analyzer.directory when it changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.12.20
+Your global settings stop being rewritten every time a window opens.
+
+- **`analyzer.directory` is only written when it actually changes.** The setting was rewritten on every single activation, almost always to the path of the folder you had open. Two windows on two different analyzer folders would therefore take turns overwriting the same global setting with their own path, and every start touched `settings.json` whether anything had changed or not -- which Settings Sync then had something to sync. The value is only ever read as a fallback for when the open folder holds no analyzers, so none of that writing was buying anything.
+- Nothing else changes: the folder the extension uses is worked out exactly as before, and a genuinely new value is still saved.
+
 ### 3.12.19
 Startup stops walking folders that hold no analyzers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.12.19",
+    "version": "3.12.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.12.19",
+            "version": "3.12.20",
             "license": "MIT",
             "dependencies": {
                 "copy-dir": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.12.19",
+    "version": "3.12.20",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/visualText.ts
+++ b/src/visualText.ts
@@ -1101,7 +1101,12 @@ export class VisualText {
         }
 
         this.analyzerDir = vscode.Uri.file(directory);
-        if (directory.length > 1)
+        // Only write when the value actually changes. This runs on every
+        // activation, and the path it writes is usually the workspace folder --
+        // so two windows open on two analyzer folders each rewrote the same
+        // global setting to their own path, over and over, for a value that is
+        // only ever read as a fallback when the open folder holds no analyzers.
+        if (directory.length > 1 && config.get<string>('directory') !== directory)
             config.update('directory', directory, vscode.ConfigurationTarget.Global);
     }
 


### PR DESCRIPTION
`configAnalzyerDirectory` ran an unconditional `config.update(..., ConfigurationTarget.Global)` on **every activation**, and the value it wrote was almost always the workspace folder currently open.

Two consequences:

- Two windows open on two different analyzer folders each rewrote the same global setting to their own path, taking turns clobbering it.
- Every start touched `settings.json` whether anything had changed or not — which Settings Sync then had something to sync.

The setting is only ever read as a **fallback**, for when the open folder contains no analyzers — its own description says so. So none of that writing was buying anything.

Now guarded on the value actually differing. The directory the extension resolves is worked out exactly as before, and a genuinely new value is still saved.

## Verification

Typecheck, lint, 79 language + 63 treeview + 12,374 corpus files, integration 27/0, webpack clean.

## Note on ordering

This bumps to **3.12.20**, so merging publishes. #1179 (dropping the unused proposed-API typings) carries no version bump by design — if it merges first, it ships along with this one rather than triggering a release of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
