### PR TITLE
Read parse-tree node flags by name, not by field position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.13.1
+Parse-tree node flags are read by name.
+
+- **"Display Built Only" no longer hides nodes that were built.** The engine writes a node's flags only when they are set -- `b`, `un`, `sem`, `fired`, `blt`, in that order -- so which field holds `blt` depends on how many flags precede it. The reader took a fixed field, which is right for a node written `node,fired,blt` and wrong for one written `node,un,fired,blt`, where the flag has shifted along by one. Those nodes came back as not built and were dropped from the tree in BUILT mode. In the sample analyzers 63 nodes are written that way, `_sentence` and `_year` among them.
+- The same fixed-field reading in the other tree reader marked any unsealed node as fired: `node,un` has `un` where the reader expected `fired`. That field is not consulted by anything today, so nothing displayed wrongly, but it was wrong on 23,621 of the 37,863 node lines in the sample analyzers -- and it is exactly the field a future reader would reach for.
+- Both readers now share one flag parser with the `.tree` reader added in 3.13.0, so the vocabulary lives in one place and the two cannot drift apart again.
+
 ### 3.13.0
 NLP++ gets a language server and a replay debugger.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.13.0",
+    "version": "3.13.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.13.0",
+            "version": "3.13.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.13.0",
+    "version": "3.13.1",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/trace/traceTest.ts
+++ b/src/trace/traceTest.ts
@@ -11,7 +11,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { parseTreeLine, parseTreeFile, nodeAtOffset, walkTree } from "./treeParse";
+import { parseTreeLine, parseTreeFile, nodeAtOffset, walkTree, parseNodeFlags } from "./treeParse";
 import {
 	loadTrace, findLatestLogDir, parseSequence, sequencePassNames,
 	passesForSource, firedRuleLines, nodesBuiltBy,
@@ -81,6 +81,50 @@ function eq<T>(name: string, actual: T, expected: T): void {
 	check("line: header is not a node", parseTreeLine("    PASS 15 (moneyAttributes)") === undefined);
 	check("line: blank is not a node", parseTreeLine("") === undefined);
 	check("line: banner is not a node", parseTreeLine("PAT OUTPUT TREE:") === undefined);
+}
+
+// ---- flag vocabulary -------------------------------------------------------
+// parseNodeFlags is shared with the older reader in treeFile.ts. These cases are
+// the ones a positional reader gets wrong, and they are not hypothetical: the
+// sample analyzers contain 63 nodes written with a flag before "fired".
+{
+	const none = parseNodeFlags([]);
+	eq("flags: nothing set by default", [none.base, none.unsealed, none.sem, none.fired, none.built].join(","), "false,false,false,false,false");
+
+	// "node,un" -- field 7 is "un". Read positionally this reports fired.
+	const un = parseNodeFlags(["un"]);
+	eq("flags: un is unsealed", un.unsealed, true);
+	eq("flags: un is not fired", un.fired, false);
+
+	// "node,fired,blt" -- the shape a positional reader was tuned for.
+	const plain = parseNodeFlags(["fired", "blt"]);
+	eq("flags: fired,blt fired", plain.fired, true);
+	eq("flags: fired,blt built", plain.built, true);
+
+	// "node,un,fired,blt" -- blt has shifted one field along. This is the case
+	// that dropped built nodes from the tree in "Display Built Only" mode.
+	const shifted = parseNodeFlags(["un", "fired", "blt"]);
+	eq("flags: un,fired,blt still built", shifted.built, true);
+	eq("flags: un,fired,blt still fired", shifted.fired, true);
+	eq("flags: un,fired,blt unsealed", shifted.unsealed, true);
+
+	// "node,b,fired,blt" -- the other real shifted shape in the corpus.
+	const based = parseNodeFlags(["b", "fired", "blt"]);
+	eq("flags: b,fired,blt built", based.built, true);
+	eq("flags: b,fired,blt base", based.base, true);
+
+	// Every flag at once, shifting blt as far as it goes.
+	const all = parseNodeFlags(["b", "un", "sem", "fired", "blt"]);
+	eq("flags: all five set", [all.base, all.unsealed, all.sem, all.fired, all.built].join(","), "true,true,true,true,true");
+
+	// The attribute chunk trails the flags in the same field list and must not
+	// be mistaken for one.
+	const withAttrs = parseNodeFlags(["un", ' ("name" "sentence1")']);
+	eq("flags: attribute chunk is not a flag", withAttrs.fired, false);
+	eq("flags: attribute chunk leaves un set", withAttrs.unsealed, true);
+
+	// Whitespace around a flag (the field list is split on commas, not trimmed).
+	eq("flags: padded flag still reads", parseNodeFlags([" blt "]).built, true);
 }
 
 // ---- file parsing ----------------------------------------------------------

--- a/src/trace/treeParse.ts
+++ b/src/trace/treeParse.ts
@@ -92,7 +92,40 @@ function parseAttributes(text: string): TraceAttribute[] {
 	return out;
 }
 
+// The flags a node line can carry, in the order Pn::print emits them.
+export interface NodeFlags {
+	base: boolean;     // b
+	unsealed: boolean; // un
+	sem: boolean;      // sem
+	fired: boolean;    // fired -- a rule matched here
+	built: boolean;    // blt   -- a rule created this node
+}
+
 const FLAG_NAMES = new Set(["b", "un", "sem", "fired", "blt"]);
+
+// Read node flags out of the comma-separated fields that FOLLOW the type field.
+//
+// Shared with the older reader in treeFile.ts so the two cannot drift: both are
+// looking at the same engine output, and the vocabulary belongs in one place.
+//
+// Reading these by POSITION is the trap. Because a flag is written only when it
+// is set, the field after the type is whichever flag happens to be first --
+// "node,un" is unsealed, not fired, and a node written "node,un,fired,blt" has
+// "blt" two fields further along than one written "node,fired,blt". Any fixed
+// index is therefore wrong for some real subset of nodes.
+export function parseNodeFlags(fieldsAfterType: string[]): NodeFlags {
+	const flags: NodeFlags = { base: false, unsealed: false, sem: false, fired: false, built: false };
+	for (const raw of fieldsAfterType) {
+		const flag = raw.trim();
+		if (!FLAG_NAMES.has(flag)) continue;
+		if (flag === "b") flags.base = true;
+		else if (flag === "un") flags.unsealed = true;
+		else if (flag === "sem") flags.sem = true;
+		else if (flag === "fired") flags.fired = true;
+		else if (flag === "blt") flags.built = true;
+	}
+	return flags;
+}
 
 // Parse one "<name> [<fields>]" line into a node, or undefined if the line is
 // not a tree node (headers, blank lines, the "PAT OUTPUT TREE:" banner).
@@ -125,24 +158,11 @@ export function parseTreeLine(line: string): TraceNode | undefined {
 		passNum: num(parts[4]),
 		ruleLine: num(parts[5]),
 		type: parts[6],
-		base: false,
-		unsealed: false,
-		sem: false,
-		fired: false,
-		built: false,
+		...parseNodeFlags(parts.slice(7)),
 		attributes: parseAttributes(tail),
 		depth: Math.floor(indent.length / INDENT_WIDTH),
 		children: [],
 	};
-
-	for (const flag of parts.slice(7)) {
-		if (!FLAG_NAMES.has(flag)) continue;
-		if (flag === "b") node.base = true;
-		else if (flag === "un") node.unsealed = true;
-		else if (flag === "sem") node.sem = true;
-		else if (flag === "fired") node.fired = true;
-		else if (flag === "blt") node.built = true;
-	}
 	return node;
 }
 

--- a/src/treeFile.ts
+++ b/src/treeFile.ts
@@ -9,6 +9,7 @@ import { SequenceFile } from './sequence';
 import { FindFile, FindItem } from './findFile';
 import { findView } from './findView';
 import { dirfuncs } from './dirfuncs';
+import { parseNodeFlags } from './trace/treeParse';
 import * as os from 'os';
 
 export enum generateType { GENERAL, EXACT }
@@ -496,14 +497,13 @@ ${ruleStr}
 				treeLine.passNum = +toks[4];
 				treeLine.ruleLine = +toks[5];
 				treeLine.type = toks[6];
-				if (toks.length > 7) {
-					if (toks[7].length)
-						treeLine.fired = true;
-				}
-				if (toks.length > 8) {
-					if (toks[8].length > 0)
-						treeLine.built = true;
-				}
+				// Flags are read by NAME. The engine writes each one only when it
+				// is set (Pn::print, lite/pn.cpp), so the field after the type is
+				// whichever flag comes first -- taking field 7 as "fired" marked
+				// every unsealed node ("node,un") as fired.
+				const flags = parseNodeFlags(toks.slice(7));
+				treeLine.fired = flags.fired;
+				treeLine.built = flags.built;
 			}
 		}
 		return treeLine;
@@ -709,7 +709,12 @@ ${ruleStr}
 					tts[0] = firstChar;
 					tts.splice(1, 1);
 				}
-				fired.built = (tts.length >= 9 && tts[9] === 'blt') ? true : false;
+				// Same rule as parseTreeLine: flags are named, not positional. The
+				// type is field 7 here, so the flags start at 8. Fixing field 9 as
+				// "blt" missed "built" on every node that also carries b, un or
+				// sem -- 63 such nodes in the sample analyzers alone, all of them
+				// dropped from the tree in "Display Built Only" mode.
+				fired.built = parseNodeFlags(tts.slice(8)).built;
 				if (+tts[2] > lastTo) {
 					fired.str = tts[0].trim();
 					fired.from = +tts[1];


### PR DESCRIPTION
Follow-up to #1187, which flagged this.

The engine writes a node's flags only when they are set — `b`, `un`, `sem`, `fired`, `blt`, in that order ([`Pn::print`](https://github.com/VisualText/nlp-engine/blob/master/lite/pn.cpp)) — so the field holding any given flag depends on how many flags precede it. Both tree readers took a fixed index, correct only for the one combination each was written against.

## The one that bites

`parseFireds` took field 9 as `blt`. That holds for a node written `node,fired,blt` and fails for `node,un,fired,blt`, where `blt` has shifted along and field 9 is `fired`. Those nodes reported `built = false`, and since that value gates the BUILT display mode, they were **dropped from the tree entirely**.

63 nodes across the sample analyzers are written that way, `_sentence` and `_year` among them:

```
_sentence [0,183,0,183,5,24,node,un,fired,blt, ("name" "sentence1") ...]
_year     [354,357,354,357,4,24,node,b,fired,blt]
```

## The latent one

`parseTreeLine` took field 7 as `fired`, so every unsealed node (`node,un`) came back fired. Nothing reads `TreeLine.fired` today, so nothing displayed wrongly — but it was wrong on **23,621 of 37,863** node lines in the sample analyzers, and it is the field the next reader would reach for.

## Fix

Both now call `parseNodeFlags()`, shared with the `.tree` reader added in 3.13.0, so the vocabulary lives in one place and the readers cannot drift apart again. The condition it replaces in `parseFireds` also had an off-by-one — it guarded `tts[9]` with `tts.length >= 9` — which the shared helper makes moot.

## Testing

Fourteen new cases cover the shapes a positional reader gets wrong: `un` alone, `fired,blt`, `un,fired,blt`, `b,fired,blt`, all five at once, and the attribute chunk that trails the flags in the same field list and must not be mistaken for one.

Measured across the sample analyzers: of 37,863 node lines, `built` now differs on exactly the 63 shifted nodes and `fired` on 23,621 — no other behaviour changed.

| Suite | Result |
| --- | --- |
| integration (real VSCode host) | 27 / 27 |
| trace | 141 / 141 (was 127) |
| language | 79 / 79 |
| treeview | 63 / 63 |
| lint + typecheck | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
