### PR TITLE
Add a live rule debugger driving the engine's debug server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ out-language/
 out-treeview/
 out-test/
 out-trace/
+out-debug/
 
 # VS Code builds downloaded by the integration harness
 .vscode-test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.14.0
+Rules can be debugged as they run.
+
+- **A new "live" debug mode steps through rules as the engine tries them.** The replay debugger added in 3.13.0 steps over the parse trees a finished run left behind, which shows what each pass produced but nothing about how. Live mode runs the analyzer under the engine's own rule debugger and stops between individual rule attempts: which rule is being tried at which node, whether it matched, and -- when it did not -- how many of its elements matched before it gave up. That last number is usually the whole question when a rule does not fire, because it says which element stopped agreeing with the text.
+- The three step buttons map to the three things a rule debugger can do, since NLP++ has no call stack to step into: **Step Over** goes to the next rule tried, **Step Into** to the next rule that actually matches, and **Step Out** to the start of the next pass. Breakpoints work on rule lines in pass files, and the parse tree is browsable mid-pass, each node showing the text it covers and the pass and rule line that built it.
+- Turning on `stopOnRuleFailure` stops on every rule that fails, not just the ones that match. Most rules fail at most nodes, so this stops very often -- it is for tracking down one rule, not for browsing.
+- You can also **attach to an engine that is already running** under `nlp -ANA ... -DEBUG <port>`, rather than having the editor start it.
+- Live mode needs NLP++ engine 3.9.0 or later, and cannot step backward -- a running engine cannot un-run a rule. Replay mode is unchanged and still steps in both directions, so the two are offered side by side rather than one replacing the other. If the installed engine is too old the extension says so instead of failing to connect.
+
 ### 3.13.1
 Parse-tree node flags are read by name.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.13.1",
+    "version": "3.14.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.13.1",
+            "version": "3.14.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.13.1",
+    "version": "3.14.0",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,
@@ -3505,19 +3505,95 @@
                             "analyzer"
                         ],
                         "properties": {
+                            "mode": {
+                                "type": "string",
+                                "enum": [
+                                    "replay",
+                                    "live"
+                                ],
+                                "enumDescriptions": [
+                                    "Step through the per-pass parse trees of the last run. Works with any engine, and can step backward as well as forward, but stops only at pass boundaries.",
+                                    "Run the analyzer under the engine's rule debugger and stop between individual rule attempts, including on rules that fail. Needs NLP++ engine 3.9.0 or later and cannot step backward."
+                                ],
+                                "description": "Which debugger to use: replay the last run's tree dumps, or drive a live engine rule by rule.",
+                                "default": "replay"
+                            },
                             "analyzer": {
                                 "type": "string",
-                                "description": "The analyzer directory to replay (the folder containing spec/ and input/). Defaults to the analyzer currently open in the Analyzers view.",
+                                "description": "The analyzer directory (the folder containing spec/ and input/). Defaults to the analyzer currently open in the Analyzers view.",
                                 "default": "${command:nlp.currentAnalyzerDir}"
                             },
                             "logDir": {
                                 "type": "string",
-                                "description": "A specific <text>_log directory to replay. Defaults to the most recently written run under the analyzer's input/ tree."
+                                "description": "replay mode: a specific <text>_log directory to replay. Defaults to the most recently written run under the analyzer's input/ tree."
+                            },
+                            "input": {
+                                "type": "string",
+                                "description": "live mode: the text file to analyze. Defaults to the analyzer's current text file.",
+                                "default": "${command:nlp.currentTextFile}"
+                            },
+                            "enginePath": {
+                                "type": "string",
+                                "description": "live mode: path to nlp.exe. Defaults to the engine the extension installed."
+                            },
+                            "workDir": {
+                                "type": "string",
+                                "description": "live mode: the engine working directory passed as -WORK. Defaults to the installed engine directory."
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": "live mode: TCP port for the engine's debug server on 127.0.0.1. A free port is chosen when this is not set."
+                            },
+                            "stopOnRuleFailure": {
+                                "type": "boolean",
+                                "description": "live mode: also stop every time a rule fails, reporting how many of its elements matched first. Most rules fail at most nodes, so this stops very often -- it is for tracking down one rule, not for browsing.",
+                                "default": false
+                            },
+                            "engineArgs": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "live mode: extra arguments appended to the nlp command line, e.g. [\"-DEV\"]."
                             },
                             "stopOnEntry": {
                                 "type": "boolean",
                                 "description": "Stop at the first pass instead of running to the first breakpoint.",
                                 "default": true
+                            }
+                        }
+                    },
+                    "attach": {
+                        "required": [
+                            "analyzer",
+                            "port"
+                        ],
+                        "properties": {
+                            "mode": {
+                                "type": "string",
+                                "enum": [
+                                    "live"
+                                ],
+                                "description": "Attaching is only meaningful for the live rule debugger.",
+                                "default": "live"
+                            },
+                            "analyzer": {
+                                "type": "string",
+                                "description": "The analyzer directory the running engine was started on. Needed to map breakpoints in pass files to the pass numbers the engine uses.",
+                                "default": "${command:nlp.currentAnalyzerDir}"
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": "The port the engine was started with, as in: nlp -ANA ... -IN ... -DEBUG 9777"
+                            },
+                            "input": {
+                                "type": "string",
+                                "description": "The text file the engine is analyzing. Optional: it is only used to show the text each tree node covers."
+                            },
+                            "stopOnRuleFailure": {
+                                "type": "boolean",
+                                "description": "Also stop every time a rule fails, reporting how many of its elements matched first.",
+                                "default": false
                             }
                         }
                     }
@@ -3527,20 +3603,56 @@
                         "type": "nlpxx",
                         "request": "launch",
                         "name": "NLP++: replay last analyzer run",
+                        "mode": "replay",
                         "analyzer": "${command:nlp.currentAnalyzerDir}",
+                        "stopOnEntry": true
+                    },
+                    {
+                        "type": "nlpxx",
+                        "request": "launch",
+                        "name": "NLP++: debug rules (live)",
+                        "mode": "live",
+                        "analyzer": "${command:nlp.currentAnalyzerDir}",
+                        "input": "${command:nlp.currentTextFile}",
                         "stopOnEntry": true
                     }
                 ],
                 "configurationSnippets": [
                     {
                         "label": "NLP++: replay last analyzer run",
-                        "description": "Step through the per-pass parse trees from the most recent run of an analyzer.",
+                        "description": "Step through the per-pass parse trees from the most recent run of an analyzer. Steps backward as well as forward.",
                         "body": {
                             "type": "nlpxx",
                             "request": "launch",
                             "name": "NLP++: replay last analyzer run",
+                            "mode": "replay",
                             "analyzer": "^\"\\${command:nlp.currentAnalyzerDir}\"",
                             "stopOnEntry": true
+                        }
+                    },
+                    {
+                        "label": "NLP++: debug rules (live)",
+                        "description": "Run the analyzer under the engine's rule debugger. Step Over = next rule tried, Step Into = next rule that matches, Step Out = next pass. Needs engine 3.9.0+.",
+                        "body": {
+                            "type": "nlpxx",
+                            "request": "launch",
+                            "name": "NLP++: debug rules (live)",
+                            "mode": "live",
+                            "analyzer": "^\"\\${command:nlp.currentAnalyzerDir}\"",
+                            "input": "^\"\\${command:nlp.currentTextFile}\"",
+                            "stopOnEntry": true
+                        }
+                    },
+                    {
+                        "label": "NLP++: attach to a running engine",
+                        "description": "Attach to an engine already started with -DEBUG <port>. Needs engine 3.9.0+.",
+                        "body": {
+                            "type": "nlpxx",
+                            "request": "attach",
+                            "name": "NLP++: attach to a running engine",
+                            "mode": "live",
+                            "analyzer": "^\"\\${command:nlp.currentAnalyzerDir}\"",
+                            "port": 9777
                         }
                     }
                 ]
@@ -3574,11 +3686,12 @@
         "lint:fix": "npm run lint -- --fix",
         "typecheck": "tsc --noEmit -p tsconfig.json",
         "pretest": "npm run typecheck && npm run lint",
-        "test": "npm run check-grammars && npm run check-worker && npm run test:language && npm run test:treeview && npm run test:format && npm run test:trace",
+        "test": "npm run check-grammars && npm run check-worker && npm run test:language && npm run test:treeview && npm run test:format && npm run test:trace && npm run test:debug",
         "test:integration": "tsc -p tsconfig.test.json && node ./out-test/test/runTest.js",
         "test:format": "tsc -p tsconfig.format.json && node ./out-format/corpusTest.js",
         "test:language": "tsc -p tsconfig.language.json && node ./out-language/language/langTest.js",
         "test:trace": "tsc -p tsconfig.trace.json && node ./out-trace/trace/traceTest.js",
+        "test:debug": "tsc -p tsconfig.debug.json && node ./out-debug/debug/debugTest.js",
         "test:treeview": "tsc -p tsconfig.treeview.json && node ./out-treeview/treeTest.js",
         "vsce-package": "npm run check-grammars && npm run webpack-prod && vsce package -o ./vscode.nlp.vsix"
     },

--- a/src/debug/debugAdapter.ts
+++ b/src/debug/debugAdapter.ts
@@ -1,9 +1,22 @@
-// Standalone entry point for the NLP++ replay debug adapter.
+// Standalone entry point for the NLP++ debug adapters.
 //
-// Runs the DAP session over stdin/stdout as its own process. VSCode starts this
-// via a DebugAdapterExecutable (see src/debug/debugConfig.ts); any other
-// DAP-speaking editor can launch `node dist/debugAdapter.js` the same way.
+// Runs a DAP session over stdin/stdout as its own process. Which session depends
+// on how it was started:
+//
+//   node dist/debugAdapter.js          replay a finished run's .tree dumps
+//   node dist/debugAdapter.js --live   drive a running engine, rule by rule
+//
+// The mode is an argv flag rather than a launch-config field because DAP settles
+// capabilities at `initialize`, before any launch arguments arrive -- and the two
+// sessions genuinely differ there (only replay can step backward). VSCode picks
+// the flag from `mode` in the launch config; see src/debug/debugConfig.ts. Any
+// other DAP-speaking editor can launch either directly.
 
 import { NlpDebugSession } from "./nlpDebugSession";
+import { NlpLiveDebugSession } from "./nlpLiveDebugSession";
 
-NlpDebugSession.run(NlpDebugSession);
+if (process.argv.includes("--live")) {
+	NlpLiveDebugSession.run(NlpLiveDebugSession);
+} else {
+	NlpDebugSession.run(NlpDebugSession);
+}

--- a/src/debug/debugConfig.ts
+++ b/src/debug/debugConfig.ts
@@ -1,29 +1,55 @@
-// VSCode wiring for the NLP++ replay debugger.
+// VSCode wiring for the NLP++ debuggers.
 //
-// This is the ONLY file in src/debug that imports 'vscode'. The session itself
-// (nlpDebugSession.ts) and its entry point (debugAdapter.ts) are plain Node, so
-// the debugger can be driven from any DAP-speaking editor.
+// This is the ONLY file in src/debug that imports 'vscode'. The sessions
+// themselves and their entry point are plain Node, so both debuggers can be
+// driven from any DAP-speaking editor.
 //
 // Two jobs: fill in a launch config from the analyzer the user currently has
 // open (so F5 works with no .vscode/launch.json at all), and tell VSCode how to
-// start the adapter process.
+// start the adapter process -- including which of the two modes to run.
 
 import * as vscode from "vscode";
 import * as path from "path";
+import * as fs from "fs";
 import { visualText } from "../visualText";
 
 const DEBUG_TYPE = "nlpxx";
 
+// Rule-level debugging needs the engine's -DEBUG server, added in 3.9.0.
+const MIN_LIVE_ENGINE = "3.9.0";
+
+function compareVersions(a: string, b: string): number {
+	const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+	const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+	for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+		const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+		if (d !== 0) return d;
+	}
+	return 0;
+}
+
 class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
 	// Offered when the user picks "create a launch.json" for NLP++.
 	provideDebugConfigurations(): vscode.DebugConfiguration[] {
-		return [{
-			type: DEBUG_TYPE,
-			request: "launch",
-			name: "NLP++: replay last analyzer run",
-			analyzer: "${command:nlp.currentAnalyzerDir}",
-			stopOnEntry: true,
-		}];
+		return [
+			{
+				type: DEBUG_TYPE,
+				request: "launch",
+				name: "NLP++: replay last analyzer run",
+				mode: "replay",
+				analyzer: "${command:nlp.currentAnalyzerDir}",
+				stopOnEntry: true,
+			},
+			{
+				type: DEBUG_TYPE,
+				request: "launch",
+				name: "NLP++: debug rules (live)",
+				mode: "live",
+				analyzer: "${command:nlp.currentAnalyzerDir}",
+				input: "${command:nlp.currentTextFile}",
+				stopOnEntry: true,
+			},
+		];
 	}
 
 	// Called for every launch, including F5 with no launch.json (which arrives as
@@ -37,16 +63,77 @@ class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
 			config.type = DEBUG_TYPE;
 			config.request = "launch";
 			config.name = "NLP++: replay last analyzer run";
+			config.mode = "replay";
 			config.stopOnEntry = true;
+		}
+		// Attaching only makes sense for the live debugger -- there is no running
+		// engine to attach to in a replay.
+		if (config.request === "attach") config.mode = "live";
+		else config.mode = config.mode === "live" ? "live" : "replay";
+
+		if (config.request === "attach") {
+			if (!config.analyzer && visualText.analyzer?.isLoaded()) {
+				config.analyzer = visualText.analyzer.getAnalyzerDirectory().fsPath;
+			}
+			if (!config.port) {
+				void vscode.window.showErrorMessage(
+					"Attaching needs the port the engine was started with (nlp ... -DEBUG <port>).");
+				return undefined;
+			}
+			return config;
 		}
 
 		if (!config.analyzer) {
 			if (!visualText.analyzer || !visualText.analyzer.isLoaded()) {
 				void vscode.window.showErrorMessage(
-					"No analyzer is open. Open one in the Analyzers view, run it once, then start debugging.");
+					"No analyzer is open. Open one in the Analyzers view, then start debugging.");
 				return undefined;
 			}
 			config.analyzer = visualText.analyzer.getAnalyzerDirectory().fsPath;
+		}
+
+		if (config.mode !== "live") return config;
+
+		// ---- live mode needs an engine and an input file ----------------------
+
+		if (!config.enginePath) {
+			config.enginePath = path.join(
+				visualText.engineDirectory().fsPath,
+				process.platform === "win32" ? "nlp.exe" : "nlp");
+		}
+		if (!fs.existsSync(config.enginePath)) {
+			void vscode.window.showErrorMessage(
+				`NLP++ engine not found at ${config.enginePath}. Run the updater to install it.`);
+			return undefined;
+		}
+		if (!config.workDir) {
+			config.workDir = visualText.engineDirectory().fsPath;
+		}
+
+		// The engine must be new enough to have the -DEBUG server at all. Without
+		// this check the failure is a connection timeout, which says nothing about
+		// the actual cause.
+		const version = visualText.engineVersion;
+		if (version && compareVersions(version, MIN_LIVE_ENGINE) < 0) {
+			void vscode.window.showErrorMessage(
+				`Live rule debugging needs NLP++ engine ${MIN_LIVE_ENGINE} or later; ` +
+				`this one is ${version}. Run the updater, or use "mode": "replay".`);
+			return undefined;
+		}
+
+		if (!config.input) {
+			const active = vscode.window.activeTextEditor?.document.uri.fsPath;
+			// A text file open in the editor is the obvious thing to run; anything
+			// under the analyzer's input/ tree qualifies.
+			if (active && active.toLowerCase().includes(`${path.sep}input${path.sep}`)) {
+				config.input = active;
+			}
+		}
+		if (!config.input || !fs.existsSync(config.input)) {
+			void vscode.window.showErrorMessage(
+				"Live rule debugging needs a text file to run. Open one from the TEXT view, " +
+				"or set \"input\" in your launch configuration.");
+			return undefined;
 		}
 		return config;
 	}
@@ -55,11 +142,16 @@ class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
 class NlpDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
 	constructor(private readonly ctx: vscode.ExtensionContext) { }
 
-	createDebugAdapterDescriptor(): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+	createDebugAdapterDescriptor(
+		session: vscode.DebugSession,
+	): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
 		const adapter = this.ctx.asAbsolutePath(path.join("dist", "debugAdapter.js"));
+		// The mode has to be decided here, not in the launch request: DAP settles
+		// capabilities at `initialize`, and only the replay session can step back.
+		const args = session.configuration.mode === "live" ? [adapter, "--live"] : [adapter];
 		// Its own process, like the language server: a crash in the adapter must
 		// not take the extension host with it.
-		return new vscode.DebugAdapterExecutable("node", [adapter]);
+		return new vscode.DebugAdapterExecutable("node", args);
 	}
 }
 
@@ -68,8 +160,10 @@ export function registerDebugger(ctx: vscode.ExtensionContext): void {
 		vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPE, new NlpConfigurationProvider()),
 		vscode.debug.registerDebugAdapterDescriptorFactory(DEBUG_TYPE, new NlpDebugAdapterFactory(ctx)),
 		// Referenced by the generated launch.json above so the config stays
-		// readable rather than hard-coding an absolute path.
+		// readable rather than hard-coding absolute paths.
 		vscode.commands.registerCommand("nlp.currentAnalyzerDir", () =>
 			visualText.analyzer?.isLoaded() ? visualText.analyzer.getAnalyzerDirectory().fsPath : ""),
+		vscode.commands.registerCommand("nlp.currentTextFile", () =>
+			visualText.analyzer?.getTextPath()?.fsPath ?? ""),
 	);
 }

--- a/src/debug/debugTest.ts
+++ b/src/debug/debugTest.ts
@@ -1,0 +1,257 @@
+// Test harness for the engine debug client's protocol handling.
+//
+// Runs with plain Node (no Electron/VSCode, and no engine) over EngineClient,
+// mirroring src/trace/traceTest.ts. Compiled via tsconfig.debug.json and run by
+// `npm run test:debug`.
+//
+// What is worth pinning here is the wire handling, because it is the part that
+// fails silently: a message split across two TCP reads, two messages arriving in
+// one read, a reply correlated to the wrong request, or a waiter left hanging
+// when the engine exits. None of that shows up in a happy-path manual run, and
+// all of it would look like "the debugger froze".
+//
+// The tests use the client's attach path -- no enginePath, so nothing is
+// spawned -- against a fake server on a loopback port speaking the engine's
+// protocol. That is the same transport the launch path uses once connected, so
+// everything below exercises the real framing and correlation code.
+
+import * as net from "net";
+import { EngineClient } from "./engineClient";
+
+let passed = 0;
+let failed = 0;
+
+function check(name: string, cond: boolean, detail?: string): void {
+	if (cond) {
+		passed++;
+	} else {
+		failed++;
+		console.error(`  FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+	}
+}
+function eq<T>(name: string, actual: T, expected: T): void {
+	check(name, actual === expected, `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+interface Fake {
+	port: number;
+	/** Bytes written to whichever client is connected. */
+	write(text: string): void;
+	/** Every whole line the client has sent. */
+	received: string[];
+	close(): Promise<void>;
+}
+
+function fakeEngine(): Promise<Fake> {
+	return new Promise((resolve) => {
+		const received: string[] = [];
+		let sock: net.Socket | undefined;
+		let buf = "";
+		const srv = net.createServer((s) => {
+			sock = s;
+			s.setEncoding("utf8");
+			s.on("data", (d: string) => {
+				buf += d;
+				for (;;) {
+					const nl = buf.indexOf("\n");
+					if (nl < 0) break;
+					received.push(buf.slice(0, nl));
+					buf = buf.slice(nl + 1);
+				}
+			});
+			s.on("error", () => { /* the test may close abruptly */ });
+		});
+		srv.listen(0, "127.0.0.1", () => {
+			const addr = srv.address();
+			const port = typeof addr === "object" && addr ? addr.port : 0;
+			resolve({
+				port,
+				write: (text: string) => { try { sock?.write(text); } catch { /* closed */ } },
+				received,
+				close: () => new Promise<void>((r) => {
+					try { sock?.destroy(); } catch { /* already gone */ }
+					srv.close(() => r());
+				}),
+			});
+		});
+	});
+}
+
+async function startClient(fake: Fake): Promise<EngineClient> {
+	const client = new EngineClient();
+	await client.start({ port: fake.port }); // attach: no process is spawned
+	return client;
+}
+
+// Give the socket a moment to deliver; the client has no "flushed" signal.
+const settle = (ms = 60) => new Promise((r) => setTimeout(r, ms));
+
+const STOP = (extra = "") =>
+	`{"event":"stopped","reason":"breakpoint","pass":15,"passName":"spec/moneyAttributes.nlp",` +
+	`"line":17,"ruleOrd":3,"node":"_money","nodeStart":163,"nodeEnd":166${extra}}`;
+
+async function main(): Promise<void> {
+	// ---- framing: two messages in one chunk, one message split across chunks --
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+
+		// Both events arrive in a single TCP write.
+		fake.write(STOP() + "\n" + STOP(',"eltsMatched":2') + "\n");
+		const first = await client.nextStop();
+		const second = await client.nextStop();
+		eq("framing: first of two in one chunk", first.line, 17);
+		eq("framing: second of two in one chunk", second.eltsMatched, 2);
+
+		// One event split mid-token across two writes.
+		const whole = STOP() + "\n";
+		fake.write(whole.slice(0, 20));
+		await settle(30);
+		fake.write(whole.slice(20));
+		const third = await client.nextStop();
+		eq("framing: message split across reads", third.pass, 15);
+		eq("framing: split message keeps its name", third.passName, "spec/moneyAttributes.nlp");
+
+		// A stop that arrives before anyone asks for it must be queued, not lost.
+		fake.write(STOP() + "\n");
+		await settle();
+		const queued = await client.nextStop();
+		eq("framing: stop queued before nextStop", queued.reason, "breakpoint");
+
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- request / response correlation --------------------------------------
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+
+		// Answer out of order: the second request replies first. A client that
+		// matched replies positionally rather than by seq would cross the wires.
+		const ruleP = client.rule();
+		const nodeP = client.node();
+		await settle();
+		eq("correlation: two requests were sent", fake.received.length, 2);
+		const ruleSeq = JSON.parse(fake.received[0]).seq;
+		const nodeSeq = JSON.parse(fake.received[1]).seq;
+		eq("correlation: first request is rule", JSON.parse(fake.received[0]).command, "rule");
+		eq("correlation: second request is node", JSON.parse(fake.received[1]).command, "node");
+
+		fake.write(`{"seq":${nodeSeq},"ok":true,"node":{"name":"_money","type":"node","start":163,` +
+			`"end":166,"ustart":163,"uend":166,"passNum":14,"ruleLine":79,"fired":true,"built":true}}\n`);
+		fake.write(`{"seq":${ruleSeq},"ok":true,"rule":{"line":17,"num":1,"builds":"_money",` +
+			`"elements":[{"name":"_money","min":1,"max":1},{"name":"in","min":1,"max":1}]}}\n`);
+
+		const rule = await ruleP;
+		const node = await nodeP;
+		eq("correlation: rule reply reached the rule request", rule?.line, 17);
+		eq("correlation: rule builds", rule?.builds, "_money");
+		eq("correlation: rule element count", rule?.elements.length, 2);
+		eq("correlation: node reply reached the node request", node?.name, "_money");
+		eq("correlation: node provenance", node?.ruleLine, 79);
+
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- command shapes ------------------------------------------------------
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+
+		void client.setBreakpoints(15, [17, 23]);
+		void client.stopOnFailure(true);
+		void client.tree(2);
+		void client.resume("stepMatch");
+		await settle();
+
+		const sent = fake.received.map((l) => JSON.parse(l));
+		eq("commands: setBreakpoints command", sent[0].command, "setBreakpoints");
+		eq("commands: setBreakpoints pass", sent[0].pass, 15);
+		eq("commands: setBreakpoints lines", JSON.stringify(sent[0].lines), "[17,23]");
+		eq("commands: stopOnFailure value", sent[1].value, true);
+		eq("commands: tree depth", sent[2].depth, 2);
+		eq("commands: resume is sent verbatim", sent[3].command, "stepMatch");
+		check("commands: every message carries a distinct seq",
+			new Set(sent.map((m) => m.seq)).size === sent.length);
+
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- a malformed line must not kill the session --------------------------
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		const noise: string[] = [];
+		client.onOutput = (t) => noise.push(t);
+
+		fake.write("this is not json\n");
+		fake.write(STOP() + "\n");
+		const stop = await client.nextStop();
+		eq("malformed: the next good message still arrives", stop.line, 17);
+		check("malformed: the bad line was reported", noise.some((n) => n.includes("unparsable")));
+		check("malformed: session is still live", !client.isTerminated);
+
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- termination ---------------------------------------------------------
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		let notified = false;
+		client.onTerminated = () => { notified = true; };
+
+		// A waiter outstanding when the run ends must be rejected, not left to
+		// hang -- that is the difference between "the run finished" and "the
+		// debugger froze".
+		const waiting = client.nextStop();
+		fake.write('{"event":"terminated"}\n');
+
+		let rejected = false;
+		try {
+			await waiting;
+		} catch {
+			rejected = true;
+		}
+		check("terminated: an outstanding nextStop rejects", rejected);
+		check("terminated: onTerminated fired", notified);
+		check("terminated: isTerminated is set", client.isTerminated);
+
+		// Requests after the end resolve with a failure rather than hanging.
+		const after = await client.rule();
+		eq("terminated: later requests resolve as undefined", after, undefined);
+
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- the engine process exiting ends the session too ---------------------
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		const waiting = client.nextStop();
+		client.kill(); // stands in for the engine dying
+
+		let rejected = false;
+		try {
+			await waiting;
+		} catch {
+			rejected = true;
+		}
+		check("exit: killing the engine rejects a pending wait", rejected);
+		check("exit: isTerminated is set", client.isTerminated);
+		await fake.close();
+	}
+
+	console.log(`\ndebug client tests: ${passed} passed, ${failed} failed`);
+	if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+	console.error("harness threw:", err instanceof Error ? err.stack : String(err));
+	process.exit(1);
+});

--- a/src/debug/engineClient.ts
+++ b/src/debug/engineClient.ts
@@ -1,0 +1,272 @@
+// Client for the NLP++ engine's rule-level debug server.
+//
+// PURE MODULE: no 'vscode' import. Speaks the newline-delimited JSON protocol
+// that nlp.exe exposes when started with -DEBUG <port> (engine 3.9.0; the
+// message catalogue lives at the top of lite/nlpdebug.cpp in nlp-engine).
+//
+// Shape of the conversation: the engine runs until it hits a pause point, sends
+// an unsolicited {"event":"stopped",...}, and then blocks reading commands until
+// one of them resumes it. So this client is strictly half-duplex -- requests are
+// only answered while the engine is stopped -- and every resume command is the
+// last thing sent before waiting for the next event.
+
+import * as cp from "child_process";
+import * as net from "net";
+
+// ---- protocol types ---------------------------------------------------------
+
+export type StopReason =
+	| "entry" | "step" | "breakpoint" | "matched" | "failed" | "passStart" | "pause";
+
+// The engine's stopped event. Everything but `reason` is best-effort: a stop at
+// a pass boundary has no rule or node yet, and eltsMatched only accompanies a
+// failure.
+export interface EngineStop {
+	reason: StopReason;
+	pass: number;
+	passName: string;   // the pass's file name, as the .tree headers spell it
+	line: number;       // line of the rule in that pass file
+	ruleOrd: number;    // the rule's position in this node's candidate list
+	node?: string;
+	nodeStart?: number;
+	nodeEnd?: number;
+	eltsMatched?: number; // failures only: how far the rule got
+}
+
+export interface EngineNode {
+	name: string;
+	type: string;
+	start: number;
+	end: number;
+	ustart: number;
+	uend: number;
+	passNum: number;
+	ruleLine: number;
+	fired: boolean;
+	built: boolean;
+	children?: EngineNode[];
+	childCount?: number; // present instead of children when depth ran out
+}
+
+export interface EngineRuleElement {
+	name: string;
+	min: number;
+	max: number;
+}
+
+export interface EngineRule {
+	line: number;
+	num: number;
+	builds?: string;
+	elements: EngineRuleElement[];
+}
+
+export type ResumeCommand = "continue" | "stepRule" | "stepMatch" | "stepPass";
+
+export interface EngineClientOptions {
+	/**
+	 * Absolute path to nlp.exe / nlp. Omit to ATTACH to an engine that is
+	 * already listening on `port` -- someone having run
+	 *   nlp -ANA ... -IN ... -DEBUG 9777
+	 * by hand. Everything after connecting is identical either way.
+	 */
+	enginePath?: string;
+	analyzer?: string;    // analyzer directory (launch only)
+	input?: string;       // text file to analyze (launch only)
+	workDir?: string;     // engine working directory, -WORK (launch only)
+	port: number;
+	/** Extra args appended verbatim, e.g. ["-DEV"]. Launch only. */
+	extraArgs?: string[];
+}
+
+// ---- client -----------------------------------------------------------------
+
+export class EngineClient {
+	private proc: cp.ChildProcess | undefined;
+	private sock: net.Socket | undefined;
+	private buf = "";
+	private seq = 1;
+	private pending = new Map<number, (msg: any) => void>();
+	private stopQueue: EngineStop[] = [];
+	private stopWaiters: Array<(s: EngineStop) => void> = [];
+	private terminated = false;
+	private termWaiters: Array<() => void> = [];
+
+	/** Raw stdout/stderr from the engine, for the debug console. */
+	public onOutput: ((text: string) => void) | undefined;
+	/** Called once when the engine run ends, however it ends. */
+	public onTerminated: (() => void) | undefined;
+
+	async start(opts: EngineClientOptions): Promise<void> {
+		if (opts.enginePath) {
+			const args = [
+				"-ANA", String(opts.analyzer ?? ""),
+				"-IN", String(opts.input ?? ""),
+				"-WORK", String(opts.workDir ?? ""),
+				"-DEBUG", String(opts.port),
+				...(opts.extraArgs ?? []),
+			];
+			// Not shell-quoted: execFile-style spawn passes argv through directly,
+			// so a path with spaces needs no quoting and adding it would become
+			// part of the path.
+			this.proc = cp.spawn(opts.enginePath, args, { stdio: ["ignore", "pipe", "pipe"] });
+			this.proc.stdout?.on("data", (d) => this.onOutput?.(d.toString()));
+			this.proc.stderr?.on("data", (d) => this.onOutput?.(d.toString()));
+			this.proc.on("exit", () => this.markTerminated());
+			this.proc.on("error", (err) => {
+				this.onOutput?.(`failed to start the engine: ${err.message}\n`);
+				this.markTerminated();
+			});
+		}
+
+		this.sock = await this.connect(opts.port);
+		this.sock.setEncoding("utf8");
+		this.sock.on("data", (chunk: string) => this.consume(chunk));
+		this.sock.on("close", () => this.markTerminated());
+		this.sock.on("error", () => this.markTerminated());
+	}
+
+	// The engine binds its socket before it does anything else, but process start
+	// is not instant, so retry briefly rather than racing it.
+	private connect(port: number): Promise<net.Socket> {
+		return new Promise((resolve, reject) => {
+			const attempt = (left: number) => {
+				const s = net.connect(port, "127.0.0.1");
+				s.once("connect", () => resolve(s));
+				s.once("error", () => {
+					s.destroy();
+					if (left <= 0) {
+						reject(new Error(
+							`could not reach the engine's debug port ${port}. ` +
+							`Does this nlp build support -DEBUG? It needs engine 3.9.0 or later.`));
+						return;
+					}
+					setTimeout(() => attempt(left - 1), 200);
+				});
+			};
+			attempt(50); // ~10s, which covers a cold start with a large KB
+		});
+	}
+
+	private consume(chunk: string): void {
+		this.buf += chunk;
+		for (;;) {
+			const nl = this.buf.indexOf("\n");
+			if (nl < 0) return;
+			const line = this.buf.slice(0, nl).trim();
+			this.buf = this.buf.slice(nl + 1);
+			if (!line.length) continue;
+			let msg: any;
+			try {
+				msg = JSON.parse(line);
+			} catch {
+				// A malformed line is the engine's problem, not a reason to drop
+				// the session; surface it and keep reading.
+				this.onOutput?.(`[debug protocol: unparsable line] ${line}\n`);
+				continue;
+			}
+			if (msg.event === "stopped") this.pushStop(msg as EngineStop);
+			else if (msg.event === "terminated") this.markTerminated();
+			else if (msg.event === "output") this.onOutput?.(String(msg.text ?? ""));
+			else if (typeof msg.seq === "number") {
+				const resolve = this.pending.get(msg.seq);
+				if (resolve) {
+					this.pending.delete(msg.seq);
+					resolve(msg);
+				}
+			}
+		}
+	}
+
+	private pushStop(stop: EngineStop): void {
+		const waiter = this.stopWaiters.shift();
+		if (waiter) waiter(stop);
+		else this.stopQueue.push(stop);
+	}
+
+	private markTerminated(): void {
+		if (this.terminated) return;
+		this.terminated = true;
+		// Anything still waiting would hang forever otherwise.
+		for (const [, resolve] of this.pending) resolve({ ok: false, error: "engine exited" });
+		this.pending.clear();
+		for (const w of this.termWaiters) w();
+		this.termWaiters = [];
+		this.onTerminated?.();
+	}
+
+	get isTerminated(): boolean {
+		return this.terminated;
+	}
+
+	/** Resolves at the engine's next stop, or rejects if the run ends first. */
+	nextStop(): Promise<EngineStop> {
+		const queued = this.stopQueue.shift();
+		if (queued) return Promise.resolve(queued);
+		if (this.terminated) return Promise.reject(new Error("the engine run has ended"));
+		return new Promise((resolve, reject) => {
+			this.stopWaiters.push(resolve);
+			this.termWaiters.push(() => reject(new Error("the engine run has ended")));
+		});
+	}
+
+	private request(command: string, extra?: Record<string, unknown>): Promise<any> {
+		if (this.terminated || !this.sock) {
+			return Promise.resolve({ ok: false, error: "engine exited" });
+		}
+		const id = this.seq++;
+		const msg = JSON.stringify({ seq: id, command, ...(extra ?? {}) });
+		return new Promise((resolve) => {
+			this.pending.set(id, resolve);
+			this.sock!.write(msg + "\n");
+		});
+	}
+
+	// ---- commands -----------------------------------------------------------
+
+	/** Resume. The engine answers immediately, then runs to its next stop. */
+	resume(command: ResumeCommand): Promise<void> {
+		return this.request(command).then(() => undefined);
+	}
+
+	/** Breakpoint lines for one pass. An empty list clears that pass. */
+	setBreakpoints(pass: number, lines: number[]): Promise<void> {
+		return this.request("setBreakpoints", { pass, lines }).then(() => undefined);
+	}
+
+	stopOnFailure(value: boolean): Promise<void> {
+		return this.request("stopOnFailure", { value }).then(() => undefined);
+	}
+
+	async state(): Promise<EngineStop | undefined> {
+		const r = await this.request("state");
+		return r?.ok ? (r as EngineStop) : undefined;
+	}
+
+	async rule(): Promise<EngineRule | undefined> {
+		const r = await this.request("rule");
+		return r?.ok ? (r.rule ?? undefined) : undefined;
+	}
+
+	async node(): Promise<EngineNode | undefined> {
+		const r = await this.request("node");
+		return r?.ok ? (r.node ?? undefined) : undefined;
+	}
+
+	async tree(depth: number): Promise<EngineNode | undefined> {
+		const r = await this.request("tree", { depth });
+		return r?.ok ? (r.tree ?? undefined) : undefined;
+	}
+
+	/** Let the run finish without the debugger. */
+	async detach(): Promise<void> {
+		await this.request("detach");
+	}
+
+	/** Stop the engine outright. */
+	kill(): void {
+		try { this.sock?.destroy(); } catch { /* already gone */ }
+		try { this.proc?.kill(); } catch { /* already gone */ }
+		this.markTerminated();
+	}
+}

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -1,0 +1,594 @@
+// NLP++ live debugger: a Debug Adapter Protocol session over a running engine.
+//
+// No 'vscode' import -- this runs as its own process (see debugAdapter.ts).
+//
+// HOW THIS DIFFERS FROM THE REPLAY SESSION. nlpDebugSession.ts steps over the
+// .tree dumps of a finished run: every state is on disk, so it can move freely
+// in both directions but only ever sees pass boundaries. This one drives a live
+// nlp.exe stopped inside its rule-matching loop (engine 3.9.0, -DEBUG <port>),
+// so it can stop between individual rule attempts and see a rule that failed and
+// how far it got -- but it is forward-only, because the engine cannot un-run.
+//
+// The two are offered as `mode: "replay"` and `mode: "live"` on the same launch
+// type rather than being merged: their capabilities genuinely differ, and a
+// single session that silently lost Step Back depending on a config value would
+// be worse than two honest ones.
+//
+// STEP MAPPING. NLP++ has no call stack to step into, so the three step buttons
+// are mapped to the three things a rule debugger can actually do:
+//
+//   Step Over  (F10)       -> the next rule the engine tries
+//   Step Into  (F11)       -> the next rule that MATCHES (skips the misses)
+//   Step Out   (Shift+F11) -> the start of the next pass
+//
+// This is documented in the launch snippet and in the frame names, because it is
+// a convention rather than something a user would guess.
+
+import {
+	LoggingDebugSession, InitializedEvent, TerminatedEvent, StoppedEvent,
+	OutputEvent, Thread, StackFrame, Scope, Source, Handles,
+	Breakpoint,
+} from "@vscode/debugadapter";
+import { DebugProtocol } from "@vscode/debugprotocol";
+import * as fs from "fs";
+import * as path from "path";
+import * as net from "net";
+import {
+	EngineClient, EngineStop, EngineNode, EngineRule, ResumeCommand,
+} from "./engineClient";
+import { parseSequence, sequencePassNames } from "../trace/traceModel";
+
+const THREAD_ID = 1;
+
+export interface NlpLiveLaunchArguments extends DebugProtocol.LaunchRequestArguments {
+	analyzer: string;      // analyzer directory (holds spec/ and input/)
+	input: string;         // the text file to run
+	enginePath: string;    // nlp.exe / nlp
+	workDir: string;       // engine working directory (-WORK)
+	port?: number;         // debug port; a free one is chosen when absent
+	stopOnEntry?: boolean;
+	stopOnRuleFailure?: boolean; // also stop on every rule that fails
+	engineArgs?: string[];
+}
+
+// Attaching skips the spawn: the engine is already running under -DEBUG <port>,
+// started by hand or by a script. The analyzer directory is still needed, to map
+// breakpoint source files to the pass numbers the engine expects.
+export interface NlpLiveAttachArguments extends DebugProtocol.AttachRequestArguments {
+	analyzer: string;
+	port: number;
+	input?: string;              // only for the text preview in the tree view
+	stopOnRuleFailure?: boolean;
+}
+
+type VariableRef =
+	| { kind: "pass" }
+	| { kind: "rule" }
+	| { kind: "node" }
+	| { kind: "tree" }
+	| { kind: "engineNode"; node: EngineNode };
+
+export class NlpLiveDebugSession extends LoggingDebugSession {
+	private client = new EngineClient();
+	private variableHandles = new Handles<VariableRef>();
+	private currentStop: EngineStop | undefined;
+	private analyzer = "";
+	private inputText = "";
+	// Lowercased absolute pass-file path -> pass number, from the analyzer.seq.
+	// Lowercased because DAP hands back whatever case the editor used and Windows
+	// does not care, but the ORIGINAL casing has to be kept too -- it is what gets
+	// sent back as the stack frame's source, and a lowercased path fails to open
+	// on a case-sensitive filesystem.
+	private passOfSource = new Map<string, number>();
+	private sourceOfPass = new Map<number, string>();
+	// Breakpoints the client set before we were connected to the engine.
+	private pendingBreakpoints = new Map<number, number[]>();
+	private launched = false;
+	private attached = false;
+	private breakpointSeq = 1;
+
+	public constructor() {
+		super("nlp-live-debug.log");
+		this.setDebuggerLinesStartAt1(true);
+		this.setDebuggerColumnsStartAt1(true);
+	}
+
+	protected initializeRequest(
+		response: DebugProtocol.InitializeResponse,
+		_args: DebugProtocol.InitializeRequestArguments,
+	): void {
+		response.body = response.body ?? {};
+		response.body.supportsConfigurationDoneRequest = true;
+		response.body.supportsEvaluateForHovers = true;
+		response.body.supportsTerminateRequest = true;
+		// Deliberately absent: supportsStepBack. A live engine cannot un-run a
+		// rule, and advertising it would put a Step Back button on the toolbar
+		// that could only ever fail. The replay session is where that lives.
+		response.body.supportsRestartRequest = false;
+
+		this.sendResponse(response);
+		this.sendEvent(new InitializedEvent());
+	}
+
+	// ---- launch -------------------------------------------------------------
+
+	protected async launchRequest(
+		response: DebugProtocol.LaunchResponse,
+		args: NlpLiveLaunchArguments,
+	): Promise<void> {
+		for (const [name, value] of [["analyzer", args.analyzer], ["input", args.input],
+			["enginePath", args.enginePath]] as Array<[string, string]>) {
+			if (!value || !fs.existsSync(value)) {
+				this.sendErrorResponse(response, 2001, `${name} not found: ${value || "(not set)"}`);
+				return;
+			}
+		}
+
+		this.analyzer = args.analyzer;
+		this.loadSequence(args.analyzer);
+		try {
+			this.inputText = fs.readFileSync(args.input, "utf8");
+		} catch {
+			// Only the text preview in the variables view depends on this.
+		}
+
+		this.client.onOutput = (text) => this.sendEvent(new OutputEvent(text, "stdout"));
+		this.client.onTerminated = () => this.sendEvent(new TerminatedEvent());
+
+		const port = args.port && args.port > 0 ? args.port : await freePort();
+		try {
+			await this.client.start({
+				enginePath: args.enginePath,
+				analyzer: args.analyzer,
+				input: args.input,
+				workDir: args.workDir,
+				port,
+				extraArgs: args.engineArgs,
+			});
+		} catch (err) {
+			this.sendErrorResponse(response, 2002,
+				err instanceof Error ? err.message : String(err));
+			return;
+		}
+
+		this.emit_(`Debugging ${path.basename(args.analyzer)} on ${path.basename(args.input)} ` +
+			`(engine port ${port}).\n`);
+		this.emit_("Step Over = next rule tried, Step Into = next rule that matches, " +
+			"Step Out = next pass.\n\n");
+
+		this.launched = true;
+		if (args.stopOnRuleFailure) await this.client.stopOnFailure(true);
+		// Breakpoints the client sent during configuration, before the engine was
+		// up, are only now deliverable.
+		for (const [pass, lines] of this.pendingBreakpoints) {
+			await this.client.setBreakpoints(pass, lines);
+		}
+		this.pendingBreakpoints.clear();
+
+		this.sendResponse(response);
+
+		// The engine attaches already stopped at the first pass.
+		try {
+			this.currentStop = await this.client.nextStop();
+		} catch {
+			this.sendEvent(new TerminatedEvent());
+			return;
+		}
+		if (args.stopOnEntry) this.announceStop();
+		else await this.resume("continue");
+	}
+
+	// Attach to an engine already listening on `port`. Everything after the
+	// connection is identical to launch -- the difference is only who started the
+	// process, and therefore who gets to kill it (see disconnectRequest).
+	protected async attachRequest(
+		response: DebugProtocol.AttachResponse,
+		args: NlpLiveAttachArguments,
+	): Promise<void> {
+		if (!args.analyzer || !fs.existsSync(args.analyzer)) {
+			this.sendErrorResponse(response, 2003,
+				`analyzer not found: ${args.analyzer || "(not set)"}`);
+			return;
+		}
+		if (!args.port) {
+			this.sendErrorResponse(response, 2004,
+				"attach needs the port the engine was started with (nlp ... -DEBUG <port>).");
+			return;
+		}
+
+		this.attached = true;
+		this.loadSequence(args.analyzer);
+		if (args.input) {
+			try {
+				this.inputText = fs.readFileSync(args.input, "utf8");
+			} catch { /* only the text preview depends on this */ }
+		}
+
+		this.client.onOutput = (text) => this.sendEvent(new OutputEvent(text, "stdout"));
+		this.client.onTerminated = () => this.sendEvent(new TerminatedEvent());
+
+		try {
+			await this.client.start({ port: args.port });
+		} catch (err) {
+			this.sendErrorResponse(response, 2005,
+				err instanceof Error ? err.message : String(err));
+			return;
+		}
+
+		this.emit_(`Attached to the engine on port ${args.port}.
+`);
+		this.launched = true;
+		if (args.stopOnRuleFailure) await this.client.stopOnFailure(true);
+		for (const [pass, lines] of this.pendingBreakpoints) {
+			await this.client.setBreakpoints(pass, lines);
+		}
+		this.pendingBreakpoints.clear();
+		this.sendResponse(response);
+
+		// An engine we attached to is already sitting at a stop.
+		try {
+			this.currentStop = await this.client.nextStop();
+			this.announceStop();
+		} catch {
+			this.sendEvent(new TerminatedEvent());
+		}
+	}
+
+	// Pass number <- pass file, taken from the analyzer.seq the way the engine
+	// numbers passes. Needed because DAP breakpoints arrive as a source path and
+	// the engine wants a pass number.
+	private loadSequence(analyzerDir: string): void {
+		this.passOfSource.clear();
+		this.sourceOfPass.clear();
+		let text: string;
+		try {
+			text = fs.readFileSync(path.join(analyzerDir, "spec", "analyzer.seq"), "utf8");
+		} catch {
+			return;
+		}
+		const specDir = path.join(analyzerDir, "spec");
+		for (const [num, name] of sequencePassNames(parseSequence(text))) {
+			for (const ext of [".nlp", ".pat"]) {
+				const file = path.join(specDir, name + ext);
+				if (fs.existsSync(file)) {
+					const resolved = path.resolve(file);
+					this.passOfSource.set(resolved.toLowerCase(), num);
+					this.sourceOfPass.set(num, resolved);
+					break;
+				}
+			}
+		}
+	}
+
+	// ---- breakpoints --------------------------------------------------------
+
+	protected async setBreakPointsRequest(
+		response: DebugProtocol.SetBreakpointsResponse,
+		args: DebugProtocol.SetBreakpointsArguments,
+	): Promise<void> {
+		const sourcePath = args.source.path ?? "";
+		const lines = args.breakpoints?.map((b) => b.line) ?? [];
+		const pass = this.passOfSource.get(path.resolve(sourcePath).toLowerCase());
+
+		if (pass === undefined) {
+			// Not a pass in this analyzer's sequence, so the engine has no pass
+			// number to hang it on. Say so rather than accepting it silently.
+			response.body = {
+				breakpoints: lines.map((line) => {
+					const bp = new Breakpoint(false, line) as DebugProtocol.Breakpoint;
+					bp.id = this.breakpointSeq++;
+					bp.message = "This file is not a pass in the analyzer's sequence.";
+					return bp;
+				}),
+			};
+			this.sendResponse(response);
+			return;
+		}
+
+		if (this.launched) await this.client.setBreakpoints(pass, lines);
+		else this.pendingBreakpoints.set(pass, lines);
+
+		// Verified means "the engine has been told about it". Unlike the replay
+		// session we cannot say in advance whether the rule will fire -- that is
+		// the whole point of running live.
+		response.body = {
+			breakpoints: lines.map((line) => {
+				const bp = new Breakpoint(true, line) as DebugProtocol.Breakpoint;
+				bp.id = this.breakpointSeq++;
+				return bp;
+			}),
+		};
+		this.sendResponse(response);
+	}
+
+	// ---- execution ----------------------------------------------------------
+
+	private async resume(command: ResumeCommand): Promise<void> {
+		this.variableHandles.reset();
+		await this.client.resume(command);
+		try {
+			this.currentStop = await this.client.nextStop();
+		} catch {
+			this.sendEvent(new TerminatedEvent());
+			return;
+		}
+		this.announceStop();
+	}
+
+	private announceStop(): void {
+		const stop = this.currentStop;
+		if (!stop) return;
+		// DAP has no "a rule failed" reason, so failures arrive as a step stop
+		// and the frame name carries the distinction.
+		const reason =
+			stop.reason === "breakpoint" ? "breakpoint" :
+			stop.reason === "entry" ? "entry" : "step";
+		this.sendEvent(new StoppedEvent(reason, THREAD_ID));
+	}
+
+	protected continueRequest(response: DebugProtocol.ContinueResponse): void {
+		this.sendResponse(response);
+		void this.resume("continue");
+	}
+
+	protected nextRequest(response: DebugProtocol.NextResponse): void {
+		this.sendResponse(response);
+		void this.resume("stepRule");
+	}
+
+	protected stepInRequest(response: DebugProtocol.StepInResponse): void {
+		this.sendResponse(response);
+		void this.resume("stepMatch");
+	}
+
+	protected stepOutRequest(response: DebugProtocol.StepOutResponse): void {
+		this.sendResponse(response);
+		void this.resume("stepPass");
+	}
+
+	protected disconnectRequest(
+		response: DebugProtocol.DisconnectResponse,
+		args: DebugProtocol.DisconnectArguments,
+	): void {
+		// Let the analyzer finish on its own if the user just detaches; kill it
+		// only when they actually asked to stop it. An engine we attached to was
+		// not ours to start, so it is not ours to kill either unless asked
+		// explicitly -- the default there is to detach and leave it running.
+		const kill = args.terminateDebuggee ?? !this.attached;
+		if (kill) this.client.kill();
+		else void this.client.detach();
+		this.sendResponse(response);
+	}
+
+	protected terminateRequest(response: DebugProtocol.TerminateResponse): void {
+		this.client.kill();
+		this.sendResponse(response);
+		this.sendEvent(new TerminatedEvent());
+	}
+
+	private emit_(text: string): void {
+		this.sendEvent(new OutputEvent(text, "stdout"));
+	}
+
+	// ---- stack --------------------------------------------------------------
+
+	protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+		response.body = { threads: [new Thread(THREAD_ID, "NLP++ analysis")] };
+		this.sendResponse(response);
+	}
+
+	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse): void {
+		const stop = this.currentStop;
+		if (!stop) {
+			response.body = { stackFrames: [], totalFrames: 0 };
+			this.sendResponse(response);
+			return;
+		}
+
+		const sourceFile = this.sourceForPass(stop.pass);
+		const source = sourceFile ? new Source(path.basename(sourceFile), sourceFile) : undefined;
+		const frames: DebugProtocol.StackFrame[] = [];
+
+		// Frame 0: the rule attempt, when we are inside one. The name carries what
+		// DAP's stop reason cannot: whether this rule matched or failed, and for a
+		// failure how many elements matched before it gave up -- which is the
+		// thing that says WHERE the rule stopped agreeing with the text.
+		if (stop.line > 0) {
+			let label = `rule at line ${stop.line}`;
+			if (stop.reason === "matched") label += " — matched";
+			else if (stop.reason === "failed") {
+				label += stop.eltsMatched !== undefined
+					? ` — failed after ${stop.eltsMatched} element${stop.eltsMatched === 1 ? "" : "s"}`
+					: " — failed";
+			}
+			if (stop.node) label += `  [${stop.node}]`;
+			frames.push(new StackFrame(1, label, source, stop.line));
+		}
+
+		// Frame 1: the pass. Passes run in sequence rather than calling each
+		// other, so this is the bottom of a genuinely two-deep stack.
+		const passFrame = new StackFrame(2, `Pass ${stop.pass}: ${this.passLabel(stop)}`,
+			source, stop.line > 0 ? stop.line : 1);
+		if (!source) passFrame.presentationHint = "subtle";
+		frames.push(passFrame);
+
+		response.body = { stackFrames: frames, totalFrames: frames.length };
+		this.sendResponse(response);
+	}
+
+	private passLabel(stop: EngineStop): string {
+		// The engine sends the pass's file name; the pass is known by its stem.
+		if (!stop.passName) return `pass ${stop.pass}`;
+		return path.basename(stop.passName).replace(/\.(nlp|pat)$/i, "");
+	}
+
+	private sourceForPass(pass: number): string | undefined {
+		return this.sourceOfPass.get(pass);
+	}
+
+	// ---- variables ----------------------------------------------------------
+
+	protected scopesRequest(response: DebugProtocol.ScopesResponse): void {
+		response.body = {
+			scopes: [
+				new Scope("Rule", this.variableHandles.create({ kind: "rule" }), false),
+				new Scope("Pass", this.variableHandles.create({ kind: "pass" }), false),
+				new Scope("Current node", this.variableHandles.create({ kind: "node" }), false),
+				new Scope("Parse tree", this.variableHandles.create({ kind: "tree" }), true),
+			],
+		};
+		this.sendResponse(response);
+	}
+
+	protected async variablesRequest(
+		response: DebugProtocol.VariablesResponse,
+		args: DebugProtocol.VariablesArguments,
+	): Promise<void> {
+		const ref = this.variableHandles.get(args.variablesReference);
+		let variables: DebugProtocol.Variable[] = [];
+
+		if (ref && !this.client.isTerminated) {
+			switch (ref.kind) {
+				case "pass":
+					variables = this.passVariables();
+					break;
+				case "rule":
+					variables = this.ruleVariables(await this.client.rule());
+					break;
+				case "node": {
+					const node = await this.client.node();
+					variables = node ? this.nodeChildren(node) : [];
+					break;
+				}
+				case "tree": {
+					// One level at a time: the tree can be tens of thousands of
+					// nodes, and the client only expands what it displays.
+					const tree = await this.client.tree(1);
+					variables = tree ? [this.nodeVariable(tree)] : [];
+					break;
+				}
+				case "engineNode":
+					variables = this.nodeChildren(ref.node);
+					break;
+			}
+		}
+
+		response.body = { variables };
+		this.sendResponse(response);
+	}
+
+	private plain(name: string, value: string): DebugProtocol.Variable {
+		return { name, value, variablesReference: 0 };
+	}
+
+	private passVariables(): DebugProtocol.Variable[] {
+		const stop = this.currentStop;
+		if (!stop) return [];
+		const out = [
+			this.plain("pass number", String(stop.pass)),
+			this.plain("name", this.passLabel(stop)),
+			this.plain("stopped because", stop.reason),
+		];
+		if (stop.ruleOrd > 0) {
+			out.push(this.plain("rule # at this node", String(stop.ruleOrd)));
+		}
+		return out;
+	}
+
+	private ruleVariables(rule: EngineRule | undefined): DebugProtocol.Variable[] {
+		const stop = this.currentStop;
+		if (!rule) return [this.plain("(no rule)", "stopped at a pass boundary")];
+		const out = [
+			this.plain("line", String(rule.line)),
+			this.plain("builds", rule.builds ?? "(nothing)"),
+			this.plain("elements", rule.elements.map((e) => e.name).join(" ") || "(none)"),
+		];
+		// Pair the element list with how far the match got, so the two read
+		// together: "3 elements, failed after 2" points at element 3.
+		if (stop?.reason === "failed" && stop.eltsMatched !== undefined) {
+			out.push(this.plain("matched before failing",
+				`${stop.eltsMatched} of ${rule.elements.length}`));
+			const next = rule.elements[stop.eltsMatched];
+			if (next) out.push(this.plain("failed on element", next.name));
+		}
+		return out;
+	}
+
+	private nodeVariable(node: EngineNode): DebugProtocol.Variable {
+		const expandable = (node.children && node.children.length > 0) || (node.childCount ?? 0) > 0;
+		return {
+			name: node.name,
+			value: this.describeNode(node),
+			variablesReference: expandable
+				? this.variableHandles.create({ kind: "engineNode", node })
+				: 0,
+			namedVariables: node.children?.length ?? node.childCount ?? 0,
+		};
+	}
+
+	private describeNode(node: EngineNode): string {
+		const text = this.spanText(node);
+		const flags: string[] = [];
+		if (node.built) flags.push("built");
+		else if (node.fired) flags.push("fired");
+		const origin = node.passNum > 0 ? ` — pass ${node.passNum} line ${node.ruleLine}` : "";
+		const suffix = flags.length ? ` [${flags.join(", ")}]` : "";
+		return `${text} (${node.type})${origin}${suffix}`;
+	}
+
+	private spanText(node: EngineNode): string {
+		if (!this.inputText.length || node.ustart < 0 || node.uend < node.ustart) return "";
+		const raw = this.inputText.slice(node.ustart, node.uend + 1).replace(/\s+/g, " ").trim();
+		if (!raw.length) return '""';
+		return JSON.stringify(raw.length > 60 ? raw.slice(0, 57) + "..." : raw);
+	}
+
+	private nodeChildren(node: EngineNode): DebugProtocol.Variable[] {
+		if (node.children && node.children.length) {
+			return node.children.map((c) => this.nodeVariable(c));
+		}
+		if ((node.childCount ?? 0) > 0) {
+			// The engine trimmed the walk at this depth. Rather than pretend the
+			// node is a leaf, say what is there and how to get it.
+			return [this.plain(`(${node.childCount} children)`,
+				"expand the Parse tree scope to walk deeper")];
+		}
+		return [];
+	}
+
+	// ---- evaluate -----------------------------------------------------------
+
+	protected async evaluateRequest(
+		response: DebugProtocol.EvaluateResponse,
+		args: DebugProtocol.EvaluateArguments,
+	): Promise<void> {
+		const expr = args.expression.trim();
+		// The engine has no expression evaluator, so rather than invent one that
+		// half-works, only the three things it can actually answer are accepted.
+		if (expr === "rule" || expr === "node" || expr === "tree") {
+			const ref = this.variableHandles.create({ kind: expr as "rule" | "node" | "tree" });
+			response.body = { result: `<${expr}>`, variablesReference: ref };
+			this.sendResponse(response);
+			return;
+		}
+		this.sendErrorResponse(response, 2010,
+			`The engine cannot evaluate expressions. Try "rule", "node" or "tree", ` +
+			`or read the Variables pane.`);
+	}
+}
+
+// Ask the OS for a free port by binding one and letting it go. There is a race
+// between releasing it and the engine binding it, but it is the standard trick
+// and the window is microseconds; an explicit `port` in the launch config avoids
+// it entirely.
+function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const srv = net.createServer();
+		srv.once("error", reject);
+		srv.listen(0, "127.0.0.1", () => {
+			const addr = srv.address();
+			const port = typeof addr === "object" && addr ? addr.port : 0;
+			srv.close(() => (port ? resolve(port) : reject(new Error("no free port"))));
+		});
+	});
+}

--- a/tsconfig.debug.json
+++ b/tsconfig.debug.json
@@ -1,0 +1,26 @@
+// Standalone build for the debug adapters + their test harness.
+// Mirrors tsconfig.trace.json: emits to out-debug/ (gitignored, not shipped) so
+// the DAP sessions and the engine client can be exercised with plain Node.
+// Run via: npm run test:debug
+//
+// src/debug is free of any 'vscode' import -- both sessions run as their own
+// process -- and building it here under a Node-only config is what proves that
+// stays true.
+{
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "out-debug",
+		"module": "node16",
+		"moduleResolution": "node16",
+		"target": "es2019",
+		"lib": ["es2019"],
+		"strict": true,
+		"noImplicitAny": false,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"types": ["node"],
+		"sourceMap": false
+	},
+	"include": ["src/debug/**/*.ts", "src/trace/**/*.ts"],
+	"exclude": ["src/debug/debugConfig.ts", "src/trace/traceTest.ts"]
+}


### PR DESCRIPTION
The replay debugger from 3.13.0 steps over the `.tree` dumps a finished run left behind: every state is on disk, so it moves in both directions, but it only ever sees pass boundaries. Engine 3.9.0 ([nlp-engine#727](https://github.com/VisualText/nlp-engine/pull/727)) added a debug server that can stop between individual rule attempts. This wires the editor to it.

```jsonc
{ "mode": "replay" }  // step over the last run's per-pass trees (any engine)
{ "mode": "live"   }  // drive a running engine, rule by rule (engine 3.9.0+)
```

Both are the same launch type. They are **not** merged into one session because their capabilities genuinely differ — only replay can step backward — and a session that silently lost Step Back depending on a config value would be worse than two honest ones. The mode reaches the adapter as an argv flag rather than being read from the launch config, because DAP settles capabilities at `initialize`, before any launch arguments arrive.

## What live mode shows

Which rule is being tried at which node, whether it matched, and when it did not, **how many of its elements matched before it gave up** — the number that says which element stopped agreeing with the text. The Rule scope pairs that count with the element list, so "3 elements, failed after 2" points at element 3.

Step mapping, since NLP++ has no call stack to step into:

| Button | Goes to |
| --- | --- |
| Step Over (F10) | the next rule the engine tries |
| Step Into (F11) | the next rule that **matches**, skipping the misses |
| Step Out (⇧F11) | the start of the next pass |

Breakpoints on rule lines are translated to the pass numbers the engine wants, using the same `analyzer.seq` numbering the `.tree` dumps use. A breakpoint in a file that is not a pass of this analyzer is reported unverified with the reason rather than silently accepted. `stopOnRuleFailure` additionally stops on every rule that fails — most rules fail at most nodes, so it is for tracking down one rule, not for browsing.

## Attach

`request: "attach"` connects to an engine already running under `nlp -ANA ... -DEBUG <port>`, started by hand or by a script. Disconnecting from an attached engine leaves it running by default — it was not ours to start, so it is not ours to kill.

## Layout

| File | vscode? | DAP? |
| --- | --- | --- |
| `src/debug/engineClient.ts` | no | no — just the wire protocol |
| `src/debug/nlpLiveDebugSession.ts` | no | yes |
| `src/debug/debugConfig.ts` | **yes** — the only one | no |

## Testing

A new suite (`npm run test:debug`, 29 assertions) covers the transport, which is the part that fails silently: a message split across two TCP reads, two messages in one read, a reply correlated to the wrong request, and a waiter left hanging when the engine exits. All of those would look like *"the debugger froze"*, and none show up in a happy-path manual run. The tests use the client's attach path against a fake server, so they need no engine.

Driven end to end over real DAP against a real `nlp.exe` on the corporate analyzer — the reported rules match the source exactly:

| Debugger reported | Source |
| --- | --- |
| `join.nlp:92` builds `_alphaNum` from `_xALPHA _xNUM` | matches |
| `moneyAttributes.nlp:35` builds `_money` from `_det total _prep _money` | matches |

Two bugs found while testing: the stack frame's source path came back **lowercased** (would fail to open on a case-sensitive filesystem), and the session's `stop` field shadowed `DebugSession.stop()`.

| Suite | Result |
| --- | --- |
| integration (real VSCode host) | 27 / 27 |
| trace | 141 / 141 |
| language | 79 / 79 |
| treeview | 63 / 63 |
| debug client (new) | 29 / 29 |
| lint + typecheck | clean |

If the installed engine predates 3.9.0 the extension says so rather than failing to connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
