### PR TITLE
Show NLP++ variables in the live debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.14.1
+The live debugger shows NLP++ variables.
+
+- **Variables are visible while stepping.** A new Variables pane group shows `L()` locals, `S()` suggested values, `X()` context values and `N()` matched elements, with `G()` globals in their own scope. The `N()` rows are labelled by the ordinal you would actually write -- `N(1)`, `N(2)` -- so the row name is the expression, not a description of it.
+- **Node attributes appear at last.** The `("name" value)` pairs that `.tree` dumps have always printed were missing from the live debugger entirely, so it showed less about a node than the post-mortem file did. Every node in the tree now carries them, named on the row itself so a node holding values is visible without opening each one to look.
+- **The parse tree can be walked.** It was fetched one level deep, so every child row expanded to "(N children)" and there was no way to go further -- which is also why node attributes were unreachable even once the engine sent them. Several levels now arrive at each stop; `treeDepth` in the launch configuration bounds the cost.
+- An element that matched a *range* of nodes says so rather than showing one node and implying `N()` can address it. That mirrors the engine, whose own `N(n,"x")` refuses those.
+- Needs NLP++ engine 3.10.0 or later for the variable commands; everything from 3.14.0 still works against 3.9.0.
+
 ### 3.14.0
 Rules can be debugged as they run.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.14.0",
+            "version": "3.14.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,
@@ -3560,6 +3560,11 @@
                                 "type": "boolean",
                                 "description": "Stop at the first pass instead of running to the first breakpoint.",
                                 "default": true
+                            },
+                            "treeDepth": {
+                                "type": "number",
+                                "description": "live mode: how many levels of parse tree to fetch at each stop. This is also how deep the Variables pane can be expanded, since a row carries the subtree it arrived with. Deeper costs a bigger reply at every stop.",
+                                "default": 5
                             }
                         }
                     },

--- a/src/debug/debugTest.ts
+++ b/src/debug/debugTest.ts
@@ -198,6 +198,80 @@ async function main(): Promise<void> {
 		await fake.close();
 	}
 
+	// ---- variables -----------------------------------------------------------
+	// Every NLP++ variable kind arrives as the same {name,value} shape, because
+	// the engine stores them all as one Dlist<Ipair>. What is worth pinning is
+	// that each command reads its OWN field out of the reply -- a copy-paste slip
+	// there returns an empty list rather than an error, and the pane just looks
+	// like the analyzer has no variables.
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+
+		const gP = client.globals();
+		const lP = client.locals();
+		const sP = client.suggested();
+		const xP = client.context();
+		const cP = client.collect();
+		await settle();
+
+		const sent = fake.received.map((l) => JSON.parse(l));
+		eq("vars: five commands were sent", sent.length, 5);
+		eq("vars: command names", sent.map((m) => m.command).join(","),
+			"globals,locals,suggested,context,collect");
+
+		const reply = (i: number, body: string) =>
+			fake.write(`{"seq":${sent[i].seq},"ok":true,${body}}
+`);
+		reply(0, '"globals":[{"name":"corporate","value":"concept:\\"corporate\\""}]');
+		reply(1, '"locals":[{"name":"n","value":"3"}]');
+		reply(2, '"suggested":[{"name":"value","value":"130"}]');
+		reply(3, '"context":[]');
+		reply(4, '"collect":[' +
+			'{"ord":1,"single":true,"node":{"name":"No","type":"alpha","start":24,"end":25,' +
+			'"ustart":24,"uend":25,"passNum":0,"ruleLine":0,"fired":false,"built":false,"attributes":[]}},' +
+			'{"ord":2,"single":false,"spanEnd":40,"node":{"name":"_x","type":"node","start":27,"end":30,' +
+			'"ustart":27,"uend":30,"passNum":4,"ruleLine":9,"fired":true,"built":true,' +
+			'"attributes":[{"name":"number","value":"1"}]}}]');
+
+		const globals = await gP;
+		eq("vars: globals count", globals.length, 1);
+		eq("vars: global name", globals[0].name, "corporate");
+		eq("vars: global value keeps its quotes", globals[0].value, 'concept:"corporate"');
+		eq("vars: locals", (await lP)[0]?.value, "3");
+		eq("vars: suggested", (await sP)[0]?.name, "value");
+		eq("vars: context may be empty", (await xP).length, 0);
+
+		const coll = await cP;
+		eq("collect: element count", coll.length, 2);
+		eq("collect: first ordinal", coll[0].ord, 1);
+		check("collect: a single-node element is marked single", coll[0].single === true);
+		eq("collect: node name", coll[0].node.name, "No");
+		// A range element is what N(n,"x") cannot address; the flag is how the
+		// client knows to say so instead of showing one node.
+		check("collect: a range element is marked not single", coll[1].single === false);
+		eq("collect: range reports where it reached", coll[1].spanEnd, 40);
+		eq("collect: node attributes come through", coll[1].node.attributes?.[0]?.name, "number");
+
+		client.kill();
+		await fake.close();
+	}
+
+	// A reply that is missing its field, or malformed, yields an empty list
+	// rather than throwing -- a stopped engine is still usable.
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		const p = client.globals();
+		await settle();
+		const seqNo = JSON.parse(fake.received[0]).seq;
+		fake.write(`{"seq":${seqNo},"ok":true}
+`); // no "globals" field
+		eq("vars: a reply with no payload is an empty list", (await p).length, 0);
+		client.kill();
+		await fake.close();
+	}
+
 	// ---- termination ---------------------------------------------------------
 	{
 		const fake = await fakeEngine();

--- a/src/debug/engineClient.ts
+++ b/src/debug/engineClient.ts
@@ -33,6 +33,26 @@ export interface EngineStop {
 	eltsMatched?: number; // failures only: how far the rule got
 }
 
+// One NLP++ variable. The engine renders values with the same call the .tree
+// dumps use, so a value reads identically in the debugger and in a dump.
+export interface EngineVar {
+	name: string;
+	value: string;
+}
+
+// A rule element that matched, in rule order -- what N(n,"x") indexes.
+export interface EngineCollectElement {
+	ord: number;
+	/**
+	 * False when the element matched a RANGE of nodes (a wildcard, say). The
+	 * engine's own N(n,"x") lookup refuses those, so the debugger says so
+	 * rather than showing one node and implying it is addressable.
+	 */
+	single: boolean;
+	node: EngineNode;
+	spanEnd?: number; // ranges only: where the element reached
+}
+
 export interface EngineNode {
 	name: string;
 	type: string;
@@ -46,6 +66,7 @@ export interface EngineNode {
 	built: boolean;
 	children?: EngineNode[];
 	childCount?: number; // present instead of children when depth ran out
+	attributes?: EngineVar[]; // the node's own ("name" value) pairs
 }
 
 export interface EngineRuleElement {
@@ -256,6 +277,31 @@ export class EngineClient {
 	async tree(depth: number): Promise<EngineNode | undefined> {
 		const r = await this.request("tree", { depth });
 		return r?.ok ? (r.tree ?? undefined) : undefined;
+	}
+
+	// ---- variables ----------------------------------------------------------
+	//
+	// One command per kind rather than one bundle, so expanding a single scope
+	// does not pay for the rest -- globals in particular can be numerous.
+
+	private async vars(command: string, field: string): Promise<EngineVar[]> {
+		const r = await this.request(command);
+		return r?.ok && Array.isArray(r[field]) ? (r[field] as EngineVar[]) : [];
+	}
+
+	/** G("x") */
+	globals(): Promise<EngineVar[]> { return this.vars("globals", "globals"); }
+	/** L("x") */
+	locals(): Promise<EngineVar[]> { return this.vars("locals", "locals"); }
+	/** S("x"), on the node this rule suggests */
+	suggested(): Promise<EngineVar[]> { return this.vars("suggested", "suggested"); }
+	/** X("x"), on the pass's select node */
+	context(): Promise<EngineVar[]> { return this.vars("context", "context"); }
+
+	/** The rule elements matched so far, in order: what N(n,"x") indexes. */
+	async collect(): Promise<EngineCollectElement[]> {
+		const r = await this.request("collect");
+		return r?.ok && Array.isArray(r.collect) ? (r.collect as EngineCollectElement[]) : [];
 	}
 
 	/** Let the run finish without the debugger. */

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -34,7 +34,8 @@ import * as fs from "fs";
 import * as path from "path";
 import * as net from "net";
 import {
-	EngineClient, EngineStop, EngineNode, EngineRule, ResumeCommand,
+	EngineClient, EngineStop, EngineNode, EngineRule, EngineVar,
+	EngineCollectElement, ResumeCommand,
 } from "./engineClient";
 import { parseSequence, sequencePassNames } from "../trace/traceModel";
 
@@ -49,6 +50,14 @@ export interface NlpLiveLaunchArguments extends DebugProtocol.LaunchRequestArgum
 	stopOnEntry?: boolean;
 	stopOnRuleFailure?: boolean; // also stop on every rule that fails
 	engineArgs?: string[];
+	/**
+	 * How many levels of parse tree to fetch at each stop. The engine walks the
+	 * tree in one request, and a handle handed to the client holds the subtree it
+	 * came with -- so this is also how deep the Variables pane can be expanded.
+	 * Deeper costs a bigger reply at every stop; 5 covers the usual
+	 * _ROOT / paragraph / sentence / phrase / token shape.
+	 */
+	treeDepth?: number;
 }
 
 // Attaching skips the spawn: the engine is already running under -DEBUG <port>,
@@ -66,7 +75,14 @@ type VariableRef =
 	| { kind: "rule" }
 	| { kind: "node" }
 	| { kind: "tree" }
-	| { kind: "engineNode"; node: EngineNode };
+	| { kind: "vars" }        // the L/S/X group
+	| { kind: "locals" }
+	| { kind: "suggested" }
+	| { kind: "context" }
+	| { kind: "globals" }
+	| { kind: "collect" }     // the N() matched elements
+	| { kind: "engineNode"; node: EngineNode }
+	| { kind: "attributes"; node: EngineNode };
 
 export class NlpLiveDebugSession extends LoggingDebugSession {
 	private client = new EngineClient();
@@ -85,6 +101,7 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	private pendingBreakpoints = new Map<number, number[]>();
 	private launched = false;
 	private attached = false;
+	private treeDepth = 5;
 	private breakpointSeq = 1;
 
 	public constructor() {
@@ -125,6 +142,7 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		}
 
 		this.analyzer = args.analyzer;
+		if (args.treeDepth && args.treeDepth > 0) this.treeDepth = args.treeDepth;
 		this.loadSequence(args.analyzer);
 		try {
 			this.inputText = fs.readFileSync(args.input, "utf8");
@@ -429,12 +447,17 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	// ---- variables ----------------------------------------------------------
 
 	protected scopesRequest(response: DebugProtocol.ScopesResponse): void {
+		// "expensive" tells the client not to fetch until the user expands it.
+		// Globals and the parse tree are the two that can be large, and both are
+		// a round trip to a stopped engine.
 		response.body = {
 			scopes: [
 				new Scope("Rule", this.variableHandles.create({ kind: "rule" }), false),
-				new Scope("Pass", this.variableHandles.create({ kind: "pass" }), false),
+				new Scope("Variables", this.variableHandles.create({ kind: "vars" }), false),
+				new Scope("Globals G()", this.variableHandles.create({ kind: "globals" }), true),
 				new Scope("Current node", this.variableHandles.create({ kind: "node" }), false),
 				new Scope("Parse tree", this.variableHandles.create({ kind: "tree" }), true),
+				new Scope("Pass", this.variableHandles.create({ kind: "pass" }), false),
 			],
 		};
 		this.sendResponse(response);
@@ -461,14 +484,48 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 					break;
 				}
 				case "tree": {
-					// One level at a time: the tree can be tens of thousands of
-					// nodes, and the client only expands what it displays.
-					const tree = await this.client.tree(1);
+					// Fetched several levels deep in one go, because a handle
+					// carries the subtree it arrived with: at depth 1 every child
+					// row expanded to "(N children)" and there was no way to go
+					// further, which also meant node attributes were never
+					// reachable. treeDepth bounds the cost.
+					const tree = await this.client.tree(this.treeDepth);
 					variables = tree ? [this.nodeVariable(tree)] : [];
 					break;
 				}
 				case "engineNode":
 					variables = this.nodeChildren(ref.node);
+					break;
+				case "attributes":
+					variables = (ref.node.attributes ?? []).map((a) => this.plain(a.name, a.value));
+					break;
+
+				// ---- variables ------------------------------------------------
+				case "vars":
+					// L/S/X grouped under one scope, plus the matched elements.
+					// Each row is a separate round trip only when expanded, so an
+					// analyzer with no locals costs nothing to display.
+					variables = [
+						this.group("L() locals", { kind: "locals" }),
+						this.group("S() suggested", { kind: "suggested" }),
+						this.group("X() context", { kind: "context" }),
+						this.group("N() matched elements", { kind: "collect" }),
+					];
+					break;
+				case "locals":
+					variables = this.varRows(await this.client.locals());
+					break;
+				case "suggested":
+					variables = this.varRows(await this.client.suggested());
+					break;
+				case "context":
+					variables = this.varRows(await this.client.context());
+					break;
+				case "globals":
+					variables = this.varRows(await this.client.globals());
+					break;
+				case "collect":
+					variables = this.collectRows(await this.client.collect());
 					break;
 			}
 		}
@@ -479,6 +536,40 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 
 	private plain(name: string, value: string): DebugProtocol.Variable {
 		return { name, value, variablesReference: 0 };
+	}
+
+	// An expandable row that fetches its contents only when opened.
+	private group(name: string, ref: VariableRef): DebugProtocol.Variable {
+		return { name, value: "", variablesReference: this.variableHandles.create(ref) };
+	}
+
+	private varRows(vars: EngineVar[]): DebugProtocol.Variable[] {
+		if (!vars.length) return [this.plain("(none)", "")];
+		return vars.map((v) => this.plain(v.name, v.value));
+	}
+
+	// The rule elements matched so far. Labelled by the ordinal N() uses, so the
+	// row name is the expression an author would write.
+	private collectRows(elements: EngineCollectElement[]): DebugProtocol.Variable[] {
+		if (!elements.length) return [this.plain("(nothing matched yet)", "")];
+		return elements.map((e) => {
+			const label = `N(${e.ord})`;
+			if (!e.single) {
+				// The engine's own N(n,"x") refuses a multi-node element, so say
+				// that rather than showing one node and implying it is addressable.
+				const span = e.spanEnd !== undefined ? ` through ${e.spanEnd}` : "";
+				return {
+					name: label,
+					value: `${e.node.name} … a range of nodes${span} — N() cannot address it`,
+					variablesReference: this.variableHandles.create({ kind: "engineNode", node: e.node }),
+				};
+			}
+			return {
+				name: label,
+				value: this.describeNode(e.node),
+				variablesReference: this.variableHandles.create({ kind: "engineNode", node: e.node }),
+			};
+		});
 	}
 
 	private passVariables(): DebugProtocol.Variable[] {
@@ -515,7 +606,9 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	}
 
 	private nodeVariable(node: EngineNode): DebugProtocol.Variable {
-		const expandable = (node.children && node.children.length > 0) || (node.childCount ?? 0) > 0;
+		const expandable = (node.children && node.children.length > 0)
+			|| (node.childCount ?? 0) > 0
+			|| (node.attributes?.length ?? 0) > 0;
 		return {
 			name: node.name,
 			value: this.describeNode(node),
@@ -533,7 +626,11 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		else if (node.fired) flags.push("fired");
 		const origin = node.passNum > 0 ? ` — pass ${node.passNum} line ${node.ruleLine}` : "";
 		const suffix = flags.length ? ` [${flags.join(", ")}]` : "";
-		return `${text} (${node.type})${origin}${suffix}`;
+		// Name the attributes on the row itself so a node carrying values is
+		// visible without expanding every node in the tree to find it.
+		const attrs = node.attributes && node.attributes.length
+			? `  {${node.attributes.map((a) => a.name).join(", ")}}` : "";
+		return `${text} (${node.type})${origin}${suffix}${attrs}`;
 	}
 
 	private spanText(node: EngineNode): string {
@@ -544,16 +641,25 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	}
 
 	private nodeChildren(node: EngineNode): DebugProtocol.Variable[] {
-		if (node.children && node.children.length) {
-			return node.children.map((c) => this.nodeVariable(c));
+		const out: DebugProtocol.Variable[] = [];
+		// A node's attributes come first: they are what N("x") and X("x") read,
+		// and usually the reason to open a node at all.
+		if (node.attributes && node.attributes.length) {
+			out.push({
+				name: "(attributes)",
+				value: node.attributes.map((a) => a.name).join(", "),
+				variablesReference: this.variableHandles.create({ kind: "attributes", node }),
+			});
 		}
-		if ((node.childCount ?? 0) > 0) {
+		if (node.children && node.children.length) {
+			for (const c of node.children) out.push(this.nodeVariable(c));
+		} else if ((node.childCount ?? 0) > 0) {
 			// The engine trimmed the walk at this depth. Rather than pretend the
 			// node is a leaf, say what is there and how to get it.
-			return [this.plain(`(${node.childCount} children)`,
-				"expand the Parse tree scope to walk deeper")];
+			out.push(this.plain(`(${node.childCount} children)`,
+				"expand the Parse tree scope to walk deeper"));
 		}
-		return [];
+		return out;
 	}
 
 	// ---- evaluate -----------------------------------------------------------


### PR DESCRIPTION
Pairs with [nlp-engine#729](https://github.com/VisualText/nlp-engine/pull/729).

The live debugger could say which rule was being tried and whether it matched, but nothing about the values involved — and it could not even show a node's own attributes, so it displayed *less* about a node than the `.tree` dump does.

## Scopes

| Scope | Shows |
| --- | --- |
| Rule | line / builds / elements / how far a failure got |
| Variables | `L()` locals, `S()` suggested, `X()` context, `N()` matched elements |
| Globals `G()` | marked *expensive*, so it is only fetched when opened |
| Current node | now including its attributes |
| Parse tree | every node carrying its attributes |
| Pass | pass number, name, why we stopped |

`N()` rows are labelled by the ordinal an author would actually write — `N(1)`, `N(2)` — so the row name *is* the expression rather than a description of it. An element that matched a **range** of nodes says so instead of showing one node and implying `N()` can address it, mirroring the engine, whose own `N(n,"x")` refuses those.

## The tree could not be walked

It was fetched one level deep, so every child row expanded to "(N children)" and there was no way to go further: a handle carries the subtree it arrived with, and at depth 1 there was nothing under a child to hand back.

That is also why node attributes were unreachable even once the engine started sending them — the walk never got past `_ROOT`'s immediate children, which carry none. The tree now arrives several levels deep, bounded by a `treeDepth` launch option (default 5).

## Testing

16 new client assertions (45 total) cover the new commands: that each reads its **own** field out of the reply — a copy-paste slip there returns an empty list rather than an error, and the pane just looks like the analyzer has no variables — that a range element is flagged, and that a reply missing its payload yields an empty list rather than throwing.

Verified end to end over real DAP against a real engine on the corporate analyzer:

| Checked | Result |
| --- | --- |
| `N(1..4)` at `join.nlp:117` (`_rank`) | `"No"` / `"."` / whitespace / `"1"` — the rule's four elements |
| `Globals G()` | the analyzer's own `concept:` values |
| Tree attributes | `name="sentence1", object=concept:"sentence1"` — the same pair `ana005.tree` prints |

| Suite | Result |
| --- | --- |
| integration (real VSCode host) | 27 / 27 |
| debug client | 45 / 45 |
| trace | 141 / 141 |
| language | 79 / 79 |
| treeview | 63 / 63 |
| lint + typecheck | clean |

Needs engine 3.10.0 for the variable commands; everything from 3.14.0 still works against 3.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
