### PR TITLE
Say when the engine is too old for the variable commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.14.2
+An older engine says so instead of showing an empty Variables pane.
+
+- **The Variables pane now explains itself when the engine is too old.** The variable commands arrived in NLP++ engine 3.10.0. Against 3.9.0 they are simply unknown, and every group came back empty -- which looks exactly like an analyzer that happens to have no variables set, and sends you looking for the wrong problem. The pane now says which engine version it needs.
+- The extension asks the engine rather than comparing version strings. A version check is a second thing to keep in step, and getting it wrong produces the very silence it was meant to prevent; a command the engine rejects cannot be misread.
+- An ordinary failure is still an empty list. "The engine does not know this question" and "nothing is set right now" are different answers and no longer look alike.
+
 ### 3.14.1
 The live debugger shows NLP++ variables.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.14.1",
+    "version": "3.14.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.14.1",
+            "version": "3.14.2",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.14.1",
+    "version": "3.14.2",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/debugTest.ts
+++ b/src/debug/debugTest.ts
@@ -234,15 +234,15 @@ async function main(): Promise<void> {
 			'"ustart":27,"uend":30,"passNum":4,"ruleLine":9,"fired":true,"built":true,' +
 			'"attributes":[{"name":"number","value":"1"}]}}]');
 
-		const globals = await gP;
+		const globals = (await gP) ?? [];
 		eq("vars: globals count", globals.length, 1);
 		eq("vars: global name", globals[0].name, "corporate");
 		eq("vars: global value keeps its quotes", globals[0].value, 'concept:"corporate"');
-		eq("vars: locals", (await lP)[0]?.value, "3");
-		eq("vars: suggested", (await sP)[0]?.name, "value");
-		eq("vars: context may be empty", (await xP).length, 0);
+		eq("vars: locals", ((await lP) ?? [])[0]?.value, "3");
+		eq("vars: suggested", ((await sP) ?? [])[0]?.name, "value");
+		eq("vars: context may be empty", ((await xP) ?? []).length, 0);
 
-		const coll = await cP;
+		const coll = (await cP) ?? [];
 		eq("collect: element count", coll.length, 2);
 		eq("collect: first ordinal", coll[0].ord, 1);
 		check("collect: a single-node element is marked single", coll[0].single === true);
@@ -267,7 +267,43 @@ async function main(): Promise<void> {
 		const seqNo = JSON.parse(fake.received[0]).seq;
 		fake.write(`{"seq":${seqNo},"ok":true}
 `); // no "globals" field
-		eq("vars: a reply with no payload is an empty list", (await p).length, 0);
+		eq("vars: a reply with no payload is an empty list", ((await p) ?? []).length, 0);
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- an engine too old to know the variable commands ----------------------
+	// The commands arrived in engine 3.10.0. An older one answers "unknown
+	// command", and the difference between that and "no variables are set" is
+	// the difference between a stale install and a real property of the
+	// analyzer -- so undefined and [] must not be conflated.
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		check("old engine: variables assumed supported until told otherwise",
+			client.supportsVariables);
+
+		const p = client.globals();
+		await settle();
+		const seqNo = JSON.parse(fake.received[0]).seq;
+		fake.write(`{"seq":${seqNo},"ok":false,"error":"unknown command: globals"}
+`);
+		const result = await p;
+		check("old engine: an unknown command reads as undefined, not empty",
+			result === undefined, `got ${JSON.stringify(result)}`);
+		check("old engine: the client remembers", !client.supportsVariables);
+
+		// A genuine failure that is NOT "unknown command" must not be mistaken
+		// for an old engine.
+		const c = client.collect();
+		await settle();
+		const seq2 = JSON.parse(fake.received[1]).seq;
+		fake.write(`{"seq":${seq2},"ok":false,"error":"no rule in progress"}
+`);
+		const coll = await c;
+		check("old engine: an ordinary failure is still an empty list",
+			Array.isArray(coll) && coll.length === 0, `got ${JSON.stringify(coll)}`);
+
 		client.kill();
 		await fake.close();
 	}

--- a/src/debug/engineClient.ts
+++ b/src/debug/engineClient.ts
@@ -284,23 +284,46 @@ export class EngineClient {
 	// One command per kind rather than one bundle, so expanding a single scope
 	// does not pay for the rest -- globals in particular can be numerous.
 
-	private async vars(command: string, field: string): Promise<EngineVar[]> {
+	/**
+	 * True until the engine rejects a variable command as unknown.
+	 *
+	 * Checked rather than inferred from the engine's version string: the version
+	 * is a second thing to keep in step, and getting it wrong shows an empty
+	 * Variables pane instead of an explanation. Asking the engine cannot drift.
+	 */
+	private varsSupported = true;
+	get supportsVariables(): boolean { return this.varsSupported; }
+
+	// undefined means "this engine has no such command"; [] means "none set".
+	// The difference matters -- one is a stale engine, the other is an analyzer
+	// that simply has no locals here, and they should not look alike.
+	private async vars(command: string, field: string): Promise<EngineVar[] | undefined> {
 		const r = await this.request(command);
+		if (r && r.ok === false && typeof r.error === "string"
+			 && r.error.indexOf("unknown command") >= 0) {
+			this.varsSupported = false;
+			return undefined;
+		}
 		return r?.ok && Array.isArray(r[field]) ? (r[field] as EngineVar[]) : [];
 	}
 
 	/** G("x") */
-	globals(): Promise<EngineVar[]> { return this.vars("globals", "globals"); }
+	globals(): Promise<EngineVar[] | undefined> { return this.vars("globals", "globals"); }
 	/** L("x") */
-	locals(): Promise<EngineVar[]> { return this.vars("locals", "locals"); }
+	locals(): Promise<EngineVar[] | undefined> { return this.vars("locals", "locals"); }
 	/** S("x"), on the node this rule suggests */
-	suggested(): Promise<EngineVar[]> { return this.vars("suggested", "suggested"); }
+	suggested(): Promise<EngineVar[] | undefined> { return this.vars("suggested", "suggested"); }
 	/** X("x"), on the pass's select node */
-	context(): Promise<EngineVar[]> { return this.vars("context", "context"); }
+	context(): Promise<EngineVar[] | undefined> { return this.vars("context", "context"); }
 
 	/** The rule elements matched so far, in order: what N(n,"x") indexes. */
-	async collect(): Promise<EngineCollectElement[]> {
+	async collect(): Promise<EngineCollectElement[] | undefined> {
 		const r = await this.request("collect");
+		if (r && r.ok === false && typeof r.error === "string"
+			 && r.error.indexOf("unknown command") >= 0) {
+			this.varsSupported = false;
+			return undefined;
+		}
 		return r?.ok && Array.isArray(r.collect) ? (r.collect as EngineCollectElement[]) : [];
 	}
 

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -41,6 +41,11 @@ import { parseSequence, sequencePassNames } from "../trace/traceModel";
 
 const THREAD_ID = 1;
 
+// Shown in place of a variable list when the engine predates the commands that
+// serve them. Naming the version is the point: "(none)" would look like an
+// analyzer with no variables, which is a very different problem to chase.
+const OLD_ENGINE = "needs NLP++ engine 3.10.0 or later — run the updater";
+
 export interface NlpLiveLaunchArguments extends DebugProtocol.LaunchRequestArguments {
 	analyzer: string;      // analyzer directory (holds spec/ and input/)
 	input: string;         // the text file to run
@@ -505,12 +510,17 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 					// L/S/X grouped under one scope, plus the matched elements.
 					// Each row is a separate round trip only when expanded, so an
 					// analyzer with no locals costs nothing to display.
-					variables = [
-						this.group("L() locals", { kind: "locals" }),
-						this.group("S() suggested", { kind: "suggested" }),
-						this.group("X() context", { kind: "context" }),
-						this.group("N() matched elements", { kind: "collect" }),
-					];
+					//
+					// Once the engine has told us it does not know these commands,
+					// say it once here rather than four times inside.
+					variables = this.client.supportsVariables
+						? [
+							this.group("L() locals", { kind: "locals" }),
+							this.group("S() suggested", { kind: "suggested" }),
+							this.group("X() context", { kind: "context" }),
+							this.group("N() matched elements", { kind: "collect" }),
+						]
+						: [this.plain("(unavailable)", OLD_ENGINE)];
 					break;
 				case "locals":
 					variables = this.varRows(await this.client.locals());
@@ -543,14 +553,19 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		return { name, value: "", variablesReference: this.variableHandles.create(ref) };
 	}
 
-	private varRows(vars: EngineVar[]): DebugProtocol.Variable[] {
+	// The engine returning nothing and the engine not knowing the question are
+	// different answers, and an author staring at an empty pane deserves to be
+	// told which one this is.
+	private varRows(vars: EngineVar[] | undefined): DebugProtocol.Variable[] {
+		if (vars === undefined) return [this.plain("(unavailable)", OLD_ENGINE)];
 		if (!vars.length) return [this.plain("(none)", "")];
 		return vars.map((v) => this.plain(v.name, v.value));
 	}
 
 	// The rule elements matched so far. Labelled by the ordinal N() uses, so the
 	// row name is the expression an author would write.
-	private collectRows(elements: EngineCollectElement[]): DebugProtocol.Variable[] {
+	private collectRows(elements: EngineCollectElement[] | undefined): DebugProtocol.Variable[] {
+		if (elements === undefined) return [this.plain("(unavailable)", OLD_ENGINE)];
 		if (!elements.length) return [this.plain("(nothing matched yet)", "")];
 		return elements.map((e) => {
 			const label = `N(${e.ord})`;


### PR DESCRIPTION
Follow-up to #1191, closing a gap it left.

The variable commands arrived in NLP++ engine **3.10.0**. Against 3.9.0 they are simply unknown, the client read every rejection as an empty list, and the Variables pane came back blank — which looks exactly like an analyzer that happens to have no variables set. That sends an author looking for the wrong problem entirely.

The pane now names the version it needs.

## Ask the engine, don't compare versions

The obvious fix is a version check next to the 3.9.0 one already in `debugConfig.ts`. This deliberately doesn't do that: a version number is a *second* thing to keep in step with the protocol, and getting it wrong reproduces the exact silence it was meant to prevent. A command the engine rejects as unknown cannot drift.

So the client distinguishes three cases that were previously one:

| Reply | Means | Shows |
| --- | --- | --- |
| `ok: true`, list | variables are set | the variables |
| `ok: true`, empty | nothing set right now | `(none)` |
| `ok: false, "unknown command"` | engine predates 3.10.0 | `(unavailable) — needs NLP++ engine 3.10.0 or later` |

The client remembers the first rejection, so the group says it once rather than four times inside. Any *other* failure is still an empty list — "the engine does not know this question" and "nothing is set" are different answers and should not look alike.

## Testing

Four new assertions (49 total): support is assumed until the engine says otherwise, an unknown command reads as `undefined`, the client remembers, and a non-`unknown command` failure is still an empty list.

Re-verified against a real 3.10.0 engine — the corporate analyzer still shows 25 tree rows carrying attributes, and `name="sentence1", object=concept:"sentence1"`.

| Suite | Result |
| --- | --- |
| integration (real VSCode host) | 27 / 27 |
| debug client | 49 / 49 |
| trace | 141 / 141 |
| lint + typecheck | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
