### PR TITLE
Ship the language server and debug adapter in the vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -71,10 +71,21 @@ test/**
 *.test.ts
 *.test.js
 
-# Keep only what's needed for the extension
+# Keep only what's needed for the extension.
+#
+# One re-include per webpack entry point. These are separate PROCESSES, not
+# imports, so nothing here is reachable from extension.js and nothing warns when
+# they go missing -- the extension installs cleanly and then silently has no
+# language features and no debugger. scripts/check-bundles.js fails the package
+# step if a bundle webpack built is not in the vsix, so adding an entry point
+# without a line here cannot ship again.
 !dist/extension.js
 !dist/extension.js.map
 !dist/extension.js.LICENSE.txt
+!dist/server.js
+!dist/server.js.map
+!dist/debugAdapter.js
+!dist/debugAdapter.js.map
 !resources/**
 !snippets/**
 !grammars/syntaxes/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.14.3
+The published extension actually contains the language server and the debugger.
+
+- **`.vscodeignore` was stripping two of the three bundles out of every release.** It excludes `dist/**` and re-includes files one at a time, and it was written when `extension.js` was the only bundle there was. When the language features moved into a language server in 3.13.0, and the debugger arrived in 3.14.0, `dist/server.js` and `dist/debugAdapter.js` were silently left out of the package. Installing from the Marketplace gave you an extension with **no outline, hover, completion, go-to-definition, diagnostics or formatting, and no debugger** -- and no error saying why, because each of those is a separate process that simply never started. Running from source was unaffected, which is why it went unnoticed. Fixed, and 3.13.0 through 3.14.2 should be considered broken installs.
+- **A packaging check now makes this impossible to repeat.** `npm run package` reads the entry points out of the webpack config and fails if any of their bundles is absent from the built `.vsix`. Adding a fourth process later without a matching `.vscodeignore` line will now stop the build rather than ship quietly.
+
 ### 3.14.2
 An older engine says so instead of showing an empty Variables pane.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.14.2",
+    "version": "3.14.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.14.2",
+            "version": "3.14.3",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.14.2",
+    "version": "3.14.3",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,
@@ -3683,8 +3683,9 @@
         "webpack-prod": "webpack --mode production --devtool hidden-source-map",
         "check-grammars": "node ./scripts/check-grammars.js",
         "check-worker": "node ./scripts/check-worker-deps.js",
-        "package": "npm run check-grammars && npm run webpack-prod && vsce package",
-        "publish": "npm run check-grammars && npm run webpack-prod && vsce publish",
+        "check-bundles": "node ./scripts/check-bundles.js",
+        "package": "npm run check-grammars && npm run webpack-prod && vsce package && npm run check-bundles",
+        "publish": "npm run check-grammars && npm run webpack-prod && vsce package && npm run check-bundles && vsce publish --packagePath $(ls -t *.vsix | head -1)",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "lint": "eslint src scripts eslint.config.js webpack.config.js",
@@ -3698,7 +3699,7 @@
         "test:trace": "tsc -p tsconfig.trace.json && node ./out-trace/trace/traceTest.js",
         "test:debug": "tsc -p tsconfig.debug.json && node ./out-debug/debug/debugTest.js",
         "test:treeview": "tsc -p tsconfig.treeview.json && node ./out-treeview/treeTest.js",
-        "vsce-package": "npm run check-grammars && npm run webpack-prod && vsce package -o ./vscode.nlp.vsix"
+        "vsce-package": "npm run check-grammars && npm run webpack-prod && vsce package -o ./vscode.nlp.vsix && npm run check-bundles ./vscode.nlp.vsix"
     },
     "devDependencies": {
         "@types/node": "^22.20.1",

--- a/scripts/check-bundles.js
+++ b/scripts/check-bundles.js
@@ -1,0 +1,115 @@
+// Fail the package step if a webpack bundle is missing from the .vsix.
+//
+// WHY THIS EXISTS. Every webpack entry point is a separate PROCESS -- the
+// extension host, the language server, the debug adapter. Nothing imports the
+// server or the adapter, so nothing warns when they are absent: the extension
+// packages cleanly, installs cleanly, activates cleanly, and then has no
+// language features and no debugger, with no error anywhere pointing at the
+// cause.
+//
+// That is not hypothetical. `.vscodeignore` excludes dist/** and re-includes
+// files one by one; it was written when extension.js was the only bundle, so
+// 3.13.0 through 3.14.2 shipped without dist/server.js or dist/debugAdapter.js.
+// The marketplace build was broken for two releases before anyone could tell.
+//
+// So: read the entry points out of webpack.config.js, and require each one's
+// output to be inside the packaged .vsix. Adding an entry point without a
+// matching "!dist/..." line in .vscodeignore now fails the build.
+
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const root = path.resolve(__dirname, "..");
+
+function expectedBundles() {
+	// The config is an array of webpack configs, one per process.
+	const configs = require(path.join(root, "webpack.config.js"));
+	const list = Array.isArray(configs) ? configs : [configs];
+	return list.map((c) => c.output && c.output.filename).filter(Boolean);
+}
+
+function findVsix() {
+	const named = process.argv[2];
+	if (named) return path.resolve(root, named);
+	const candidates = fs.readdirSync(root).filter((f) => f.endsWith(".vsix"));
+	if (!candidates.length) {
+		console.error("check-bundles: no .vsix found in the repo root.");
+		process.exit(1);
+	}
+	// Newest, so a stale one from an earlier build is not what gets checked.
+	candidates.sort((a, b) =>
+		fs.statSync(path.join(root, b)).mtimeMs - fs.statSync(path.join(root, a)).mtimeMs);
+	return path.join(root, candidates[0]);
+}
+
+// A .vsix is a zip. Read its central directory directly rather than shelling
+// out: Windows' Git Bash provides GNU tar, which cannot read zips at all, and
+// `unzip` is not guaranteed anywhere. This needs no dependency and no external
+// tool, so it behaves the same on a laptop and on a CI runner.
+function vsixEntries(vsix) {
+	const buf = fs.readFileSync(vsix);
+
+	// End of Central Directory: signature 0x06054b50, within the last 64KB.
+	const EOCD_SIG = 0x06054b50;
+	let eocd = -1;
+	for (let i = buf.length - 22; i >= 0 && i >= buf.length - 65557; i--) {
+		if (buf.readUInt32LE(i) === EOCD_SIG) { eocd = i; break; }
+	}
+	if (eocd < 0) throw new Error("not a zip archive (no end-of-central-directory record)");
+
+	const count = buf.readUInt16LE(eocd + 10);
+	let offset = buf.readUInt32LE(eocd + 16);
+
+	const names = [];
+	const CEN_SIG = 0x02014b50;
+	for (let i = 0; i < count; i++) {
+		if (offset + 46 > buf.length || buf.readUInt32LE(offset) !== CEN_SIG) {
+			throw new Error(`central directory entry ${i + 1} of ${count} is malformed`);
+		}
+		const nameLen = buf.readUInt16LE(offset + 28);
+		const extraLen = buf.readUInt16LE(offset + 30);
+		const commentLen = buf.readUInt16LE(offset + 32);
+		names.push(buf.toString("utf8", offset + 46, offset + 46 + nameLen));
+		offset += 46 + nameLen + extraLen + commentLen;
+	}
+	return names;
+}
+
+function main() {
+	const vsix = findVsix();
+	const bundles = expectedBundles();
+	if (!bundles.length) {
+		console.error("check-bundles: webpack.config.js declared no output filenames.");
+		process.exit(1);
+	}
+
+	let entries;
+	try {
+		entries = vsixEntries(vsix);
+	} catch (err) {
+		console.error(`check-bundles: could not read ${path.basename(vsix)} — ${err.message}`);
+		process.exit(1);
+	}
+
+	const missing = bundles.filter(
+		(b) => !entries.some((e) => e === `extension/dist/${b}` || e.endsWith(`/dist/${b}`)));
+
+	if (missing.length) {
+		console.error(
+			`\ncheck-bundles: ${path.basename(vsix)} is missing ${missing.length} of ` +
+			`${bundles.length} webpack bundles:\n`);
+		for (const m of missing) console.error(`  dist/${m}`);
+		console.error(
+			`\nEach one is a separate process, so nothing will report this at runtime —\n` +
+			`the extension just loses whatever that bundle provides. Add a matching\n` +
+			`"!dist/<name>" line (and "!dist/<name>.map") to .vscodeignore.\n`);
+		process.exit(1);
+	}
+
+	console.log(
+		`check-bundles: all ${bundles.length} webpack bundles are in ` +
+		`${path.basename(vsix)} (${bundles.join(", ")}).`);
+}
+
+main();


### PR DESCRIPTION
**3.13.0 through 3.14.2 shipped broken from the Marketplace.** This fixes the cause and adds a check so it cannot happen again.

## What was wrong

`.vscodeignore` excludes `dist/**` and re-includes files one at a time. It was written when `extension.js` was the only bundle there was:

```
dist/**
...
!dist/extension.js
!dist/extension.js.map
!dist/extension.js.LICENSE.txt
```

When the language features moved into a language server in 3.13.0, and the debugger arrived in 3.14.0, `dist/server.js` and `dist/debugAdapter.js` were silently dropped from every package.

Confirmed against the published artifact — `nlp-3.14.2.vsix` from the GitHub release contains `dist/extension.js` and nothing else from `dist/`:

```
check-bundles: nlp-3.14.2.vsix is missing 2 of 3 webpack bundles:
  dist/server.js
  dist/debugAdapter.js
```

So a Marketplace install had **no outline, hover, completion, go-to-definition, diagnostics or formatting, and no debugger**.

## Why nothing caught it

Each bundle is a separate **process**, not an import. A missing one does not fail to resolve at load time — the client tries to spawn something that isn't there and the feature simply never appears, with no error pointing at the cause.

And every test in this repo runs against the source tree, where `dist/` has all three. The tests were right; they were just testing a different artifact than the one users install.

## The check matters more than the fix

Two lines in `.vscodeignore` fix today. `scripts/check-bundles.js` stops it recurring: it reads the entry points out of `webpack.config.js` and requires each one's output to be present in the built `.vsix`. Adding a fourth process later without a matching re-include line now fails the build.

Wired into `package`, `vsce-package` and `publish`. It reads the vsix's zip central directory in plain Node — Git Bash ships GNU tar, which cannot read zips at all, and `unzip` isn't guaranteed on the machines this packages on.

Verified both directions:

| Input | Result |
| --- | --- |
| freshly built vsix | passes, all 3 bundles, exit 0 |
| published 3.14.2 | fails, names both missing bundles, exit 1 |

## End-to-end

A rebuilt 3.14.2 was installed locally and driven through **its own** debug adapter against **its own** engine and analyzers — stepping, breakpoints, `N(1..4)` matched elements and globals all work from the installed extension, not just from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
