### PR TITLE
Find the text file the TEXT view selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.14.4
+Live debugging finds the text file you picked in the TEXT view.
+
+- **Choosing a text file and pressing F5 said "Live rule debugging needs a text file to run".** The only thing consulted was the file open in the editor -- and while you are setting a breakpoint, that is the pass file, not a text file. The analyzer's current text file, which is exactly what selecting one in the TEXT view sets, was never looked at. It is now the first thing checked.
+- An unset path is stored as a lone separator rather than an empty string, so it passed every "is this set?" test while naming no file, and failed later as a path that does not exist. Paths are now checked for being real files rather than merely non-empty.
+- The message when nothing is found says what was looked for, instead of suggesting the one thing you had just done.
+
 ### 3.14.3
 The published extension actually contains the language server and the debugger.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.14.3",
+    "version": "3.14.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.14.3",
+            "version": "3.14.4",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.14.3",
+    "version": "3.14.4",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/debugConfig.ts
+++ b/src/debug/debugConfig.ts
@@ -28,6 +28,20 @@ function compareVersions(a: string, b: string): number {
 	return 0;
 }
 
+// An unset Uri stringifies to a lone separator ("\\" on Windows), which is
+// truthy and therefore passed every plain `if (path)` check while naming no
+// file. Anything shorter than a drive-qualified path is treated as unset.
+function usableFile(p: string | undefined): boolean {
+	return typeof p === "string" && p.trim().length > 1 && fs.existsSync(p);
+}
+
+// Under the analyzer's input/ tree. Checked with both separators: a path can
+// reach here from a launch config or a Uri, and those do not agree on Windows.
+function isUnderInput(p: string): boolean {
+	const lower = p.toLowerCase().split("\\").join("/");
+	return lower.includes("/input/");
+}
+
 class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
 	// Offered when the user picks "create a launch.json" for NLP++.
 	provideDebugConfigurations(): vscode.DebugConfiguration[] {
@@ -121,18 +135,31 @@ class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
 			return undefined;
 		}
 
-		if (!config.input) {
-			const active = vscode.window.activeTextEditor?.document.uri.fsPath;
-			// A text file open in the editor is the obvious thing to run; anything
-			// under the analyzer's input/ tree qualifies.
-			if (active && active.toLowerCase().includes(`${path.sep}input${path.sep}`)) {
-				config.input = active;
-			}
+		// Which text file to run, in order of what the user most likely meant.
+		//
+		// The first source is the one that was missing: the analyzer's CURRENT
+		// text file, which is exactly what picking a file in the TEXT view sets.
+		// Without it, choosing a file there and pressing F5 failed -- the only
+		// thing consulted was the active editor, and while setting a breakpoint
+		// that is the .nlp pass file, not a text file.
+		if (!usableFile(config.input)) {
+			config.input = undefined;
+			const chosen = visualText.analyzer?.getTextPath()?.fsPath;
+			if (usableFile(chosen)) config.input = chosen;
 		}
-		if (!config.input || !fs.existsSync(config.input)) {
+		if (!config.input) {
+			// Then an editor tab, but only one under the analyzer's input/ tree --
+			// otherwise F5 from a pass file would try to analyze the pass file.
+			const active = vscode.window.activeTextEditor?.document.uri.fsPath;
+			if (usableFile(active) && isUnderInput(active as string)) config.input = active;
+		}
+		if (!config.input) {
+			// Say what was looked for. "Open one from the TEXT view" was unhelpful
+			// to someone who had just done exactly that.
 			void vscode.window.showErrorMessage(
-				"Live rule debugging needs a text file to run. Open one from the TEXT view, " +
-				"or set \"input\" in your launch configuration.");
+				"Live rule debugging needs a text file to run, and none was found. " +
+				"Select one in the TEXT view (that sets the analyzer's current text file), " +
+				"or set \"input\" to a path in your launch configuration.");
 			return undefined;
 		}
 		return config;
@@ -163,7 +190,12 @@ export function registerDebugger(ctx: vscode.ExtensionContext): void {
 		// readable rather than hard-coding absolute paths.
 		vscode.commands.registerCommand("nlp.currentAnalyzerDir", () =>
 			visualText.analyzer?.isLoaded() ? visualText.analyzer.getAnalyzerDirectory().fsPath : ""),
-		vscode.commands.registerCommand("nlp.currentTextFile", () =>
-			visualText.analyzer?.getTextPath()?.fsPath ?? ""),
+		// Empty rather than a lone separator when no text file is set, so a
+		// launch config substituting this gets a falsy value the resolver can
+		// recognise instead of a path that merely fails to exist.
+		vscode.commands.registerCommand("nlp.currentTextFile", () => {
+			const p = visualText.analyzer?.getTextPath()?.fsPath;
+			return usableFile(p) ? (p as string) : "";
+		}),
 	);
 }


### PR DESCRIPTION
Choosing a text file in the TEXT view and starting live debugging reported **"Live rule debugging needs a text file to run"** — with the file plainly selected.

## Cause

The resolver only ever consulted `vscode.window.activeTextEditor`. While you're setting a breakpoint, that's the `.nlp` pass file — not a text file — so the check found nothing and gave up.

The analyzer's **current text file**, which is exactly what selecting one in the TEXT view sets (`TextView` → `saveCurrentFile`), was never looked at. It's now the first source checked, ahead of the editor tab.

## An unset path made it worse

`Uri.file("").fsPath` is a lone separator, not an empty string. So `if (config.input)` passed while naming no file, and the failure surfaced later as a path that doesn't exist — the same message by a different route.

Confirmed in a real analyzer's saved state:

```json
"currentTextFile": "...\corporate\input\Dev\Sold.txt",
"currentPassFile": "\\"
```

Paths are now tested for being real files rather than merely non-empty, and `nlp.currentTextFile` reports `""` instead of a separator, so a launch config substituting it gets something the resolver can recognise.

## Resolution order

| # | Source |
| --- | --- |
| 1 | explicit `input` in the launch config |
| 2 | **the analyzer's current text file** (what the TEXT view sets) |
| 3 | the active editor tab, if it's under the analyzer's `input/` tree |

The tab fallback still requires `input/`, so F5 from a pass file can't try to analyze the pass file. That check now normalises separators — it matched only a backslash before, which is wrong for any path arriving from a launch configuration.

The message when nothing is found says what was looked for, rather than suggesting the one thing the user had just done.

## Verified

Built, packaged (bundle guard passes: all 3), installed locally, and confirmed against the corporate analyzer's saved state that the file selected in the TEXT view is what gets picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
