### PR TITLE
Break and step inside @CODE, @POST and @DECL (3.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,27 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.16.0
+Breakpoints in `@CODE`, `@POST` and `@DECL`, and stepping through them statement by statement.
+
+- **A breakpoint in an `@POST` now stops on the statement.** Those regions are ordinary imperative code, and up to now the only way to see what one did was to break on the rule above it and read the result afterwards. A breakpoint there goes through on the line you clicked -- no snapping, because here the line you clicked is the unit that runs -- and the stop happens BEFORE that line runs, so the variables beside it are the ones it is about to act on.
+- **The step buttons follow where you are.** At a rule they still mean next rule tried / next rule matched / next pass. Inside a statement body they mean what they mean in every other debugger:
+
+  |             | at a rule          | in a statement body               |
+  | ----------- | ------------------ | --------------------------------- |
+  | Step Over   | next rule tried    | next statement, calls run whole   |
+  | Step Into   | next rule matched  | next statement, entering a call   |
+  | Step Out    | next pass          | until this function returns       |
+
+- **Step Into enters a function.** Stopping inside a `@DECL` body lands in the file the function was *written* in, not the caller's, and its parameters read back as `L()` locals while the globals it changes update as you step.
+- Needs NLP++ engine **3.12.0**. The extension asks the engine what it supports rather than reading its version; against an older one a breakpoint outside a rule is withdrawn with the reason rather than sitting there never firing.
+
 ### 3.15.1
 A breakpoint anywhere in a rule now stops on that rule.
 
 - **Clicking on an element line did nothing.** The engine identifies a rule by its head line -- the `_name <-` -- and reports no other, so a breakpoint set on `_det [s]` inside `_money <- _det total _prep _money` was accepted and then never fired. The eye lands on whichever line names the thing you are looking for, which is rarely the head. Breakpoints now move to the head of the rule that contains them, and say so.
 - Rule extents come from the same parser the outline and go-to-definition use, so the debugger's idea of where a rule begins and ends cannot drift from the editor's.
-- A breakpoint outside every rule -- in `@CODE`, `@POST` or `@DECL` -- is reported unverified with the reason, instead of being accepted silently. Stopping there needs engine support that does not exist yet.
+- A breakpoint outside every rule -- in `@CODE`, `@POST` or `@DECL` -- is reported unverified with the reason, instead of being accepted silently. (3.16.0 makes those stop, given a new enough engine.)
 
 ### 3.15.0
 The debugger shows the nodes a rule is actually about.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.15.1
+A breakpoint anywhere in a rule now stops on that rule.
+
+- **Clicking on an element line did nothing.** The engine identifies a rule by its head line -- the `_name <-` -- and reports no other, so a breakpoint set on `_det [s]` inside `_money <- _det total _prep _money` was accepted and then never fired. The eye lands on whichever line names the thing you are looking for, which is rarely the head. Breakpoints now move to the head of the rule that contains them, and say so.
+- Rule extents come from the same parser the outline and go-to-definition use, so the debugger's idea of where a rule begins and ends cannot drift from the editor's.
+- A breakpoint outside every rule -- in `@CODE`, `@POST` or `@DECL` -- is reported unverified with the reason, instead of being accepted silently. Stopping there needs engine support that does not exist yet.
+
+### 3.15.0
+The debugger shows the nodes a rule is actually about.
+
+- **"Parse tree" is now "Nodes in play", and shows the rule's own nodes.** It used to start at `_ROOT`, so finding the handful of nodes a rule cared about meant walking down through thousands. At a match it now lists exactly the nodes the rule took, labelled `N(1)`, `N(2)`... -- the same names you would write in the rule. At an attempt, where nothing has matched yet, it shows the current node and the candidates after it, as many as the rule has elements. The whole document is still one row away at the bottom.
+- **You can read forward from the current node.** A rule matches a sequence, so the nodes after the current one are the ones it is about to be tried against -- and they were reachable only from the root. They now appear as `+1`, `+2`, `+3`..., each expandable.
+- **Nodes open properly.** "Current node" was fetched one level deep, so expanding any child hit "(N children)" and stopped. It now arrives deep enough to walk.
+- **Node text was wrong past the first line.** It was sliced out of the input file using the engine's offsets, and those index the engine's buffer, whose line endings are normalised -- so on a CRLF file every node after line 1 was shifted by one character per preceding line. A `(` showed as `"g"`, a `)` as `"R"`, `for` as `") f"`. The engine now sends each node's text from its own buffer. Needs NLP++ engine 3.11.0; against an older one the extension falls back to the old slicing.
+
+### 3.14.5
+The debugger shows the text a rule is being matched against.
+
+- **"Current node" never showed the node.** It listed the node's children and attributes, so the node itself -- crucially the TEXT it covers -- appeared nowhere. While a rule is being tried, that text is what the rule is being matched against, which is the most useful thing on the screen. The scope now opens with the node's name, its text, type, span and which pass and rule line built it, before its contents.
+- The Rule scope says which node the rule is being tried at, so the rule and the text it is being matched against are on the same screen.
+- **A pass with no source file says why, instead of "Unknown Source".** The tokenizers -- `tokenize`, `dicttokz`, `chartok` and the rest -- are built into the engine and have no `.nlp` file to open, so VSCode rendered the stack frame as "Unknown Source". That is the *first* pass of almost every analyzer, so it was the first thing anyone saw on pressing F5, and it reads like something went wrong when nothing did. The frame now says `Pass 1: dicttokz (built into the engine — no pass file)`.
+
+- **Stopping on a tokenizer looked like a failure.** The tokenizers -- `tokenize`, `dicttokz`, `chartok` and the rest -- are built into the engine and have no `.nlp` file to open, so VSCode rendered the stack frame as "Unknown Source". That is the *first* pass of almost every analyzer, so it was the first thing anyone saw on pressing F5, and it reads like something went wrong when nothing did. The frame now says `Pass 1: dicttokz (built into the engine — no pass file)`.
+
 ### 3.14.4
 Live debugging finds the text file you picked in the TEXT view.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nlp",
-    "version": "3.14.4",
+    "version": "3.15.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nlp",
-            "version": "3.14.4",
+            "version": "3.15.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/debugadapter": "^1.68.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.14.4",
+    "version": "3.15.1",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.15.1",
+    "version": "3.16.0",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/debugTest.ts
+++ b/src/debug/debugTest.ts
@@ -137,6 +137,11 @@ async function main(): Promise<void> {
 		const nodeSeq = JSON.parse(fake.received[1]).seq;
 		eq("correlation: first request is rule", JSON.parse(fake.received[0]).command, "rule");
 		eq("correlation: second request is node", JSON.parse(fake.received[1]).command, "node");
+		// depth so children expand, after so the nodes a rule will be tried
+		// against come with it. Both defaulted to nothing useful before.
+		check("node request carries a depth", JSON.parse(fake.received[1]).depth >= 1);
+		check("node request carries an after count",
+			typeof JSON.parse(fake.received[1]).after === "number");
 
 		fake.write(`{"seq":${nodeSeq},"ok":true,"node":{"name":"_money","type":"node","start":163,` +
 			`"end":166,"ustart":163,"uend":166,"passNum":14,"ruleLine":79,"fired":true,"built":true}}\n`);
@@ -148,8 +153,8 @@ async function main(): Promise<void> {
 		eq("correlation: rule reply reached the rule request", rule?.line, 17);
 		eq("correlation: rule builds", rule?.builds, "_money");
 		eq("correlation: rule element count", rule?.elements.length, 2);
-		eq("correlation: node reply reached the node request", node?.name, "_money");
-		eq("correlation: node provenance", node?.ruleLine, 79);
+		eq("correlation: node reply reached the node request", node.node?.name, "_money");
+		eq("correlation: node provenance", node.node?.ruleLine, 79);
 
 		client.kill();
 		await fake.close();
@@ -193,6 +198,47 @@ async function main(): Promise<void> {
 		eq("malformed: the next good message still arrives", stop.line, 17);
 		check("malformed: the bad line was reported", noise.some((n) => n.includes("unparsable")));
 		check("malformed: session is still live", !client.isTerminated);
+
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- reading forward from the current node --------------------------------
+	// A rule matches a SEQUENCE, so the nodes after the current one are the ones
+	// it is about to be tried against. Before this they were reachable only by
+	// walking the whole document down from the root.
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+
+		const p = client.node(4, 3);
+		await settle();
+		const sent = JSON.parse(fake.received[0]);
+		eq("following: depth is passed through", sent.depth, 4);
+		eq("following: after is passed through", sent.after, 3);
+
+		const mk = (name: string, start: number) =>
+			`{"name":"${name}","type":"alpha","start":${start},"end":${start + 2},` +
+			`"ustart":${start},"uend":${start + 2},"passNum":0,"ruleLine":0,` +
+			`"fired":false,"built":false,"attributes":[]}`;
+		fake.write(`{"seq":${sent.seq},"ok":true,"node":${mk("_det", 20)},` +
+			`"following":[${mk("total", 24)},${mk("of", 30)}]}
+`);
+
+		const r = await p;
+		eq("following: the current node comes back", r.node?.name, "_det");
+		eq("following: two nodes after it", r.following.length, 2);
+		eq("following: in order", r.following.map((n) => n.name).join(","), "total,of");
+
+		// An engine that sends no "following" must not break the caller.
+		const p2 = client.node(1, 0);
+		await settle();
+		const sent2 = JSON.parse(fake.received[1]);
+		fake.write(`{"seq":${sent2.seq},"ok":true,"node":${mk("_x", 1)}}
+`);
+		const r2 = await p2;
+		eq("following: absent list reads as empty", r2.following.length, 0);
+		eq("following: node still arrives", r2.node?.name, "_x");
 
 		client.kill();
 		await fake.close();

--- a/src/debug/debugTest.ts
+++ b/src/debug/debugTest.ts
@@ -354,6 +354,68 @@ async function main(): Promise<void> {
 		await fake.close();
 	}
 
+	// ---- capabilities ---------------------------------------------------------
+	// Statement support has to be known BEFORE it is used: a breakpoint in an
+	// @POST is set long before anything could be tried and found missing, and a
+	// breakpoint that is accepted and then never fires is the worst outcome of
+	// the three. So it is asked, not inferred from a version string.
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		const p = client.capabilities();
+		await settle();
+		const seqNo = JSON.parse(fake.received[0]).seq;
+		eq("capabilities: the command is what was sent",
+			JSON.parse(fake.received[0]).command, "capabilities");
+		fake.write(`{"seq":${seqNo},"ok":true,"capabilities":["statements","variables"]}\n`);
+		const caps = await p;
+		check("capabilities: the list comes through", caps.indexOf("statements") >= 0,
+			`got ${JSON.stringify(caps)}`);
+		client.kill();
+		await fake.close();
+	}
+	{
+		// An engine older than 3.12 has no such command. An empty list, not a
+		// throw -- the session carries on with rule breakpoints only.
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		const p = client.capabilities();
+		await settle();
+		const seqNo = JSON.parse(fake.received[0]).seq;
+		fake.write(`{"seq":${seqNo},"ok":false,"error":"unknown command: capabilities"}\n`);
+		eq("capabilities: an old engine reports none", (await p).length, 0);
+		client.kill();
+		await fake.close();
+	}
+
+	// ---- statement stops and statement stepping -------------------------------
+	// The engine reports a statement stop with statement=true and a call depth,
+	// and those two fields are what make the step buttons context-sensitive.
+	{
+		const fake = await fakeEngine();
+		const client = await startClient(fake);
+		const waiting = client.nextStop();
+		fake.write('{"event":"stopped","reason":"statement","pass":2,"passName":"numbers.nlp",'
+			+ '"line":23,"ruleOrd":0,"statement":true,"depth":1}\n');
+		const stop = await waiting;
+		eq("statement stop: reason", stop.reason, "statement");
+		eq("statement stop: flagged as a statement", stop.statement, true);
+		eq("statement stop: line is the statement's", stop.line, 23);
+		eq("statement stop: depth records the call", stop.depth, 1);
+
+		for (const cmd of ["stepStatement", "stepOverStatement", "stepOutStatement"] as const) {
+			const before = fake.received.length;
+			void client.resume(cmd);
+			await settle();
+			eq(`statement stepping: ${cmd} goes out verbatim`,
+				JSON.parse(fake.received[before]).command, cmd);
+			fake.write(`{"seq":${JSON.parse(fake.received[before]).seq},"ok":true}\n`);
+		}
+
+		client.kill();
+		await fake.close();
+	}
+
 	// ---- termination ---------------------------------------------------------
 	{
 		const fake = await fakeEngine();

--- a/src/debug/engineClient.ts
+++ b/src/debug/engineClient.ts
@@ -16,7 +16,8 @@ import * as net from "net";
 // ---- protocol types ---------------------------------------------------------
 
 export type StopReason =
-	| "entry" | "step" | "breakpoint" | "matched" | "failed" | "passStart" | "pause";
+	| "entry" | "step" | "breakpoint" | "matched" | "failed" | "passStart"
+	| "statement" | "pause";
 
 // The engine's stopped event. Everything but `reason` is best-effort: a stop at
 // a pass boundary has no rule or node yet, and eltsMatched only accompanies a
@@ -31,6 +32,18 @@ export interface EngineStop {
 	nodeStart?: number;
 	nodeEnd?: number;
 	eltsMatched?: number; // failures only: how far the rule got
+
+	/**
+	 * True when the stop is on a STATEMENT in an @CODE, @POST or @DECL body
+	 * rather than on a rule. `line` then means the statement's line, and the
+	 * stop is reported BEFORE that statement runs.
+	 */
+	statement?: boolean;
+	/**
+	 * Call depth, 0 outside any function. Only meaningful for a statement stop,
+	 * and it is what makes step-over and step-out mean anything.
+	 */
+	depth?: number;
 }
 
 // One NLP++ variable. The engine renders values with the same call the .tree
@@ -88,7 +101,11 @@ export interface EngineRule {
 	elements: EngineRuleElement[];
 }
 
-export type ResumeCommand = "continue" | "stepRule" | "stepMatch" | "stepPass";
+export type ResumeCommand =
+	| "continue" | "stepRule" | "stepMatch" | "stepPass"
+	// Statement stepping, for @CODE/@POST/@DECL bodies. INTO descends into a
+	// call, OVER runs one whole, OUT runs until the current function returns.
+	| "stepStatement" | "stepOverStatement" | "stepOutStatement";
 
 export interface EngineClientOptions {
 	/**
@@ -259,6 +276,20 @@ export class EngineClient {
 	/** Breakpoint lines for one pass. An empty list clears that pass. */
 	setBreakpoints(pass: number, lines: number[]): Promise<void> {
 		return this.request("setBreakpoints", { pass, lines }).then(() => undefined);
+	}
+
+	/**
+	 * What this engine build can do, asked once after connecting.
+	 *
+	 * Statement support has to be known BEFORE it is used -- a breakpoint in an
+	 * @POST is set long before anything could be tried and found missing, and an
+	 * accepted breakpoint that never fires is worse than a refused one. An
+	 * engine older than 3.12 has no such command and answers with an error,
+	 * which reads here as an empty list.
+	 */
+	async capabilities(): Promise<string[]> {
+		const r = await this.request("capabilities");
+		return r?.ok && Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [];
 	}
 
 	stopOnFailure(value: boolean): Promise<void> {

--- a/src/debug/engineClient.ts
+++ b/src/debug/engineClient.ts
@@ -67,6 +67,12 @@ export interface EngineNode {
 	children?: EngineNode[];
 	childCount?: number; // present instead of children when depth ran out
 	attributes?: EngineVar[]; // the node's own ("name" value) pairs
+	/**
+	 * The characters this node covers, sent by the engine from its own buffer.
+	 * Authoritative: slicing the input file with start/end drifts on any file
+	 * whose line endings the engine normalised, which is every CRLF file.
+	 */
+	text?: string;
 }
 
 export interface EngineRuleElement {
@@ -269,9 +275,21 @@ export class EngineClient {
 		return r?.ok ? (r.rule ?? undefined) : undefined;
 	}
 
-	async node(): Promise<EngineNode | undefined> {
-		const r = await this.request("node");
-		return r?.ok ? (r.node ?? undefined) : undefined;
+	/**
+	 * The current node, plus the next `after` siblings.
+	 *
+	 * `depth` matters because a handle handed to the client carries the subtree
+	 * it arrived with: fetched one level deep, every child expands to a dead end.
+	 * `after` matters because a rule matches a SEQUENCE, so the nodes following
+	 * the current one are the ones it is about to be tried against.
+	 */
+	async node(depth = 3, after = 0): Promise<{ node?: EngineNode; following: EngineNode[] }> {
+		const r = await this.request("node", { depth, after });
+		if (!r?.ok) return { following: [] };
+		return {
+			node: r.node ?? undefined,
+			following: Array.isArray(r.following) ? (r.following as EngineNode[]) : [],
+		};
 	}
 
 	async tree(depth: number): Promise<EngineNode | undefined> {

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -38,6 +38,7 @@ import {
 	EngineCollectElement, ResumeCommand,
 } from "./engineClient";
 import { parseSequence, sequencePassNames } from "../trace/traceModel";
+import { declaredSymbols } from "../language/symbols";
 
 const THREAD_ID = 1;
 
@@ -87,7 +88,8 @@ type VariableRef =
 	| { kind: "globals" }
 	| { kind: "collect" }     // the N() matched elements
 	| { kind: "engineNode"; node: EngineNode }
-	| { kind: "attributes"; node: EngineNode };
+	| { kind: "attributes"; node: EngineNode }
+	| { kind: "wholeTree" };
 
 export class NlpLiveDebugSession extends LoggingDebugSession {
 	private client = new EngineClient();
@@ -102,6 +104,9 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	// on a case-sensitive filesystem.
 	private passOfSource = new Map<string, number>();
 	private sourceOfPass = new Map<number, string>();
+	// Pass file -> the head line of each rule, and the line range it covers.
+	// Built lazily per file, because breakpoints arrive one file at a time.
+	private ruleSpans = new Map<string, Array<{ head: number; from: number; to: number }>>();
 	// Breakpoints the client set before we were connected to the engine.
 	private pendingBreakpoints = new Map<number, number[]>();
 	private launched = false;
@@ -308,20 +313,95 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 			return;
 		}
 
-		if (this.launched) await this.client.setBreakpoints(pass, lines);
-		else this.pendingBreakpoints.set(pass, lines);
-
-		// Verified means "the engine has been told about it". Unlike the replay
-		// session we cannot say in advance whether the rule will fire -- that is
-		// the whole point of running live.
-		response.body = {
-			breakpoints: lines.map((line) => {
-				const bp = new Breakpoint(true, line) as DebugProtocol.Breakpoint;
-				bp.id = this.breakpointSeq++;
+		// Move each breakpoint onto the head of the rule that contains it.
+		//
+		// A rule spans several lines and the eye lands on whichever one names the
+		// thing being looked for -- an element, usually, not the `_name <-`. But
+		// the engine identifies a rule by its head line and reports no other, so
+		// a breakpoint anywhere else used to be accepted and then never fire.
+		const effective: number[] = [];
+		const reported = lines.map((line) => {
+			const head = this.ruleHeadFor(sourcePath, line);
+			const bp = new Breakpoint(true, head ?? line) as DebugProtocol.Breakpoint;
+			bp.id = this.breakpointSeq++;
+			if (head === undefined) {
+				// Outside every rule: an @CODE, @POST or @DECL region. The engine
+				// stops at rule attempts and pass boundaries, so there is nothing
+				// there to stop on -- say so rather than accept it silently.
+				bp.verified = false;
+				bp.message = "Breakpoints outside a rule are not supported yet; " +
+					"the engine stops at rules and pass boundaries.";
 				return bp;
-			}),
-		};
+			}
+			effective.push(head);
+			if (head !== line) bp.message = `Moved to line ${head}, where the rule starts.`;
+			return bp;
+		});
+
+		// Deduped: several breakpoints inside one rule are one stop.
+		const unique = [...new Set(effective)];
+		if (this.launched) await this.client.setBreakpoints(pass, unique);
+		else this.pendingBreakpoints.set(pass, unique);
+
+		response.body = { breakpoints: reported };
 		this.sendResponse(response);
+	}
+
+	// Where each rule in a pass file begins and ends, in 1-based lines.
+	//
+	// Needed because the engine identifies a rule by its HEAD line -- the
+	// `_name <-` -- and that is the only line it ever reports. A breakpoint set
+	// anywhere else inside the rule, which is where the eye naturally goes when
+	// reading `_money <- _det total _prep _money`, was sent through verbatim and
+	// simply never fired.
+	//
+	// Parsed with the same declaredSymbols() the outline and go-to-definition
+	// use, so the debugger's idea of where a rule starts and ends cannot drift
+	// from the editor's.
+	private rulesIn(sourcePath: string): Array<{ head: number; from: number; to: number }> {
+		const key = path.resolve(sourcePath).toLowerCase();
+		const cached = this.ruleSpans.get(key);
+		if (cached) return cached;
+
+		const spans: Array<{ head: number; from: number; to: number }> = [];
+		try {
+			const text = fs.readFileSync(sourcePath, "utf8");
+			// One line table for the file, rather than counting newlines per symbol.
+			const starts: number[] = [0];
+			for (let i = 0; i < text.length; i++) {
+				if (text[i] === "\n") starts.push(i + 1);
+			}
+			const lineOf = (offset: number): number => {
+				let lo = 0, hi = starts.length - 1;
+				while (lo < hi) {
+					const mid = (lo + hi + 1) >> 1;
+					if (starts[mid] <= offset) lo = mid;
+					else hi = mid - 1;
+				}
+				return lo + 1; // the engine and the editor both count from 1
+			};
+			for (const sym of declaredSymbols(text)) {
+				if (sym.kind !== "rule") continue;
+				spans.push({
+					head: lineOf(sym.selStart),
+					from: lineOf(sym.start),
+					to: lineOf(sym.end),
+				});
+			}
+		} catch {
+			// Unreadable pass file: fall back to sending lines through unchanged.
+		}
+		this.ruleSpans.set(key, spans);
+		return spans;
+	}
+
+	// The head line of the rule containing `line`, or undefined if it falls
+	// outside every rule (an @CODE or @POST region, say).
+	private ruleHeadFor(sourcePath: string, line: number): number | undefined {
+		for (const r of this.rulesIn(sourcePath)) {
+			if (line >= r.from && line <= r.to) return r.head;
+		}
+		return undefined;
 	}
 
 	// ---- execution ----------------------------------------------------------
@@ -430,7 +510,17 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 
 		// Frame 1: the pass. Passes run in sequence rather than calling each
 		// other, so this is the bottom of a genuinely two-deep stack.
-		const passFrame = new StackFrame(2, `Pass ${stop.pass}: ${this.passLabel(stop)}`,
+		//
+		// A pass with no source file is normal, not an error: the tokenizers
+		// (tokenize, dicttokz, chartok ...) are built into the engine and have no
+		// .nlp file to open. Left to itself VSCode renders that as "Unknown
+		// Source", which reads like something failed -- and the very first pass of
+		// most analyzers is a tokenizer, so it is the first thing a user sees.
+		// Saying so in the frame name costs nothing and answers the question.
+		const passName = this.passLabel(stop);
+		const passFrame = new StackFrame(2,
+			source ? `Pass ${stop.pass}: ${passName}`
+				: `Pass ${stop.pass}: ${passName} (built into the engine — no pass file)`,
 			source, stop.line > 0 ? stop.line : 1);
 		if (!source) passFrame.presentationHint = "subtle";
 		frames.push(passFrame);
@@ -461,7 +551,7 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 				new Scope("Variables", this.variableHandles.create({ kind: "vars" }), false),
 				new Scope("Globals G()", this.variableHandles.create({ kind: "globals" }), true),
 				new Scope("Current node", this.variableHandles.create({ kind: "node" }), false),
-				new Scope("Parse tree", this.variableHandles.create({ kind: "tree" }), true),
+				new Scope("Nodes in play", this.variableHandles.create({ kind: "tree" }), false),
 				new Scope("Pass", this.variableHandles.create({ kind: "pass" }), false),
 			],
 		};
@@ -484,16 +574,21 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 					variables = this.ruleVariables(await this.client.rule());
 					break;
 				case "node": {
-					const node = await this.client.node();
-					variables = node ? this.nodeChildren(node) : [];
+					// Deep enough that children expand, and carrying the nodes
+					// that FOLLOW: a rule matches a sequence, so those are the
+					// ones it is about to be tried against.
+					const r = await this.client.node(this.treeDepth, await this.followCount());
+					variables = r.node ? this.currentNodeRows(r.node, r.following) : [];
 					break;
 				}
 				case "tree": {
-					// Fetched several levels deep in one go, because a handle
-					// carries the subtree it arrived with: at depth 1 every child
-					// row expanded to "(N children)" and there was no way to go
-					// further, which also meant node attributes were never
-					// reachable. treeDepth bounds the cost.
+					variables = await this.ruleRegionRows();
+					break;
+				}
+				case "wholeTree": {
+					// The document from _ROOT, kept reachable but no longer the
+					// default: at a rule stop it is thousands of nodes of which a
+					// handful are relevant.
 					const tree = await this.client.tree(this.treeDepth);
 					variables = tree ? [this.nodeVariable(tree)] : [];
 					break;
@@ -609,6 +704,11 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 			this.plain("builds", rule.builds ?? "(nothing)"),
 			this.plain("elements", rule.elements.map((e) => e.name).join(" ") || "(none)"),
 		];
+		// Which node the rule is being tried at, and the text under it. The rule
+		// and the text it is being matched against belong on the same screen.
+		if (stop?.node) {
+			out.push(this.plain("matching at", stop.node));
+		}
 		// Pair the element list with how far the match got, so the two read
 		// together: "3 elements, failed after 2" points at element 3.
 		if (stop?.reason === "failed" && stop.eltsMatched !== undefined) {
@@ -649,10 +749,108 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	}
 
 	private spanText(node: EngineNode): string {
-		if (!this.inputText.length || node.ustart < 0 || node.uend < node.ustart) return "";
-		const raw = this.inputText.slice(node.ustart, node.uend + 1).replace(/\s+/g, " ").trim();
+		// The engine sends the text it actually spans. Slicing the input file with
+		// start/end is only a fallback for an older engine: those offsets index
+		// the engine's buffer, whose line endings are normalised, so on a CRLF
+		// file every node past the first line came out shifted -- a "(" rendered
+		// as "g", a ")" as "R".
+		let raw: string;
+		if (typeof node.text === "string") {
+			raw = node.text;
+		} else if (this.inputText.length && node.ustart >= 0 && node.uend >= node.ustart) {
+			raw = this.inputText.slice(node.ustart, node.uend + 1);
+		} else {
+			return "";
+		}
+		raw = raw.replace(/\s+/g, " ").trim();
 		if (!raw.length) return '""';
 		return JSON.stringify(raw.length > 60 ? raw.slice(0, 57) + "..." : raw);
+	}
+
+	// How many nodes beyond the current one are worth fetching: enough to cover
+	// the rule being tried, with a little slack so the sequence reads in context.
+	// Falls back to a handful at a pass boundary, where there is no rule.
+	private async followCount(): Promise<number> {
+		// One extra round trip to an engine that is already stopped, which costs
+		// nothing and avoids caching a value that goes stale at every step.
+		const rule = await this.client.rule();
+		const n = rule?.elements.length ?? 0;
+		return n > 0 ? n + 2 : 6;
+	}
+
+	// The nodes a rule is actually about, rather than the whole document.
+	//
+	// Rooting this at _ROOT meant thousands of nodes of which a handful mattered,
+	// and the ones the rule is being tried against were reachable only by walking
+	// down from the top. On a MATCH the answer is exact: the collect list is the
+	// nodes the rule took. On an attempt the rule has taken nothing yet, so the
+	// candidates are the current node and the ones after it.
+	private async ruleRegionRows(): Promise<DebugProtocol.Variable[]> {
+		const out: DebugProtocol.Variable[] = [];
+
+		const collected = await this.client.collect();
+		if (collected && collected.length) {
+			out.push(this.plain("(matched)", `${collected.length} element${collected.length === 1 ? "" : "s"}`));
+			for (const e of collected) {
+				out.push({
+					name: `N(${e.ord})`,
+					value: e.single ? this.describeNode(e.node) : `${e.node.name} … a range of nodes`,
+					variablesReference: this.variableHandles.create({ kind: "engineNode", node: e.node }),
+				});
+			}
+		} else {
+			const r = await this.client.node(this.treeDepth, await this.followCount());
+			if (r.node) {
+				out.push(this.plain("(being tried at)", ""));
+				out.push(this.nodeVariable(r.node));
+				if (r.following.length) {
+					out.push(this.plain("(nodes after it)", ""));
+					for (const n of r.following) out.push(this.nodeVariable(n));
+				}
+			}
+		}
+
+		// Never take the whole tree away -- sometimes the context above the rule
+		// is exactly what is wanted.
+		out.push({
+			name: "(whole document tree)",
+			value: "",
+			variablesReference: this.variableHandles.create({ kind: "wholeTree" }),
+		});
+		return out;
+	}
+
+	// The current node, described before its contents.
+	//
+	// This scope used to list only the node's children and attributes, so the
+	// node itself -- crucially the TEXT it covers -- never appeared anywhere.
+	// While a rule is being tried, that text is what the rule is being matched
+	// against, which is the single most useful thing on the screen.
+	private currentNodeRows(node: EngineNode, following: EngineNode[] = []): DebugProtocol.Variable[] {
+		const out: DebugProtocol.Variable[] = [
+			this.plain("node", node.name),
+			this.plain("text", this.spanText(node) || "(no text)"),
+			this.plain("type", node.type),
+			this.plain("span", `${node.start}-${node.end}`),
+		];
+		if (node.passNum > 0) {
+			out.push(this.plain("built by", `pass ${node.passNum} line ${node.ruleLine}`));
+		}
+		const rows = out.concat(this.nodeChildren(node));
+
+		// The nodes that come after this one, in order. A rule matches a
+		// sequence, so reading forward from the current node is the natural
+		// movement -- and there was no way to do it short of walking the whole
+		// tree down from the root.
+		if (following.length) {
+			rows.push(this.plain("(next nodes)", `${following.length} after this one`));
+			following.forEach((n, i) => {
+				const row = this.nodeVariable(n);
+				row.name = `+${i + 1} ${n.name}`;
+				rows.push(row);
+			});
+		}
+		return rows;
 	}
 
 	private nodeChildren(node: EngineNode): DebugProtocol.Variable[] {

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -27,7 +27,7 @@
 import {
 	LoggingDebugSession, InitializedEvent, TerminatedEvent, StoppedEvent,
 	OutputEvent, Thread, StackFrame, Scope, Source, Handles,
-	Breakpoint,
+	Breakpoint, BreakpointEvent,
 } from "@vscode/debugadapter";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import * as fs from "fs";
@@ -46,6 +46,13 @@ const THREAD_ID = 1;
 // serve them. Naming the version is the point: "(none)" would look like an
 // analyzer with no variables, which is a very different problem to chase.
 const OLD_ENGINE = "needs NLP++ engine 3.10.0 or later — run the updater";
+
+// Same idea for breakpoints outside a rule. Said in full rather than as
+// "unsupported", because the fix is a version away and the alternative reading
+// -- that NLP++ cannot be stepped through statement by statement -- is wrong.
+const OLD_ENGINE_MESSAGE =
+	"Breakpoints in @CODE, @POST and @DECL need NLP++ engine 3.12.0 or later — " +
+	"run the updater. This engine stops at rules and pass boundaries.";
 
 export interface NlpLiveLaunchArguments extends DebugProtocol.LaunchRequestArguments {
 	analyzer: string;      // analyzer directory (holds spec/ and input/)
@@ -114,6 +121,18 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	private treeDepth = 5;
 	private breakpointSeq = 1;
 
+	/**
+	 * Whether this engine stops on statements, from its capabilities reply.
+	 * Undefined until the connection is up -- breakpoints arrive during
+	 * configuration, before the engine is even started, so a statement
+	 * breakpoint is accepted optimistically and withdrawn afterwards if the
+	 * engine turns out to be older. Withdrawing one is a `breakpoint` event;
+	 * silently never firing is not.
+	 */
+	private statementsSupported: boolean | undefined;
+	/** Statement breakpoints reported as verified, in case they must be withdrawn. */
+	private statementBreakpoints: DebugProtocol.Breakpoint[] = [];
+
 	public constructor() {
 		super("nlp-live-debug.log");
 		this.setDebuggerLinesStartAt1(true);
@@ -181,8 +200,14 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 
 		this.emit_(`Debugging ${path.basename(args.analyzer)} on ${path.basename(args.input)} ` +
 			`(engine port ${port}).\n`);
-		this.emit_("Step Over = next rule tried, Step Into = next rule that matches, " +
-			"Step Out = next pass.\n\n");
+		this.emit_("At a rule: Step Over = next rule tried, Step Into = next rule that " +
+			"matches, Step Out = next pass.\n");
+		this.emit_("In an @CODE, @POST or @DECL body the same buttons step by statement, " +
+			"and Step Into enters a function.\n\n");
+
+		// What this engine can do, before anything depends on it.
+		this.statementsSupported = (await this.client.capabilities()).includes("statements");
+		if (!this.statementsSupported) this.withdrawStatementBreakpoints();
 
 		this.launched = true;
 		if (args.stopOnRuleFailure) await this.client.stopOnFailure(true);
@@ -245,6 +270,10 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 
 		this.emit_(`Attached to the engine on port ${args.port}.
 `);
+		// What this engine can do, before anything depends on it.
+		this.statementsSupported = (await this.client.capabilities()).includes("statements");
+		if (!this.statementsSupported) this.withdrawStatementBreakpoints();
+
 		this.launched = true;
 		if (args.stopOnRuleFailure) await this.client.stopOnFailure(true);
 		for (const [pass, lines] of this.pendingBreakpoints) {
@@ -325,12 +354,19 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 			const bp = new Breakpoint(true, head ?? line) as DebugProtocol.Breakpoint;
 			bp.id = this.breakpointSeq++;
 			if (head === undefined) {
-				// Outside every rule: an @CODE, @POST or @DECL region. The engine
-				// stops at rule attempts and pass boundaries, so there is nothing
-				// there to stop on -- say so rather than accept it silently.
-				bp.verified = false;
-				bp.message = "Breakpoints outside a rule are not supported yet; " +
-					"the engine stops at rules and pass boundaries.";
+				// Outside every rule: an @CODE, @POST or @DECL region. Those are
+				// ordinary imperative code and the engine stops on each statement
+				// in them, so the line goes through exactly as written -- no
+				// snapping, because here the line the user clicked IS the unit
+				// that runs.
+				if (this.statementsSupported === false) {
+					bp.verified = false;
+					bp.message = OLD_ENGINE_MESSAGE;
+					return bp;
+				}
+				// The engine may not be up yet; see statementsSupported.
+				effective.push(line);
+				this.statementBreakpoints.push(bp);
 				return bp;
 			}
 			effective.push(head);
@@ -345,6 +381,25 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 
 		response.body = { breakpoints: reported };
 		this.sendResponse(response);
+	}
+
+	/**
+	 * Tell the client a statement breakpoint cannot be honoured after all.
+	 *
+	 * Only reachable against an engine older than 3.12: they were accepted while
+	 * the connection was still coming up. A breakpoint that quietly never fires
+	 * is the worst of the three outcomes, so it is withdrawn out loud.
+	 */
+	private withdrawStatementBreakpoints(): void {
+		for (const bp of this.statementBreakpoints) {
+			bp.verified = false;
+			bp.message = OLD_ENGINE_MESSAGE;
+			this.sendEvent(new BreakpointEvent("changed", bp));
+		}
+		if (this.statementBreakpoints.length) {
+			this.emit_(OLD_ENGINE_MESSAGE + "\n");
+			this.statementBreakpoints = [];
+		}
 	}
 
 	// Where each rule in a pass file begins and ends, in 1-based lines.
@@ -434,19 +489,34 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		void this.resume("continue");
 	}
 
+	// The three step buttons mean different things depending on where the engine
+	// is stopped, because an analyzer has two kinds of execution in it. Among
+	// rules the unit is a rule attempt; inside an @CODE, @POST or @DECL body it
+	// is a statement, and there the buttons should behave the way they do in
+	// every other debugger -- which is exactly what a user stepping through
+	// @POST code expects.
+	//
+	//                    at a rule            in a statement body
+	//   Step Over        next rule tried      next statement, calls run whole
+	//   Step Into        next rule matched    next statement, entering a call
+	//   Step Out         next pass            until this function returns
+	private inStatement(): boolean {
+		return this.currentStop?.statement === true;
+	}
+
 	protected nextRequest(response: DebugProtocol.NextResponse): void {
 		this.sendResponse(response);
-		void this.resume("stepRule");
+		void this.resume(this.inStatement() ? "stepOverStatement" : "stepRule");
 	}
 
 	protected stepInRequest(response: DebugProtocol.StepInResponse): void {
 		this.sendResponse(response);
-		void this.resume("stepMatch");
+		void this.resume(this.inStatement() ? "stepStatement" : "stepMatch");
 	}
 
 	protected stepOutRequest(response: DebugProtocol.StepOutResponse): void {
 		this.sendResponse(response);
-		void this.resume("stepPass");
+		void this.resume(this.inStatement() ? "stepOutStatement" : "stepPass");
 	}
 
 	protected disconnectRequest(
@@ -496,7 +566,14 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		// DAP's stop reason cannot: whether this rule matched or failed, and for a
 		// failure how many elements matched before it gave up -- which is the
 		// thing that says WHERE the rule stopped agreeing with the text.
-		if (stop.line > 0) {
+		if (stop.statement) {
+			// A statement in an @CODE, @POST or @DECL body. The stop is BEFORE
+			// the line runs, which is worth saying: the variables read alongside
+			// it are the ones that line is about to act on, not its result.
+			const where = stop.depth ? ` — ${stop.depth} call${stop.depth === 1 ? "" : "s"} deep` : "";
+			frames.push(new StackFrame(1, `statement at line ${stop.line}${where}`,
+				source, stop.line));
+		} else if (stop.line > 0) {
 			let label = `rule at line ${stop.line}`;
 			if (stop.reason === "matched") label += " — matched";
 			else if (stop.reason === "failed") {


### PR DESCRIPTION
Three things asked for together, because they are the same gap seen from two sides: a breakpoint that does not fire where the eye put it.

### 1. A breakpoint anywhere in a rule stops on that rule

The engine identifies a rule by its head line -- the `_name <-` -- and reports no other. A breakpoint set on `_det [s]` inside

```
_money <-
    _det [s]        ### (1)
    total [s]       ### (2)
```

was accepted and then never fired. The eye lands on whichever line names the thing you are looking for, which is rarely the head. Breakpoints now move to the head of the containing rule and say so (`Moved to line 35, where the rule starts.`). Rule extents come from the same parser the outline and go-to-definition use, so the debugger's idea of where a rule begins and ends cannot drift from the editor's.

### 2 & 3. Breakpoints in `@POST`, `@CODE` and `@DECL`

Those regions are ordinary imperative code. Engine 3.12.0 ([nlp-engine#732](https://github.com/VisualText/nlp-engine/pull/732)) stops on each statement in them, so a breakpoint outside a rule now goes through on the line it was set on -- no snapping, because there the line clicked *is* the unit that runs. The stop is reported **before** that line executes, which is what makes the variables beside it worth reading: they are the state the line is about to act on, not its result.

The step buttons follow where you are:

|             | at a rule          | in a statement body               |
| ----------- | ------------------ | --------------------------------- |
| Step Over   | next rule tried    | next statement, calls run whole   |
| Step Into   | next rule matched  | next statement, entering a call   |
| Step Out    | next pass          | until this function returns       |

Step Into entering a call is the interesting one. A stop inside a `@DECL` body lands in the file the function was *written* in rather than the caller's, and the function's parameters read back as `L()` locals while the globals it changes update as you step.

### Why the engine is asked what it supports

The extension pairs with whatever engine the user has installed, and a breakpoint is set long before anything could be tried and found missing. A version string is a second thing to keep in step; the new `capabilities` command cannot drift. Breakpoints arrive during configuration, before the engine is even started, so a statement breakpoint is accepted optimistically and **withdrawn** with a `breakpoint` event if the engine turns out to be older -- accepted-then-never-fires is the worst of the three outcomes.

### Verification

- debug client tests 68 passed (capabilities both ways, a statement stop's shape, each statement step command going out verbatim)
- integration tests 27 passed
- lint clean
- end to end against the `corporate` analyzer:

```
  requested -> line 30  verified=true
  requested -> line 31  verified=true

first stop:      statement at line 30   moneyAttributes.nlp:30
after Step Over: statement at line 31   moneyAttributes.nlp:31
```

Version **3.16.0**. Needs NLP++ engine 3.12.0 for (2) and (3); (1) works against any engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
