### PR TITLE
Stop on entry at the first rule, not at the engine's first breath (3.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.16.1
+Starting the debugger lands somewhere worth looking at.
+
+- **The debugger opened on a blank editor and six empty panes.** The engine's first stop is the boundary of pass 1, which in almost every analyzer is a tokenizer built into the engine: no pass file to open, no rule, no node, and no variables set yet, because nothing you wrote has run. The only way to find that out was to press Step and watch it fill in. "Stop on entry" now means the first thing the ANALYZER does -- it runs on to the first rule tried, so the pass file opens and the rule, the node, the tree and the globals are all there. Breakpoints are still honoured on the way, including one in an `@CODE` that runs before any rule, which is what makes it safe to do unasked.
+
 ### 3.16.0
 Breakpoints in `@CODE`, `@POST` and `@DECL`, and stepping through them statement by statement.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.16.0",
+    "version": "3.16.1",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -227,8 +227,27 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 			this.sendEvent(new TerminatedEvent());
 			return;
 		}
-		if (args.stopOnEntry) this.announceStop();
-		else await this.resume("continue");
+		if (!args.stopOnEntry) {
+			await this.resume("continue");
+			return;
+		}
+
+		// "Stop on entry" means the first thing the ANALYZER does, not the first
+		// thing the engine does.
+		//
+		// The engine's first stop is the boundary of pass 1, which in almost
+		// every analyzer is a tokenizer built into the engine: no pass file to
+		// open, no rule, no node, and no variables set yet, because nothing the
+		// user wrote has run. A debugger that opens on a blank editor and six
+		// empty panes reads as one that failed to start, and the only way to
+		// find that out is to press Step and watch it fill in.
+		//
+		// So run on to the first rule the analyzer tries. Breakpoints are still
+		// honoured on the way -- the engine checks those before it consults the
+		// step mode -- so a breakpoint in an @CODE that runs before any rule
+		// still wins, which is what makes this safe to do unasked.
+		if (this.currentStop?.reason === "passStart") await this.resume("stepRule");
+		else this.announceStop();
 	}
 
 	// Attach to an engine already listening on `port`. Everything after the


### PR DESCRIPTION
Reported from real use: starting the debugger eventually breaks, but with nothing in the variables, attributes or tree panes and no file open. Stepping once fills all of it in.

### What was there

The engine's first stop is the boundary of pass 1, and in almost every analyzer pass 1 is a tokenizer **built into the engine**:

```
frame:  Pass 1: tokenize (built into the engine — no pass file)
source: (none)
Rule            (no rule) stopped at a pass boundary
Current node    0 rows
Globals G()     (none)
```

Not a display fault — there is genuinely nothing there: no pass file to open, no rule, no node, and no globals because nothing the user wrote has run yet. But a debugger that opens on a blank editor and six empty panes reads as one that failed to start, and the only way to learn otherwise is to press Step and watch it fill in.

### What is there now

"Stop on entry" means the first thing the **analyzer** does, the way other debuggers stop at the top of `main` rather than inside the C runtime:

```
frame:  rule at line 13  [LOS]
source: join.nlp:13
Rule            line=13 | builds=_num | elements=_xNUM . _xNUM
Current node    node=LOS | text="LOS" | type=alpha
Nodes in play   (being tried at) | LOS="LOS" (alpha) | (nodes after it)
Globals G()     corporate=concept:"corporate" | parse=... | companies=...
```

Breakpoints are still honoured on the way — the engine checks those before it consults the step mode, so a breakpoint in an `@CODE` that runs before any rule still wins. That is what makes this safe to do without being asked.

Attach is deliberately left alone: an engine someone attached to is already wherever they wanted it.

### Verification

- measured before and after against the `corporate` analyzer, output above
- debug client tests 68 passed, integration tests 27 passed, lint clean

Not covered by an automated test: the DAP session layer has no harness, only the engine client does. Worth building — four of the recent bugs have been in that layer — but it is a bigger piece than this fix.

Version **3.16.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
