### PR TITLE
Starting with a breakpoint set takes you to the breakpoint (3.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.16.2
+Starting with a breakpoint set takes you to the breakpoint.
+
+- **The session always stopped somewhere else first.** Every launch stopped on entry, so a user who had set one breakpoint and pressed Start landed on an unrelated rule in a file they were not looking at, and had to press Continue to get where they had said they wanted to be -- which reads as the breakpoint having been ignored. Starting now runs to your breakpoints when you have any. With none, it still stops at the first rule, so the session opens on something rather than on nothing.
+
 ### 3.16.1
 Starting the debugger lands somewhere worth looking at.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.16.1",
+    "version": "3.16.2",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -132,6 +132,12 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	private statementsSupported: boolean | undefined;
 	/** Statement breakpoints reported as verified, in case they must be withdrawn. */
 	private statementBreakpoints: DebugProtocol.Breakpoint[] = [];
+	/**
+	 * How many breakpoints stand in each source file. Kept because what should
+	 * happen when the session starts depends on whether the user set any: with
+	 * breakpoints, starting means run to them.
+	 */
+	private breakpointsPerSource = new Map<string, number>();
 
 	public constructor() {
 		super("nlp-live-debug.log");
@@ -242,10 +248,17 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		// empty panes reads as one that failed to start, and the only way to
 		// find that out is to press Step and watch it fill in.
 		//
-		// So run on to the first rule the analyzer tries. Breakpoints are still
-		// honoured on the way -- the engine checks those before it consults the
-		// step mode -- so a breakpoint in an @CODE that runs before any rule
-		// still wins, which is what makes this safe to do unasked.
+		// A user who has set a breakpoint has already said where they want to
+		// stop, and pressing Start should take them there. Stopping somewhere
+		// else first is a step they did not ask for, in a file they were not
+		// looking at, and it reads as the breakpoint having been ignored.
+		if (this.anyBreakpoints()) {
+			await this.resume("continue");
+			return;
+		}
+
+		// With no breakpoints, run on to the first rule the analyzer tries, so
+		// the session opens on something rather than on nothing.
 		if (this.currentStop?.reason === "passStart") await this.resume("stepRule");
 		else this.announceStop();
 	}
@@ -395,11 +408,17 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 
 		// Deduped: several breakpoints inside one rule are one stop.
 		const unique = [...new Set(effective)];
+		this.breakpointsPerSource.set(path.resolve(sourcePath).toLowerCase(), unique.length);
 		if (this.launched) await this.client.setBreakpoints(pass, unique);
 		else this.pendingBreakpoints.set(pass, unique);
 
 		response.body = { breakpoints: reported };
 		this.sendResponse(response);
+	}
+
+	private anyBreakpoints(): boolean {
+		for (const n of this.breakpointsPerSource.values()) if (n > 0) return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Reported from real use, with one breakpoint set in an `@CODE` in the **last** pass of a 17-pass analyzer: *"it should run and stop at this only breakpoint."*

It did not. Every launch stopped on entry, so the session opened on an unrelated rule five passes earlier, in a file the user was not looking at, and reaching the breakpoint took a Continue they should not have had to press. From the outside that looks like a breakpoint being ignored.

### After

A user who has set a breakpoint has already said where they want to stop. Starting runs there:

```
breakpoint output.nlp:11 -> verified
FIRST STOP:  statement at line 11   output.nlp:11
```

With no breakpoints set, the 3.16.1 entry behaviour stands — stop at the first rule the analyzer tries, so the session opens on something rather than on nothing:

```
FIRST STOP:  rule at line 13  [LOS]   join.nlp:13
```

### Verification

Both paths measured by driving the debug adapter against real analyzers (`date-time` for the breakpoint path, `corporate` for the no-breakpoint path). Lint clean, 68 debug client tests, 27 integration tests.

Same caveat as #1196: the DAP session layer still has no test harness, so this is verified by hand rather than pinned. That harness is the next thing worth building — this is the third bug in a row in that layer.

Version **3.16.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
