### PR TITLE
Draw the calls that led here in the Call Stack (3.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 3.17.0
+The Call Stack shows the calls that led here.
+
+- **It said "4 calls deep" and listed nothing else.** Stepping down through several functions left no way back out by eye and no way to see the line any of the calls was made from. The pane now draws a frame per call -- each named for its function and opening at the line the call was *written* on -- with the `@CODE`, `@POST` or `@DECL` statement that began it at the bottom:
+
+  ```
+  inner2()               numbers.nlp:29     <- where execution is
+  outer2()               numbers.nlp:33     <- called inner2 from 33
+  blockShapes()          numbers.nlp:61     <- called outer2 from 61
+  statement at line 87   numbers.nlp:87     <- the @POST that started it
+  Pass 2: numbers        numbers.nlp:29
+  ```
+
+- Needs NLP++ engine **3.13.0**. Against an older one the frame still says how deep it is, since that is all there is to say, and the extension does not ask for a stack it knows the engine cannot give.
+- Every pane still reads the engine's current state, so selecting an outer frame does not rewind the variables to that call -- the engine keeps one set of locals, the live one.
+
 ### 3.16.3
 Tests for the debugger's DAP layer, and they now run in CI.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.16.3",
+    "version": "3.17.0",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/engineClient.ts
+++ b/src/debug/engineClient.ts
@@ -46,6 +46,16 @@ export interface EngineStop {
 	depth?: number;
 }
 
+/**
+ * One live call, from the engine's `stack`. `pass` and `line` are the CALLER's
+ * -- where the call was written -- which is what makes a frame clickable.
+ */
+export interface EngineCall {
+	name: string;
+	pass: number;
+	line: number;
+}
+
 // One NLP++ variable. The engine renders values with the same call the .tree
 // dumps use, so a value reads identically in the debugger and in a dump.
 export interface EngineVar {
@@ -290,6 +300,18 @@ export class EngineClient {
 	async capabilities(): Promise<string[]> {
 		const r = await this.request("capabilities");
 		return r?.ok && Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [];
+	}
+
+	/**
+	 * The calls that led to where the engine is stopped, outermost first.
+	 *
+	 * Empty at the outermost level, and empty from an engine older than 3.13.0,
+	 * which answers "unknown command" -- in both cases there are no call frames
+	 * to draw, which is the same thing as far as a caller is concerned.
+	 */
+	async stack(): Promise<EngineCall[]> {
+		const r = await this.request("stack");
+		return r?.ok && Array.isArray(r.calls) ? (r.calls as EngineCall[]) : [];
 	}
 
 	stopOnFailure(value: boolean): Promise<void> {

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -163,6 +163,8 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 	 * silently never firing is not.
 	 */
 	private statementsSupported: boolean | undefined;
+	/** Whether this engine can say which calls led to where it is stopped. */
+	private callStackSupported = false;
 	/** Statement breakpoints reported as verified, in case they must be withdrawn. */
 	private statementBreakpoints: DebugProtocol.Breakpoint[] = [];
 	/**
@@ -245,7 +247,9 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 			"and Step Into enters a function.\n\n");
 
 		// What this engine can do, before anything depends on it.
-		this.statementsSupported = (await this.client.capabilities()).includes("statements");
+		const caps = await this.client.capabilities();
+		this.statementsSupported = caps.includes("statements");
+		this.callStackSupported = caps.includes("callStack");
 		if (!this.statementsSupported) this.withdrawStatementBreakpoints();
 
 		this.launched = true;
@@ -314,7 +318,9 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		this.emit_(`Attached to the engine on port ${args.port}.
 `);
 		// What this engine can do, before anything depends on it.
-		this.statementsSupported = (await this.client.capabilities()).includes("statements");
+		const caps = await this.client.capabilities();
+		this.statementsSupported = caps.includes("statements");
+		this.callStackSupported = caps.includes("callStack");
 		if (!this.statementsSupported) this.withdrawStatementBreakpoints();
 
 		this.launched = true;
@@ -599,7 +605,9 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		this.sendResponse(response);
 	}
 
-	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse): void {
+	protected async stackTraceRequest(
+		response: DebugProtocol.StackTraceResponse,
+	): Promise<void> {
 		const stop = this.currentStop;
 		if (!stop) {
 			response.body = { stackFrames: [], totalFrames: 0 };
@@ -611,6 +619,15 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		const source = sourceFile ? new Source(path.basename(sourceFile), sourceFile) : undefined;
 		const frames: DebugProtocol.StackFrame[] = [];
 
+		// Ids only have to be distinct; every scope reads the engine's CURRENT
+		// state, so which frame is selected does not change what a pane shows.
+		let frameId = 1;
+		const frameFor = (name: string, pass: number, line: number): DebugProtocol.StackFrame => {
+			const file = this.sourceForPass(pass);
+			return new StackFrame(frameId++, name,
+				file ? new Source(path.basename(file), file) : undefined, line);
+		};
+
 		// Frame 0: the rule attempt, when we are inside one. The name carries what
 		// DAP's stop reason cannot: whether this rule matched or failed, and for a
 		// failure how many elements matched before it gave up -- which is the
@@ -619,9 +636,36 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 			// A statement in an @CODE, @POST or @DECL body. The stop is BEFORE
 			// the line runs, which is worth saying: the variables read alongside
 			// it are the ones that line is about to act on, not its result.
-			const where = stop.depth ? ` — ${stop.depth} call${stop.depth === 1 ? "" : "s"} deep` : "";
-			frames.push(new StackFrame(1, `statement at line ${stop.line}${where}`,
-				source, stop.line));
+			//
+			// Inside a call, the frames are the calls that led here. Each one
+			// names the function and opens at the line the call was written on,
+			// so a user who stepped down three levels can climb back by eye --
+			// "4 calls deep" told them how far down they were and nothing about
+			// the way back.
+			const calls = (stop.depth ?? 0) > 0 && this.callStackSupported
+				? await this.client.stack()
+				: [];
+
+			if (calls.length) {
+				// Innermost: the function being executed, at the line we stopped on.
+				frames.push(frameFor(`${calls[calls.length - 1].name}()`, stop.pass, stop.line));
+				// Each caller in turn, shown at the line it made its call from.
+				for (let i = calls.length - 1; i >= 1; i--) {
+					frames.push(frameFor(`${calls[i - 1].name}()`, calls[i].pass, calls[i].line));
+				}
+				// The statement in the @CODE, @POST or @DECL that started it all.
+				frames.push(frameFor(`statement at line ${calls[0].line}`,
+					calls[0].pass, calls[0].line));
+			} else {
+				// At the outermost level, or against an engine that cannot say
+				// how it got here -- in which case the depth is still worth
+				// showing, since it is all there is.
+				const where = stop.depth
+					? ` — ${stop.depth} call${stop.depth === 1 ? "" : "s"} deep`
+					: "";
+				frames.push(frameFor(`statement at line ${stop.line}${where}`,
+					stop.pass, stop.line));
+			}
 		} else if (stop.line > 0) {
 			let label = `rule at line ${stop.line}`;
 			if (stop.reason === "matched") label += " — matched";
@@ -631,7 +675,7 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 					: " — failed";
 			}
 			if (stop.node) label += `  [${stop.node}]`;
-			frames.push(new StackFrame(1, label, source, stop.line));
+			frames.push(frameFor(label, stop.pass, stop.line));
 		}
 
 		// Frame 1: the pass. Passes run in sequence rather than calling each
@@ -644,7 +688,7 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 		// most analyzers is a tokenizer, so it is the first thing a user sees.
 		// Saying so in the frame name costs nothing and answers the question.
 		const passName = this.passLabel(stop);
-		const passFrame = new StackFrame(2,
+		const passFrame = new StackFrame(frameId++,
 			source ? `Pass ${stop.pass}: ${passName}`
 				: `Pass ${stop.pass}: ${passName} (built into the engine — no pass file)`,
 			source, stop.line > 0 ? stop.line : 1);

--- a/src/debug/sessionTest.ts
+++ b/src/debug/sessionTest.ts
@@ -398,6 +398,58 @@ async function main(): Promise<void> {
 		await fake.close();
 	}
 
+	// ---- the calls that led here become frames ------------------------------
+	// A depth number said "you are four calls down" and nothing about the way
+	// back. Each frame names a function and opens at the line its call was
+	// WRITTEN on, so stepping down several levels can be climbed back by eye.
+	{
+		const fake = await fakeEngine({
+			capabilities: { capabilities: ["statements", "callStack"] },
+			stack: { calls: [
+				{ name: "outer", pass: PASS_OF_MONEY, line: 6 },
+				{ name: "middle", pass: PASS_OF_MONEY, line: 10 },
+				{ name: "deepest", pass: PASS_OF_MONEY, line: 11 },
+			] },
+		});
+		const dap = await attached(fake, analyzer);
+		await stopAt(dap, fake, { reason: "statement", line: 7, statement: true, depth: 3 });
+
+		const st = await dap.send("stackTrace", { threadId: 1 });
+		const shown = st.body.stackFrames.map((f: any) => `${f.name} @${f.line}`);
+		deep("three calls deep draws a frame for each, innermost first", shown, [
+			"deepest() @7",              // where execution actually is
+			"middle() @11",              // it called deepest from line 11
+			"outer() @10",               // it called middle from line 10
+			"statement at line 6 @6",    // the @POST statement that began it
+			`Pass ${PASS_OF_MONEY}: money @7`,
+		]);
+		check("the frames open in the pass file",
+			st.body.stackFrames.every((f: any) => f.source?.name === "money.nlp"),
+			JSON.stringify(st.body.stackFrames.map((f: any) => f.source?.name)));
+		check("frame ids are distinct, or the client cannot tell them apart",
+			new Set(st.body.stackFrames.map((f: any) => f.id)).size
+				=== st.body.stackFrames.length);
+
+		await dap.send("disconnect", { terminateDebuggee: true });
+		await fake.close();
+	}
+	{
+		// An engine that cannot say how it got here. The depth is still worth
+		// showing, because it is all there is -- and asking it for a stack it
+		// does not have must not empty the pane.
+		const fake = await fakeEngine(
+			{ capabilities: { capabilities: ["statements"] } }, ["stack"]);
+		const dap = await attached(fake, analyzer);
+		await stopAt(dap, fake, { reason: "statement", line: 7, statement: true, depth: 3 });
+		const st = await dap.send("stackTrace", { threadId: 1 });
+		check("an engine without a stack still says how deep it is",
+			/3 calls deep/.test(st.body.stackFrames[0].name), st.body.stackFrames[0].name);
+		check("and it does not ask for one",
+			fake.commands().indexOf("stack") < 0, fake.commands().join(","));
+		await dap.send("disconnect", { terminateDebuggee: true });
+		await fake.close();
+	}
+
 	// ---- the step buttons follow where the engine is stopped ----------------
 	// An analyzer has two kinds of execution in it and one set of buttons. At a
 	// rule the unit is a rule; in an @CODE, @POST or @DECL body it is a


### PR DESCRIPTION
Reported from real use: the pane said **"statement at line 537 — 4 calls deep"** and listed nothing else. Stepping down through several functions left no way back out by eye, and no way to see the line any of the calls was made from.

Engine 3.13.0 ([nlp-engine#737](https://github.com/VisualText/nlp-engine/pull/737)) reports each call and the line it was made from, and those become frames — innermost first, each named for its function and opening at the line the call was *written* on, with the statement that began it all at the bottom:

```
inner2()               numbers.nlp:29     <- where execution is
outer2()               numbers.nlp:33     <- called inner2 from 33
blockShapes()          numbers.nlp:61     <- called outer2 from 61
statement at line 87   numbers.nlp:87     <- the @POST that started it
Pass 2: numbers        numbers.nlp:29
```

Measured end to end by driving the debug adapter against a real engine; that block is its output.

Against an engine that cannot answer, the frame still says how deep it is — that is all there is to say — and the extension does not ask for a stack it knows will come back as an error. The capability is asked for, not inferred from a version.

### What this does not do

Selecting an outer frame does **not** rewind the panes to that call. The engine keeps one set of locals, the live one, so every scope reads the current state whichever frame is selected. Frame ids are therefore only required to be distinct, which the tests check, because two frames sharing an id is the kind of thing a client resolves by quietly picking one.

### Tests

Five more session assertions: the frames for a three-deep stack in order, that they open in the pass file, that the ids are distinct, and that an older engine falls back to the depth **without being asked for a stack**. 44 in that suite, 68 in the client suite, 27 integration, lint clean.

Version **3.17.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
