### PR TITLE
Version 4: NLP++ is debuggable (4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 4.0.0
+Version 4: NLP++ is debuggable.
+
+- **The name for what 3.13 through 3.17 built.** No new features in this release -- everything it names has shipped and is live. Version 3 was about how you *build, deploy and install* an analyzer: one-click compiled analyzers, cloud builds, npm and pip. Version 4 is about how you *develop and understand* one -- a debugger with breakpoints, stepping, variables and a call stack inside a running analyzer, and a language server that any LSP editor can use.
+- **Why it is a major.** Glass-box NLP has always meant you could read the rules and audit the result. What you could not do was watch the decision being made: the only window into a run was a `.tree` dump read afterwards, from which you inferred backwards. Stopping on the line and reading the variables is a different proposition. The glass box now has a door.
+- The version numbers of the extension and the engine are resynchronised at **4.0.0**. Nothing in this line breaks compatibility -- the engine's protocol additions are all additive behind a capability handshake -- so this is a marketing major, not a semver one.
+- Needs NLP++ engine 4.0.0, which ships with the extension.
+
 ### 3.17.0
 The Call Stack shows the calls that led here.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ New to NLP++? The [hello-world video](https://visualtext.org/hello-world-tutoria
 
 ## What's in the Extension
 
-Version 3 has been the biggest chapter yet; [Everything New in Version 3](https://visualtext.org/nlp-in-vs-code-everything-new-in-version-3/) tells the long version. In brief:
+**Version 4 adds a debugger** — breakpoints, stepping, variables and a call stack inside a running analyzer. Version 3, the chapter before it, made analyzers compilable and cloud-buildable; [Everything New in Version 3](https://visualtext.org/nlp-in-vs-code-everything-new-in-version-3/) tells that story. In brief:
 
 ### Write
 
@@ -94,6 +94,25 @@ Version 3 has been the biggest chapter yet; [Everything New in Version 3](https:
 * **Knowledge-base display** at any point in the analyzer sequence
 * A **regression-test runner** with streaming pass/fail, and blessing of new expected output
 * Drag-and-drop editing of the **pass sequence** and the texts being analyzed
+
+### Debug
+
+**New in Version 4.** Press <kbd>F5</kbd> and your analyzer runs under a debugger — not a log, not a dump, a debugger.
+
+<!-- SCREENSHOT: the debugger stopped on a rule, panes populated (Rule, Variables,
+     Globals, Current node, Nodes in play, Call Stack). Suggested file:
+     resources/DebuggerStopped.png -->
+
+* **Breakpoints** on a rule — click any line inside it and it snaps to the rule the engine reports — or on a line of ordinary code inside an `@POST`, `@CODE` or `@DECL`. Start with a breakpoint set and the session runs straight to it.
+* **Stepping that follows where you are.** At a rule: Step Over is the next rule tried, Step Into the next rule that *matches*, Step Out the next pass. Inside a statement body the same three buttons step by statement, and Step Into enters a function call.
+* **Every NLP++ variable kind** at the moment you stopped — `G()` globals, `L()` locals, `S()` suggested, `X()` context, and `N()` matched elements. A stop happens *before* the line runs, so what you read is the state that line is about to act on.
+* **A call stack** through your `@DECL` functions: each frame names its function and opens at the line the call was written on. Stop inside a function and its parameters read back as locals, in the file the function was written in.
+* **Nodes in play** — at a match, exactly the nodes the rule took, labelled `N(1)`, `N(2)`… the same names you would write in the rule. At an attempt, the current node and the candidates after it. The whole document tree is still one row away.
+* **A failed rule says how far it got** before it stopped agreeing with the text, which is usually the entire question. A rule that never fired says that too, instead of leaving you staring at a breakpoint that silently never hits.
+* **Step backwards.** A second *replay* mode walks the per-pass parse trees a finished run already wrote to disk. Because the run is recorded rather than generated as you go, Step Back and reverse-continue cost nothing — walk a node's history in either direction instead of re-running to get back where you were. Its granularity is the pass; the live mode's is the individual rule attempt.
+* **Stop on rule failure** to watch every rule that did not match, and **attach** to an engine someone else started with `nlp ... -DEBUG <port>`.
+
+Needs NLP++ engine 4.0.0, which ships with the extension. The extension asks the engine what it supports rather than guessing from a version, so against an older engine a breakpoint it cannot honour is withdrawn with the reason instead of silently never firing.
 
 ### Ship
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "3.17.0",
+    "version": "4.0.0",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,


### PR DESCRIPTION
The name for what 3.13 through 3.17 built. **No new features** — everything this release names has shipped and is live on the Marketplace.

Version 3 was about how you *build, deploy and install* an analyzer: one-click compiled analyzers, cloud builds, npm and pip. Version 4 is about how you *develop and understand* one — a debugger with breakpoints, stepping, variables and a call stack inside a running analyzer, and a language server any LSP editor can use.

Glass-box NLP has always meant you could read the rules and audit the result. What you could not do was **watch the decision being made** — the only window into a run was a `.tree` dump read afterwards, from which you inferred backwards. Stopping on the line and reading the variables is a different proposition. The glass box now has a door.

### What's in this PR

- **`package.json`** — version to `4.0.0`.
- **`CHANGELOG.md`** — the 4.0.0 entry, which names the line rather than listing features, since the features already shipped.
- **`README.md`** — a new **Debug** section. Full treatment here, because this is the repo where debugging actually lives; the engine's README only points at it. It covers breakpoints on rules and on statements, stepping that changes meaning with where you are, the five variable kinds, the call stack, Nodes in play, what a failed rule reports, and the replay mode that steps *backwards*. One screenshot slot is marked for a debugger capture.

### Version numbering

`4.0.0` is a **marketing major, not a semver one**: nothing in this line breaks compatibility. It also resynchronises with the engine, which had drifted to 3.13 against this repo's 3.17 under a single "Version 3" brand.

### Verification

Lint clean, 68 debug client assertions, 44 debug session assertions.

Pairs with [nlp-engine#738](https://github.com/VisualText/nlp-engine/pull/738), which carries the announcement material in `docs/version-4/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
