### PR TITLE
Make every route into the debugger work without editing anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 4.1.0
+Every route into the debugger works without editing anything.
+
+- **A Debug button on the Text view.** The extension contributed no debug command at all, so the only way into the debugger was VS Code's Run and Debug view -- which an NLP++ author has no particular reason to have ever opened. The button sits beside the file it will run on and needs no `launch.json`: it starts a live session and fills in the analyzer, the text file, the engine and the port from what you have selected.
+- **"Create a launch.json file" seeded the wrong thing.** It wrote replay first, and VS Code runs the first configuration when you press F5. Replay steps the `.tree` dumps of a *previous* run -- it needs one to have happened, its granularity is the pass, and it cannot stop on a breakpoint inside an `@POST`. So setting a breakpoint and pressing the button did nothing at all. Live is now first, in the seeded file and for F5 with no `launch.json`; replay is still there, second.
+- **Attach is seeded too.** Three routes exist and the file offered two.
+- **Nothing in the seed needs editing.** It uses only `${command:nlp.currentAnalyzerDir}` and `${command:nlp.currentTextFile}`, so it tracks whatever is selected and works unedited on every analyzer in the folder.
+- The seed was written twice -- in `package.json` for when the extension has not been activated, and in the provider for when it has. It is one list now, and a test compares the two copies.
+- The README documents all three configurations, with the point that matters first: you do not need one. Two snippet descriptions were stale -- both claimed "Needs engine 3.9.0+", a release that never existed, and the live one described stepping as though it always meant rules, which stopped being true in 3.16.0.
+
 ### 4.0.0
 Version 4: NLP++ is debuggable.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,67 @@ New to NLP++? The [hello-world video](https://visualtext.org/hello-world-tutoria
 
 Needs NLP++ engine 4.0.0, which ships with the extension. The extension asks the engine what it supports rather than guessing from a version, so against an older engine a breakpoint it cannot honour is withdrawn with the reason instead of silently never firing.
 
+#### Configuring it
+
+**You do not need a `launch.json`.** Press <kbd>F5</kbd> with an analyzer open and the extension fills in the analyzer directory, the text file selected in the **Text** view, the bundled engine and a free port. Most people never write one.
+
+Write one when you want to pin a particular analyzer or input, keep several setups side by side, or turn on something that is off by default. VS Code's *Add Configuration…* offers all three shapes as snippets; in full they are:
+
+```jsonc
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Step a finished run's parse trees. Steps BACKWARD as well as forward.
+      "type": "nlpxx",
+      "request": "launch",
+      "name": "NLP++: replay last analyzer run",
+      "mode": "replay",
+      "analyzer": "${command:nlp.currentAnalyzerDir}",
+      "stopOnEntry": true
+    },
+    {
+      // Run the analyzer under the engine's debugger: breakpoints, variables,
+      // call stack. Forward-only -- a live engine cannot un-run.
+      "type": "nlpxx",
+      "request": "launch",
+      "name": "NLP++: debug rules (live)",
+      "mode": "live",
+      "analyzer": "${command:nlp.currentAnalyzerDir}",
+      "input": "${command:nlp.currentTextFile}",
+      "stopOnEntry": true,
+      "stopOnRuleFailure": false
+    },
+    {
+      // Attach to an engine someone already started:
+      //   nlp -ANA <analyzer> -IN <text> -WORK <dir> -DEBUG 9777
+      "type": "nlpxx",
+      "request": "attach",
+      "name": "NLP++: attach to a running engine",
+      "mode": "live",
+      "analyzer": "${command:nlp.currentAnalyzerDir}",
+      "port": 9777
+    }
+  ]
+}
+```
+
+`analyzer` is the only required field for a launch (`analyzer` and `port` for an attach); everything else has a default.
+
+| field | | default |
+| --- | --- | --- |
+| `mode` | `"replay"` or `"live"` | `"replay"` |
+| `analyzer` | the analyzer folder, the one holding `spec/` | the current analyzer |
+| `input` | the text file to run | the file selected in the **Text** view |
+| `stopOnEntry` | stop once there is something to look at. With breakpoints set, the session runs to them instead | `true` |
+| `stopOnRuleFailure` | also stop on every rule that *fails*, not just the ones that match | `false` |
+| `treeDepth` | how many levels of parse tree to fetch at each stop, and so how deep the panes can be expanded | `5` |
+| `enginePath`, `workDir` | override the bundled engine and its working directory | the bundled engine |
+| `port` | the debug port; required when attaching | a free one |
+| `engineArgs` | extra arguments passed through to the engine | none |
+
+The two `${command:…}` values resolve as you'd expect: `nlp.currentAnalyzerDir` is the analyzer you have selected, `nlp.currentTextFile` the text file. Using them keeps one configuration working across every analyzer in the folder.
+
 ### Ship
 
 * **Compile Analyzer and KB** turns an analyzer and its knowledge base into a native shared library (`.dll` / `.so` / `.dylib`) in one command. Two things follow: **faster execution**, and **protection of your NLP++ source** — customers get a library, not your rules.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/package.json
+++ b/package.json
@@ -3637,7 +3637,7 @@
                     },
                     {
                         "label": "NLP++: debug rules (live)",
-                        "description": "Run the analyzer under the engine's rule debugger. Step Over = next rule tried, Step Into = next rule that matches, Step Out = next pass. Needs engine 3.9.0+.",
+                        "description": "Run the analyzer under the engine's rule debugger. At a rule, Step Over is the next rule tried, Step Into the next rule that matches, Step Out the next pass; inside an @CODE, @POST or @DECL body the same buttons step by statement and Step Into enters a function. Needs engine 4.0.0.",
                         "body": {
                             "type": "nlpxx",
                             "request": "launch",
@@ -3650,7 +3650,7 @@
                     },
                     {
                         "label": "NLP++: attach to a running engine",
-                        "description": "Attach to an engine already started with -DEBUG <port>. Needs engine 3.9.0+.",
+                        "description": "Attach to an engine already started with -DEBUG <port>. Needs engine 4.0.0.",
                         "body": {
                             "type": "nlpxx",
                             "request": "attach",

--- a/package.json
+++ b/package.json
@@ -1848,6 +1848,11 @@
                 "icon": "$(beaker)"
             },
             {
+                "command": "textView.debugAnalyzer",
+                "title": "Debug Analyzer on Current File",
+                "icon": "$(debug-alt)"
+            },
+            {
                 "command": "analyzerView.blessRegression",
                 "title": "Bless Regression Goldens (All Files)",
                 "icon": "$(save-all)"
@@ -2222,6 +2227,11 @@
                     "command": "textView.refreshAll",
                     "when": "view == textView",
                     "group": "navigation@4"
+                },
+                {
+                    "command": "textView.debugAnalyzer",
+                    "when": "view == textView",
+                    "group": "navigation@5"
                 },
                 {
                     "command": "helpView.openHome",
@@ -3347,7 +3357,8 @@
                     "when": "view == kbView",
                     "group": "compile"
                 }
-            ]
+            ],
+            "commandPalette": []
         },
         "configuration": {
             "type": "object",
@@ -3607,6 +3618,16 @@
                     {
                         "type": "nlpxx",
                         "request": "launch",
+                        "name": "NLP++: debug rules (live)",
+                        "mode": "live",
+                        "analyzer": "${command:nlp.currentAnalyzerDir}",
+                        "input": "${command:nlp.currentTextFile}",
+                        "stopOnEntry": true,
+                        "stopOnRuleFailure": false
+                    },
+                    {
+                        "type": "nlpxx",
+                        "request": "launch",
                         "name": "NLP++: replay last analyzer run",
                         "mode": "replay",
                         "analyzer": "${command:nlp.currentAnalyzerDir}",
@@ -3614,12 +3635,11 @@
                     },
                     {
                         "type": "nlpxx",
-                        "request": "launch",
-                        "name": "NLP++: debug rules (live)",
+                        "request": "attach",
+                        "name": "NLP++: attach to a running engine",
                         "mode": "live",
                         "analyzer": "${command:nlp.currentAnalyzerDir}",
-                        "input": "${command:nlp.currentTextFile}",
-                        "stopOnEntry": true
+                        "port": 9777
                     }
                 ],
                 "configurationSnippets": [

--- a/src/debug/debugConfig.ts
+++ b/src/debug/debugConfig.ts
@@ -42,30 +42,61 @@ function isUnderInput(p: string): boolean {
 	return lower.includes("/input/");
 }
 
-class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
-	// Offered when the user picks "create a launch.json" for NLP++.
-	provideDebugConfigurations(): vscode.DebugConfiguration[] {
-		return [
-			{
-				type: DEBUG_TYPE,
-				request: "launch",
-				name: "NLP++: replay last analyzer run",
-				mode: "replay",
-				analyzer: "${command:nlp.currentAnalyzerDir}",
-				stopOnEntry: true,
-			},
-			{
-				type: DEBUG_TYPE,
-				request: "launch",
-				name: "NLP++: debug rules (live)",
-				mode: "live",
-				analyzer: "${command:nlp.currentAnalyzerDir}",
-				input: "${command:nlp.currentTextFile}",
-				stopOnEntry: true,
-			},
-		];
-	}
+/**
+ * What "create a launch.json file" writes.
+ *
+ * MUST match `contributes.debuggers[0].initialConfigurations` in
+ * package.json, which VS Code uses for the same purpose when the extension
+ * has not been activated yet. Two copies of one list is how they drift, so an
+ * integration test compares them.
+ */
+export const SEEDED_CONFIGURATIONS: vscode.DebugConfiguration[] = [
+		{
+			type: DEBUG_TYPE,
+			request: "launch",
+			name: "NLP++: debug rules (live)",
+			mode: "live",
+			analyzer: "${command:nlp.currentAnalyzerDir}",
+			input: "${command:nlp.currentTextFile}",
+			stopOnEntry: true,
+			stopOnRuleFailure: false,
+		},
+		{
+			type: DEBUG_TYPE,
+			request: "launch",
+			name: "NLP++: replay last analyzer run",
+			mode: "replay",
+			analyzer: "${command:nlp.currentAnalyzerDir}",
+			stopOnEntry: true,
+		},
+		{
+			type: DEBUG_TYPE,
+			request: "attach",
+			name: "NLP++: attach to a running engine",
+			mode: "live",
+			analyzer: "${command:nlp.currentAnalyzerDir}",
+			port: 9777,
+		},
+	];;
 
+class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
+	/**
+	 * What "create a launch.json file" writes. Kept in step with the
+	 * `initialConfigurations` in package.json, which VS Code uses for the same
+	 * purpose when the extension has not been activated yet.
+	 *
+	 * LIVE COMES FIRST, deliberately: VS Code runs the first configuration in
+	 * the file when the user presses F5, and "debug my analyzer" means the live
+	 * debugger. Seeding replay first handed people a session that reads the
+	 * .tree dumps of a PREVIOUS run -- so it needs one to have happened, steps
+	 * by pass rather than by rule, and cannot stop on a breakpoint in an @POST
+	 * at all. Setting a breakpoint, pressing the button and having nothing
+	 * happen is indistinguishable from the debugger being broken.
+	 */
+	provideDebugConfigurations(): vscode.DebugConfiguration[] {
+		// Copied so an editor writing into the returned objects cannot mutate ours.
+		return SEEDED_CONFIGURATIONS.map((c) => ({ ...c }));
+	}
 	// Called for every launch, including F5 with no launch.json (which arrives as
 	// an empty config). Fill in whatever the user left out from the current
 	// analyzer so the common case needs no configuration at all.
@@ -73,11 +104,15 @@ class NlpConfigurationProvider implements vscode.DebugConfigurationProvider {
 		_folder: vscode.WorkspaceFolder | undefined,
 		config: vscode.DebugConfiguration,
 	): vscode.DebugConfiguration | undefined {
+		// An empty config is F5 with no launch.json. Live, not replay: replay
+		// reads the .tree dumps of a PREVIOUS run, so it needs one to have
+		// happened, and it cannot honour a breakpoint inside an @POST. Someone
+		// who has set a breakpoint and pressed Start means the live debugger.
 		if (!config.type) {
 			config.type = DEBUG_TYPE;
 			config.request = "launch";
-			config.name = "NLP++: replay last analyzer run";
-			config.mode = "replay";
+			config.name = "NLP++: debug rules (live)";
+			config.mode = "live";
 			config.stopOnEntry = true;
 		}
 		// Attaching only makes sense for the live debugger -- there is no running
@@ -186,6 +221,28 @@ export function registerDebugger(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(
 		vscode.debug.registerDebugConfigurationProvider(DEBUG_TYPE, new NlpConfigurationProvider()),
 		vscode.debug.registerDebugAdapterDescriptorFactory(DEBUG_TYPE, new NlpDebugAdapterFactory(ctx)),
+		// One click, no launch.json, no Run and Debug view. Everything this
+		// leaves out -- the analyzer, the text file, the engine, the port -- is
+		// filled in by resolveDebugConfiguration from what is currently
+		// selected, which is the same path F5 takes with no launch.json.
+		//
+		// Worth having even though VS Code offers its own way in: that way is
+		// the Run and Debug view, and an NLP++ author has no reason to have ever
+		// opened it. The Text view is where they already are.
+		vscode.commands.registerCommand("textView.debugAnalyzer", async () => {
+			const started = await vscode.debug.startDebugging(
+				vscode.workspace.workspaceFolders?.[0],
+				{
+					type: DEBUG_TYPE,
+					request: "launch",
+					name: "NLP++: debug rules (live)",
+					mode: "live",
+					stopOnEntry: true,
+				} as vscode.DebugConfiguration);
+			// startDebugging returns false when the resolver refused; it has
+			// already said why, so do not pile a second message on top.
+			return started;
+		}),
 		// Referenced by the generated launch.json above so the config stays
 		// readable rather than hard-coding absolute paths.
 		vscode.commands.registerCommand("nlp.currentAnalyzerDir", () =>

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 import { check, eq, unreachable } from "./harness";
+import { SEEDED_CONFIGURATIONS } from "../../debug/debugConfig";
 
 const EXTENSION_ID = "dehilster.nlp";
 
@@ -372,4 +373,77 @@ export async function crossPassTests(): Promise<void> {
 		touched.includes(declUri.fsPath) && touched.includes(refUri.fsPath),
 		`edits ${touched.length} file(s): ${touched.map((p) => p.split(/[\\/]/).pop()).join(", ") || "none"}`
 	);
+}
+// ---- the debugger a first-time user meets ---------------------------------
+//
+// Every route into the debugger has to work with no editing, because an NLP++
+// author has no reason to know what a launch.json is. There are three of them
+// and they are seeded from two different places, which is exactly how they
+// drift apart:
+//
+//   * "create a launch.json file" writes package.json's initialConfigurations
+//     when the extension has not been activated, and the provider's
+//     provideDebugConfigurations when it has. Those are two copies of one list.
+//   * F5 with no launch.json at all goes through resolveDebugConfiguration.
+//   * The Debug button in the Text view starts a session directly.
+export async function debugSetupTests(): Promise<void> {
+	const pkg = extension()?.packageJSON as any;
+	const dbg = pkg?.contributes?.debuggers?.[0];
+
+	check("an NLP++ debugger is contributed", !!dbg, JSON.stringify(Object.keys(pkg?.contributes ?? {})));
+	if (!dbg) return;
+
+	// Without this VS Code does not know the debugger has anything to do with
+	// the file in front of the user, so it is not offered at all.
+	check("it is associated with the nlp language",
+		Array.isArray(dbg.languages) && dbg.languages.includes("nlp"),
+		JSON.stringify(dbg.languages));
+
+	const seeded = dbg.initialConfigurations as any[];
+	check("creating a launch.json seeds configurations", Array.isArray(seeded) && seeded.length > 0);
+	if (!Array.isArray(seeded) || !seeded.length) return;
+
+	// VS Code runs the FIRST configuration when the user presses F5 after
+	// creating the file. Replay reads the .tree dumps of a previous run, so it
+	// needs one to have happened and cannot stop inside an @POST -- seeding it
+	// first hands a beginner the one mode that looks broken.
+	eq("the first one is the live debugger", seeded[0]?.mode, "live");
+	check("all three routes are seeded", seeded.length === 3,
+		seeded.map((c) => c.name).join(", "));
+	check("attach is among them",
+		seeded.some((c) => c.request === "attach"), seeded.map((c) => c.request).join(", "));
+
+	// The whole point: paste it and go. Anything a user must replace by hand --
+	// a machine-specific path, an empty required field -- fails here.
+	for (const cfg of seeded) {
+		const needsEditing = Object.entries(cfg).filter(([k, v]) =>
+			typeof v === "string" && v.length > 0
+			&& !v.startsWith("${command:")
+			&& (v.includes("<") || v.includes("path/to") || /^[A-Za-z]:[\/]/.test(v) || v.startsWith("/"))
+			&& k !== "name");
+		check(`"${cfg.name}" needs no editing`, needsEditing.length === 0,
+			JSON.stringify(needsEditing));
+		check(`"${cfg.name}" names an analyzer`, typeof cfg.analyzer === "string" && cfg.analyzer.length > 0);
+	}
+
+	// The two seeds are written independently, in TypeScript and in JSON, and
+	// nothing but this makes them agree.
+	const fromCode = SEEDED_CONFIGURATIONS as any[];
+	check("package.json and the provider seed the same configurations",
+		JSON.stringify(fromCode) === JSON.stringify(seeded),
+		`code: ${JSON.stringify(fromCode.map((c) => c.name))} / json: ${JSON.stringify(seeded.map((c) => c.name))}`);
+
+	// The one-click route, for someone who never opens Run and Debug.
+	const commands = await vscode.commands.getCommands(true);
+	check("a Debug command exists outside the Run and Debug view",
+		commands.includes("textView.debugAnalyzer"));
+	const inTitle = (pkg?.contributes?.menus?.["view/title"] ?? []).some(
+		(m: any) => m.command === "textView.debugAnalyzer");
+	check("and it is a button on the Text view", inTitle);
+
+	// The commands the seeded configurations substitute have to exist, or the
+	// file resolves to empty strings and the session dies with a poor message.
+	for (const cmd of ["nlp.currentAnalyzerDir", "nlp.currentTextFile"]) {
+		check(`\${command:${cmd}} resolves`, commands.includes(cmd));
+	}
 }

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -12,7 +12,7 @@ import {
 	configurationTests,
 	providerTests,
 	languageFeatureTests,
-	crossPassTests,
+	crossPassTests, debugSetupTests,
 } from "./extension.test";
 
 export async function run(): Promise<void> {
@@ -24,6 +24,7 @@ export async function run(): Promise<void> {
 		["providers", providerTests],
 		["language features", languageFeatureTests],
 		["cross-pass resolution", crossPassTests],
+		["debugger setup", debugSetupTests],
 	];
 
 	for (const [name, fn] of groups) {


### PR DESCRIPTION
Reported: *"It does not work without a launch.json file. I tried it."* Correct — and worse than it sounds, because the seeding mechanism was already there and was handing beginners the one mode that cannot do what they wanted.

### The default was replay

An empty config — F5 with no `launch.json` — resolved to `mode: "replay"`, and **"create a launch.json file" seeded replay first**, which is the configuration VS Code runs when you then press F5.

Replay steps the `.tree` dumps of a *previous* run: it needs one to have happened, its granularity is the pass, and **it cannot stop on a breakpoint inside an `@POST`**. So the reported experience is exactly right — set a breakpoint, press the button, watch nothing happen.

Both routes now default to **live**, which is what "debug my analyzer" means. Replay stays available and is seeded second.

### Attach was never seeded

Three routes exist; the seeded file offered two.

### There was no button

The extension contributed **no debug command at all**, so the only way in was VS Code's Run and Debug view — which an NLP++ author has no particular reason to have ever opened. There is now a **Debug** button on the Text view, beside the file it will run on. It needs no `launch.json`: it starts a live session and lets the resolver fill in the analyzer, the text file, the engine and the port from what is selected.

### Nothing needs editing

The seed uses only `${command:nlp.currentAnalyzerDir}` and `${command:nlp.currentTextFile}`, so it tracks whatever is selected and works unedited across every analyzer in the folder. A test asserts that — any machine-specific path or `<placeholder>` in a seeded value fails it.

### The seed is one list now

It was written twice — in `package.json` for when the extension has not been activated, and in the provider for when it has. Two copies of one list is how they drift. The provider's is exported and an integration test compares them.

### Also

The README documents all three configurations in full, with the point that matters first: you do not need one. Two snippet descriptions were stale — both claimed *"Needs engine 3.9.0+"* (there is no v3.9.0 release; the first engine with the debug server was v3.10.0, and what this needs now is 4.0.0), and the live one described stepping as though it always meant rules, which stopped being true in 3.16.0.

### Verification

Six new integration assertions in the shape of what a first-time user hits: the debugger is associated with the `nlp` language (without which it is never offered at all), the seed is three configurations with live first, every seeded value is literal or a resolving `${command:}`, both seeds agree, the Debug button exists and is on the Text view, and the two substitution commands are registered.

The suite's existing "all declared commands are registered" check caught the button half-wired before it shipped.

44 integration, 68 debug client, 44 debug session, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
