### PR TITLE
Say when the rule has run out of nodes (4.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the [VSCode NLP++ extension](http://vscode.visualtext.org
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 4.1.2
+"Nodes in play" says when the rule has run out of nodes.
+
+- **A short list looked like a broken one.** Stopped on a rule being tried at the last node of its `@NODES` parent, the pane showed the current node and one node after it and stopped -- which reads as a truncated display, not as the reason the rule is about to fail. It now says so: *"2 nodes here, and the rule needs 3 -- it cannot match at this one."* A rule matches a sequence, so when fewer nodes remain than the rule has elements it cannot match whatever they are.
+- Nothing was wrong with what the pane showed; it was right and unexplained. Reported as "the nodes in play are wrong, there should be a `_date` and a `_time`" on a line that read `Sept 04, 2014.` -- a date and a full stop, with the time on other lines entirely.
+
 ### 4.1.1
 The debug configuration is named for what it does, and is not offered twice.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "NLP",
     "description": "NLP++: the only computer programming language built for NLP — create and visually debug analyzers directly in VS Code.",
     "icon": "resources/NLPppLogo.png",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "license": "MIT",
     "publisher": "dehilster",
     "enableApiProposals": false,

--- a/src/debug/nlpLiveDebugSession.ts
+++ b/src/debug/nlpLiveDebugSession.ts
@@ -969,13 +969,31 @@ export class NlpLiveDebugSession extends LoggingDebugSession {
 				});
 			}
 		} else {
-			const r = await this.client.node(this.treeDepth, await this.followCount());
+			// The rule is fetched here rather than only inside followCount so the
+			// element count can be compared against what is actually there.
+			const rule = await this.client.rule();
+			const needed = rule?.elements.length ?? 0;
+			const r = await this.client.node(this.treeDepth, needed > 0 ? needed + 2 : 6);
 			if (r.node) {
 				out.push(this.plain("(being tried at)", ""));
 				out.push(this.nodeVariable(r.node));
 				if (r.following.length) {
 					out.push(this.plain("(nodes after it)", ""));
 					for (const n of r.following) out.push(this.nodeVariable(n));
+				}
+
+				// Why the list is as short as it is. A rule matches a SEQUENCE, so
+				// when fewer nodes remain than the rule has elements it cannot
+				// match here whatever they are -- it has run off the end of its
+				// @NODES parent. Without saying so, a list holding one node reads
+				// as a truncated display rather than as the reason the rule is
+				// about to fail, and the obvious conclusion is that the debugger
+				// is hiding something.
+				const available = 1 + r.following.length;
+				if (needed > 0 && available < needed) {
+					out.push(this.plain("(end of the run)",
+						`${available} node${available === 1 ? "" : "s"} here, and the rule needs ` +
+						`${needed} — it cannot match at this one`));
 				}
 			}
 		}

--- a/src/debug/sessionTest.ts
+++ b/src/debug/sessionTest.ts
@@ -546,6 +546,62 @@ async function main(): Promise<void> {
 		await fake.close();
 	}
 
+	// ---- why the run of nodes is as short as it is --------------------------
+	// A rule matches a SEQUENCE, so when fewer nodes remain than the rule has
+	// elements it cannot match here whatever they are -- it has reached the end
+	// of its @NODES parent. Reported as a bug ("the nodes in play are wrong,
+	// there should be a _date and a _time"): the pane was right, the line
+	// really did end, but a list holding one node reads as a truncated display
+	// rather than as the reason the rule is about to fail.
+	{
+		const fake = await fakeEngine({
+			rule: { rule: { line: RULE_HEAD, num: 1, builds: "_dateTime",
+				elements: [{ name: "_date" }, { name: "_xWILD" }, { name: "_time" }] } },
+			node: { node: { name: "_date", text: "Sept 04, 2014", type: "alpha" },
+				following: [{ name: ".", text: ".", type: "punct" }] },
+			collect: { collect: [] },
+		});
+		const dap = await attached(fake, analyzer);
+		await stopAt(dap, fake, { reason: "step", line: RULE_HEAD });
+		const st = await dap.send("stackTrace", { threadId: 1 });
+		const scopes = await dap.send("scopes", { frameId: st.body.stackFrames[0].id });
+		const ref = scopes.body.scopes.find((s: any) => s.name === "Nodes in play").variablesReference;
+		const rows = (await dap.send("variables", { variablesReference: ref })).body.variables;
+		const note = rows.find((r: any) => r.name === "(end of the run)");
+		check("a run too short for the rule says so", !!note,
+			rows.map((r: any) => r.name).join(", "));
+		check("and says how short", /2 node.*needs 3/.test(String(note?.value)), String(note?.value));
+		await dap.send("disconnect", { terminateDebuggee: true });
+		await fake.close();
+	}
+	{
+		// Enough nodes for the rule: no note, because there is nothing to explain.
+		const fake = await fakeEngine({
+			rule: { rule: { line: RULE_HEAD, num: 1, builds: "_dateTime",
+				elements: [{ name: "_date" }, { name: "_xWILD" }, { name: "_time" }] } },
+			node: { node: { name: "_date", text: "11. 12. 2014", type: "alpha" },
+				following: [
+					{ name: ",", text: ",", type: "punct" },
+					{ name: "_time", text: "08:45:39", type: "alpha" },
+				] },
+			collect: { collect: [] },
+		});
+		const dap = await attached(fake, analyzer);
+		await stopAt(dap, fake, { reason: "step", line: RULE_HEAD });
+		const st = await dap.send("stackTrace", { threadId: 1 });
+		const scopes = await dap.send("scopes", { frameId: st.body.stackFrames[0].id });
+		const ref = scopes.body.scopes.find((s: any) => s.name === "Nodes in play").variablesReference;
+		const rows = (await dap.send("variables", { variablesReference: ref })).body.variables;
+		check("a run long enough is left to speak for itself",
+			!rows.some((r: any) => r.name === "(end of the run)"),
+			rows.map((r: any) => r.name).join(", "));
+		check("and the nodes the rule will be tried against are all listed",
+			rows.some((r: any) => String(r.name).indexOf("_time") >= 0),
+			rows.map((r: any) => r.name).join(", "));
+		await dap.send("disconnect", { terminateDebuggee: true });
+		await fake.close();
+	}
+
 	// ---- a file that is not a pass is refused, with the reason --------------
 	{
 		const fake = await fakeEngine();


### PR DESCRIPTION
Reported as *"the nodes in play are wrong, there should be a `_date` and a `_time`"*, stopped on `_dateTime <- _date _xWILD _time`.

**The pane was right.** The rule was being tried on the first line of the input, which reads `Sept 04, 2014.` — a date and a full stop. The engine returns one following node because there is one:

```
_LINE   'Sept 04, 2014.'
  _date   'Sept 04, 2014'
  .       '.'
```

The times are on other lines entirely. Asking the engine for twelve following nodes still returns one.

### The real problem

A list holding a single node reads as a **truncated display**, not as the reason the rule is about to fail — and the obvious conclusion is that the debugger is hiding something. A rule matches a *sequence*, so when fewer nodes remain than the rule has elements it cannot match whatever they are: it has reached the end of its `@NODES` parent.

Measured against the reporter's own analyzer, before and after:

```
(being tried at)
_date              "Sept 04, 2014" (node) — pass 11 line 128 [built]
(nodes after it)
.                  "." (punct) {NOSP}
(end of the run)   2 nodes here, and the rule needs 3 — it cannot match at this one
```

Where the nodes are there, nothing is added and they are simply listed:

```
(being tried at)
_date              "11. 12. 2014" (node) — pass 11 line 82 [built]
(nodes after it)
,                  "," (punct)
_time              "08:45:39" (node) — pass 8 line 23 [built]
```

### Tests

Four session assertions, both directions: the note appears with its counts when the run is too short, and is absent when it is not — a note on every attempt would be noise, and noise in a pane is how people stop reading it.

48 session, 68 client, 48 integration, lint clean. Version **4.1.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
